### PR TITLE
feat(admin-ui): uniform per-instance credentials UX for full-agent providers

### DIFF
--- a/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import ProviderCredentialsCard from './ProviderCredentialsCard';
 
 interface DeepgramProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    providerKey?: string;
 }
 
-const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onChange }) => {
+const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onChange, providerKey }) => {
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -21,6 +23,32 @@ const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onC
 
     return (
         <div className="space-y-6">
+            <div>
+                <h4 className="font-semibold mb-3">Credentials</h4>
+                <ProviderCredentialsCard
+                    providerKey={providerKey}
+                    credentialType="api-key"
+                    label="Deepgram API Key"
+                    placeholder="Token..."
+                    envVarFallback="DEEPGRAM_API_KEY"
+                    inlineValue={config.api_key}
+                    helpText={
+                        <>
+                            Find your key in the{' '}
+                            <a
+                                href="https://console.deepgram.com/"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary hover:underline"
+                            >
+                                Deepgram Console
+                            </a>
+                            . Per-instance keys override the env var fallback.
+                        </>
+                    }
+                />
+            </div>
+
             {/* Base URL Section */}
             <div>
                 <h4 className="font-semibold mb-3">API Endpoints</h4>

--- a/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface DeepgramProviderFormProps {
@@ -8,6 +8,12 @@ interface DeepgramProviderFormProps {
 }
 
 const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onChange, providerKey }) => {
+    // Latest-config ref for race-free credential patches.
+    const configRef = useRef(config);
+    useEffect(() => {
+        configRef.current = config;
+    }, [config]);
+
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -32,7 +38,7 @@ const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onC
                     placeholder="Token..."
                     envVarFallback="DEEPGRAM_API_KEY"
                     inlineValue={config.api_key}
-                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                    onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                     helpText={
                         <>
                             Find your key in the{' '}

--- a/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/DeepgramProviderForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import ProviderCredentialsCard from './ProviderCredentialsCard';
+import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface DeepgramProviderFormProps {
     config: any;
@@ -32,6 +32,7 @@ const DeepgramProviderForm: React.FC<DeepgramProviderFormProps> = ({ config, onC
                     placeholder="Token..."
                     envVarFallback="DEEPGRAM_API_KEY"
                     inlineValue={config.api_key}
+                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                     helpText={
                         <>
                             Find your key in the{' '}

--- a/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { ExternalLink, Info, Mic } from 'lucide-react';
+import { Info, Mic } from 'lucide-react';
+import ProviderCredentialsCard from './ProviderCredentialsCard';
 
 interface ElevenLabsProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    providerKey?: string;
 }
 
-const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config, onChange }) => {
+const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config, onChange, providerKey }) => {
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -31,6 +33,45 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
 
     return (
         <div className="space-y-6">
+            <div>
+                <h4 className="font-semibold mb-3">Credentials</h4>
+                <div className="space-y-3">
+                    <ProviderCredentialsCard
+                        providerKey={providerKey}
+                        credentialType="api-key"
+                        label="ElevenLabs API Key"
+                        placeholder="xi-..."
+                        envVarFallback="ELEVENLABS_API_KEY"
+                        inlineValue={config.api_key}
+                        helpText={
+                            <>
+                                Find your key in the{' '}
+                                <a
+                                    href="https://elevenlabs.io/app/settings/api-keys"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-primary hover:underline"
+                                >
+                                    ElevenLabs Console
+                                </a>
+                                .
+                            </>
+                        }
+                    />
+                    {mode === 'agent' && (
+                        <ProviderCredentialsCard
+                            providerKey={providerKey}
+                            credentialType="agent-id"
+                            label="ElevenLabs Agent ID"
+                            placeholder="agent_..."
+                            envVarFallback="ELEVENLABS_AGENT_ID"
+                            inlineValue={config.agent_id}
+                            helpText="The Agent ID identifies which Conversational AI agent to use."
+                        />
+                    )}
+                </div>
+            </div>
+
             {/* Mode Selection */}
             <div className="space-y-2">
                 <label className="text-sm font-medium">Provider Mode</label>

--- a/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Info, Mic } from 'lucide-react';
 import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
@@ -9,6 +9,12 @@ interface ElevenLabsProviderFormProps {
 }
 
 const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config, onChange, providerKey }) => {
+    // Latest-config ref for race-free credential patches.
+    const configRef = useRef(config);
+    useEffect(() => {
+        configRef.current = config;
+    }, [config]);
+
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -25,8 +31,12 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
             const { voice_id, model_id, ...rest } = config;
             onChange({ ...rest, mode: 'agent', type: 'elevenlabs_agent' });
         } else {
-            // Switch to TTS: keep voice_id if exists, clear agent_id
-            const { agent_id, ...rest } = config;
+            // Switch to TTS: keep voice_id if exists, clear agent_id AND
+            // any per-instance agent_id_file. Leaving agent_id_file behind
+            // would persist a stale credential reference pointing at an
+            // agent-id file that's no longer relevant in TTS mode (and may
+            // cause the engine to fail provider validation).
+            const { agent_id, agent_id_file, ...rest } = config;
             onChange({ ...rest, mode: 'tts', type: 'elevenlabs' });
         }
     };
@@ -43,7 +53,7 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
                         placeholder="xi-..."
                         envVarFallback="ELEVENLABS_API_KEY"
                         inlineValue={config.api_key}
-                        onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                        onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                         helpText={
                             <>
                                 Find your key in the{' '}
@@ -67,7 +77,7 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
                             placeholder="agent_..."
                             envVarFallback="ELEVENLABS_AGENT_ID"
                             inlineValue={config.agent_id}
-                            onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                            onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                             helpText="The Agent ID identifies which Conversational AI agent to use."
                         />
                     )}

--- a/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ElevenLabsProviderForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Info, Mic } from 'lucide-react';
-import ProviderCredentialsCard from './ProviderCredentialsCard';
+import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface ElevenLabsProviderFormProps {
     config: any;
@@ -43,6 +43,7 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
                         placeholder="xi-..."
                         envVarFallback="ELEVENLABS_API_KEY"
                         inlineValue={config.api_key}
+                        onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                         helpText={
                             <>
                                 Find your key in the{' '}
@@ -66,6 +67,7 @@ const ElevenLabsProviderForm: React.FC<ElevenLabsProviderFormProps> = ({ config,
                             placeholder="agent_..."
                             envVarFallback="ELEVENLABS_AGENT_ID"
                             inlineValue={config.agent_id}
+                            onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                             helpText="The Agent ID identifies which Conversational AI agent to use."
                         />
                     )}

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import { useConfirmDialog } from '../../../hooks/useConfirmDialog';
 import { AlertTriangle, Upload, Trash2, CheckCircle, XCircle, Loader2, FileJson } from 'lucide-react';
 import HelpTooltip from '../../ui/HelpTooltip';
-import ProviderCredentialsCard from './ProviderCredentialsCard';
+import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 import {
     GOOGLE_LIVE_MODEL_GROUPS,
     GOOGLE_LIVE_SUPPORTED_MODELS,
@@ -371,6 +371,7 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
                                 placeholder="AIza..."
                                 envVarFallback="GOOGLE_API_KEY"
                                 inlineValue={config.api_key}
+                                onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                                 helpText={
                                     <>
                                         Get a key from{' '}

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { useConfirmDialog } from '../../../hooks/useConfirmDialog';
 import { AlertTriangle, Upload, Trash2, CheckCircle, XCircle, Loader2, FileJson } from 'lucide-react';
 import HelpTooltip from '../../ui/HelpTooltip';
+import ProviderCredentialsCard from './ProviderCredentialsCard';
 import {
     GOOGLE_LIVE_MODEL_GROUPS,
     GOOGLE_LIVE_SUPPORTED_MODELS,
@@ -362,15 +363,45 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
 
                     {/* Developer API key — shown when Vertex AI is OFF */}
                     {!config.use_vertex_ai && (
-                        <div className="space-y-2">
-                            <label className="text-sm font-medium">API Key (Environment Variable)</label>
-                            <input
-                                type="text"
-                                className="w-full p-2 rounded border border-input bg-background"
-                                value={config.api_key || '${GOOGLE_API_KEY}'}
-                                onChange={(e) => handleChange('api_key', e.target.value)}
-                                placeholder="${GOOGLE_API_KEY}"
+                        <div className="space-y-3">
+                            <ProviderCredentialsCard
+                                providerKey={providerKey}
+                                credentialType="api-key"
+                                label="Google API Key"
+                                placeholder="AIza..."
+                                envVarFallback="GOOGLE_API_KEY"
+                                inlineValue={config.api_key}
+                                helpText={
+                                    <>
+                                        Get a key from{' '}
+                                        <a
+                                            href="https://aistudio.google.com/apikey"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-primary hover:underline"
+                                        >
+                                            Google AI Studio
+                                        </a>
+                                        . Per-instance keys override the env var fallback.
+                                    </>
+                                }
                             />
+                            <div className="space-y-2">
+                                <label className="text-sm font-medium text-muted-foreground">
+                                    API Key (inline / env var) — legacy
+                                </label>
+                                <input
+                                    type="text"
+                                    className="w-full p-2 rounded border border-input bg-background"
+                                    value={config.api_key || ''}
+                                    onChange={(e) => handleChange('api_key', e.target.value)}
+                                    placeholder="${GOOGLE_API_KEY}"
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Direct value or <code>${'{'}GOOGLE_API_KEY{'}'}</code> reference. Per-instance uploads above
+                                    take precedence over this field.
+                                </p>
+                            </div>
                         </div>
                     )}
                 </div>

--- a/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GoogleLiveProviderForm.tsx
@@ -68,6 +68,13 @@ interface GoogleLiveProviderFormProps {
 
 const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config, onChange, providerKey }) => {
     const { confirm } = useConfirmDialog();
+
+    // Latest-config ref for race-free credential patches.
+    const configRef = useRef(config);
+    useEffect(() => {
+        configRef.current = config;
+    }, [config]);
+
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -371,7 +378,7 @@ const GoogleLiveProviderForm: React.FC<GoogleLiveProviderFormProps> = ({ config,
                                 placeholder="AIza..."
                                 envVarFallback="GOOGLE_API_KEY"
                                 inlineValue={config.api_key}
-                                onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                                onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                                 helpText={
                                     <>
                                         Get a key from{' '}

--- a/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProviderCredentialsCard from './ProviderCredentialsCard';
+import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface GrokProviderFormProps {
     config: any;
@@ -69,6 +69,7 @@ const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange, p
                     placeholder="xai-..."
                     envVarFallback="XAI_API_KEY"
                     inlineValue={config.api_key}
+                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                     helpText={
                         <>
                             Find your key in the{' '}

--- a/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface GrokProviderFormProps {
@@ -21,6 +21,13 @@ const GROK_MODELS = [
 ];
 
 const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange, providerKey }) => {
+    // Keep a ref to the latest `config` so async credential patches read the
+    // freshest in-memory provider state (see applyCredentialPatch docstring).
+    const configRef = useRef(config);
+    useEffect(() => {
+        configRef.current = config;
+    }, [config]);
+
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -69,7 +76,7 @@ const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange, p
                     placeholder="xai-..."
                     envVarFallback="XAI_API_KEY"
                     inlineValue={config.api_key}
-                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                    onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                     helpText={
                         <>
                             Find your key in the{' '}

--- a/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GrokProviderForm.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import ProviderCredentialsCard from './ProviderCredentialsCard';
 
 interface GrokProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    providerKey?: string;
 }
 
 const GROK_VOICES = [
@@ -18,7 +20,7 @@ const GROK_MODELS = [
     { value: 'grok-voice-think-fast-1.0', label: 'grok-voice-think-fast-1.0 (flagship)' },
 ];
 
-const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange }) => {
+const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange, providerKey }) => {
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -56,6 +58,32 @@ const GrokProviderForm: React.FC<GrokProviderFormProps> = ({ config, onChange })
                         xAI Grok Voice Agent WebSocket endpoint. Override only for proxy / regional routes.
                     </p>
                 </div>
+            </div>
+
+            <div>
+                <h4 className="font-semibold mb-3">Credentials</h4>
+                <ProviderCredentialsCard
+                    providerKey={providerKey}
+                    credentialType="api-key"
+                    label="xAI API Key"
+                    placeholder="xai-..."
+                    envVarFallback="XAI_API_KEY"
+                    inlineValue={config.api_key}
+                    helpText={
+                        <>
+                            Find your key in the{' '}
+                            <a
+                                href="https://console.x.ai/team/default/api-keys"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary hover:underline"
+                            >
+                                xAI Console
+                            </a>
+                            . For multi-instance setups, each YAML provider key gets its own credential file.
+                        </>
+                    }
+                />
             </div>
 
             <div>

--- a/admin_ui/frontend/src/components/config/providers/LocalProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/LocalProviderForm.tsx
@@ -5,6 +5,8 @@ import { AlertCircle, RefreshCw } from 'lucide-react';
 interface LocalProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    /** Unused here; accepted for prop-shape parity with full-agent forms. */
+    providerKey?: string;
 }
 
 const LocalProviderForm: React.FC<LocalProviderFormProps> = ({ config, onChange }) => {

--- a/admin_ui/frontend/src/components/config/providers/OpenAIProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/OpenAIProviderForm.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 interface OpenAIProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    /** Unused here; accepted for prop-shape parity with full-agent forms. */
+    providerKey?: string;
 }
 
 const OpenAIProviderForm: React.FC<OpenAIProviderFormProps> = ({ config, onChange }) => {

--- a/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface OpenAIRealtimeProviderFormProps {
@@ -8,6 +8,12 @@ interface OpenAIRealtimeProviderFormProps {
 }
 
 const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({ config, onChange, providerKey }) => {
+    // Latest-config ref for race-free credential patches.
+    const configRef = useRef(config);
+    useEffect(() => {
+        configRef.current = config;
+    }, [config]);
+
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -39,7 +45,7 @@ const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({
                     placeholder="sk-..."
                     envVarFallback="OPENAI_API_KEY"
                     inlineValue={config.api_key}
-                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
+                    onConfigPatch={(patch) => applyCredentialPatch(configRef, patch, onChange)}
                     helpText={
                         <>
                             Find your key at{' '}

--- a/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProviderCredentialsCard from './ProviderCredentialsCard';
+import ProviderCredentialsCard, { applyCredentialPatch } from './ProviderCredentialsCard';
 
 interface OpenAIRealtimeProviderFormProps {
     config: any;
@@ -39,6 +39,7 @@ const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({
                     placeholder="sk-..."
                     envVarFallback="OPENAI_API_KEY"
                     inlineValue={config.api_key}
+                    onConfigPatch={(patch) => applyCredentialPatch(config, patch, onChange)}
                     helpText={
                         <>
                             Find your key at{' '}

--- a/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/OpenAIRealtimeProviderForm.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import ProviderCredentialsCard from './ProviderCredentialsCard';
 
 interface OpenAIRealtimeProviderFormProps {
     config: any;
     onChange: (newConfig: any) => void;
+    providerKey?: string;
 }
 
-const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({ config, onChange }) => {
+const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({ config, onChange, providerKey }) => {
     const handleChange = (field: string, value: any) => {
         onChange({ ...config, [field]: value });
     };
@@ -28,6 +30,32 @@ const OpenAIRealtimeProviderForm: React.FC<OpenAIRealtimeProviderFormProps> = ({
 
     return (
         <div className="space-y-6">
+            <div>
+                <h4 className="font-semibold mb-3">Credentials</h4>
+                <ProviderCredentialsCard
+                    providerKey={providerKey}
+                    credentialType="api-key"
+                    label="OpenAI API Key"
+                    placeholder="sk-..."
+                    envVarFallback="OPENAI_API_KEY"
+                    inlineValue={config.api_key}
+                    helpText={
+                        <>
+                            Find your key at{' '}
+                            <a
+                                href="https://platform.openai.com/api-keys"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary hover:underline"
+                            >
+                                platform.openai.com/api-keys
+                            </a>
+                            . Per-instance keys override the env var fallback.
+                        </>
+                    }
+                />
+            </div>
+
             <div>
                 <h4 className="font-semibold mb-3">API Endpoint</h4>
                 <div className="space-y-2">

--- a/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
@@ -1,0 +1,355 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import axios from 'axios';
+import { toast } from 'sonner';
+import { Upload, Trash2, CheckCircle, Loader2, KeyRound, ExternalLink } from 'lucide-react';
+import { useConfirmDialog } from '../../../hooks/useConfirmDialog';
+import { Link } from 'react-router-dom';
+
+/**
+ * Shared credential management card for full-agent providers.
+ *
+ * Wraps the existing admin backend endpoints:
+ *   GET    /api/config/providers/{key}/credentials
+ *   POST   /api/config/providers/{key}/credentials/api-key   (paste-upload)
+ *   POST   /api/config/providers/{key}/credentials/agent-id  (paste-upload)
+ *   DELETE /api/config/providers/{key}/credentials/{name}
+ *
+ * Behavior summary:
+ * - If `providerKey` is empty (new provider not yet saved): shows a hint to save first.
+ * - If the YAML inline value is a `${ENV_VAR}` reference: shows env-var fallback
+ *   pointing at the Environment page (no file upload — legacy single-instance flow).
+ * - Otherwise: shows file status + upload / re-upload / delete actions.
+ */
+
+interface CredentialStatus {
+    uploaded: boolean;
+    path: string;
+    uploaded_at?: number;
+    configured?: boolean;
+    error?: string;
+}
+
+interface ProviderCredentialsCardProps {
+    /** YAML key for the provider (e.g. "grok", "acme_grok"). Empty for unsaved providers. */
+    providerKey?: string;
+    /** What credential to manage. */
+    credentialType: 'api-key' | 'agent-id';
+    /** Display label (e.g. "xAI API Key"). */
+    label: string;
+    /** Input placeholder (e.g. "xai-..."). */
+    placeholder?: string;
+    /**
+     * Legacy env-var fallback name (e.g. "XAI_API_KEY"). When the YAML inline value
+     * (`inlineValue`) is a "${ENV}" reference, the card surfaces this name and links
+     * to the Environment page instead of offering per-instance upload.
+     */
+    envVarFallback?: string;
+    /** Current YAML inline value for this credential (e.g. `api_key: "${XAI_API_KEY}"`). */
+    inlineValue?: string;
+    /**
+     * Help text shown below the upload form. Use for guidance like
+     * "Find your key in the xAI console at console.x.ai".
+     */
+    helpText?: React.ReactNode;
+}
+
+const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
+    providerKey,
+    credentialType,
+    label,
+    placeholder,
+    envVarFallback,
+    inlineValue,
+    helpText,
+}) => {
+    const { confirm } = useConfirmDialog();
+    const [status, setStatus] = useState<CredentialStatus | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [showUploadField, setShowUploadField] = useState(false);
+    const [secretInput, setSecretInput] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    const fetchStatus = useCallback(async () => {
+        if (!providerKey) return;
+        setLoading(true);
+        try {
+            const res = await axios.get(`/api/config/providers/${encodeURIComponent(providerKey)}/credentials`);
+            const cred = res.data?.credentials?.[credentialType];
+            setStatus(cred || { uploaded: false, path: '' });
+        } catch (e: any) {
+            // 404 just means the provider hasn't been saved or the kind doesn't accept this credential.
+            setStatus({ uploaded: false, path: '' });
+        } finally {
+            setLoading(false);
+        }
+    }, [providerKey, credentialType]);
+
+    useEffect(() => {
+        fetchStatus();
+    }, [fetchStatus]);
+
+    const handleUpload = async () => {
+        const value = secretInput.trim();
+        if (!value) {
+            toast.error(`${label} cannot be empty.`);
+            return;
+        }
+        setSubmitting(true);
+        try {
+            const fieldName = credentialType === 'api-key' ? 'api_key' : 'agent_id';
+            await axios.post(
+                `/api/config/providers/${encodeURIComponent(providerKey || '')}/credentials/${credentialType}`,
+                { [fieldName]: value },
+            );
+            toast.success(`${label} saved.`);
+            setSecretInput('');
+            setShowUploadField(false);
+            await fetchStatus();
+        } catch (e: any) {
+            toast.error(e.response?.data?.detail || `Failed to save ${label}.`);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        const confirmed = await confirm({
+            title: `Delete ${label}?`,
+            description: `This removes the credential file for "${providerKey}" and reverts the YAML to use whatever fallback (env var or inline) you have configured. The provider will fail to load until a credential is provided.`,
+            confirmText: 'Delete',
+            variant: 'destructive',
+        });
+        if (!confirmed) return;
+        setSubmitting(true);
+        try {
+            await axios.delete(
+                `/api/config/providers/${encodeURIComponent(providerKey || '')}/credentials/${credentialType}`,
+            );
+            toast.success(`${label} deleted.`);
+            await fetchStatus();
+        } catch (e: any) {
+            toast.error(e.response?.data?.detail || `Failed to delete ${label}.`);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    // Unsaved provider — uploading would 404, so guide the user instead.
+    if (!providerKey) {
+        return (
+            <div className="border border-dashed border-input rounded-lg p-4 bg-muted/30">
+                <div className="flex items-start gap-3">
+                    <KeyRound className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
+                    <div>
+                        <p className="font-medium text-sm">{label}</p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                            Save the provider first, then upload credentials here.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    // Env-var fallback (legacy single-instance form, e.g. api_key: "${XAI_API_KEY}").
+    const isEnvVarRef = typeof inlineValue === 'string' && inlineValue.trim().startsWith('${');
+    const envVarFromInline = isEnvVarRef
+        ? inlineValue!.trim().replace(/^\$\{/, '').replace(/\}$/, '').split(':-')[0]
+        : envVarFallback;
+
+    if (isEnvVarRef && !status?.uploaded) {
+        return (
+            <div className="border border-input rounded-lg p-4 bg-muted/30">
+                <div className="flex items-start gap-3">
+                    <KeyRound className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
+                    <div className="flex-1">
+                        <p className="font-medium text-sm">{label}</p>
+                        <p className="text-xs text-muted-foreground mt-1">
+                            Using environment variable{' '}
+                            <code className="px-1 py-0.5 bg-background rounded text-foreground">
+                                {envVarFromInline}
+                            </code>
+                            {' '}— legacy single-instance form.
+                        </p>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                            <Link
+                                to="/env"
+                                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                            >
+                                Set in Environment page <ExternalLink className="w-3 h-3" />
+                            </Link>
+                            <span className="text-xs text-muted-foreground">·</span>
+                            <button
+                                type="button"
+                                className="text-xs text-primary hover:underline"
+                                onClick={() => setShowUploadField(true)}
+                            >
+                                Or upload a per-instance key file
+                            </button>
+                        </div>
+                        {showUploadField && (
+                            <UploadField
+                                label={label}
+                                placeholder={placeholder}
+                                value={secretInput}
+                                onChange={setSecretInput}
+                                onSubmit={handleUpload}
+                                onCancel={() => {
+                                    setShowUploadField(false);
+                                    setSecretInput('');
+                                }}
+                                submitting={submitting}
+                                helpText={helpText}
+                            />
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="border border-input rounded-lg p-4">
+            <div className="flex items-start gap-3">
+                <KeyRound className={`w-5 h-5 flex-shrink-0 mt-0.5 ${status?.uploaded ? 'text-green-600' : 'text-muted-foreground'}`} />
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <p className="font-medium text-sm">{label}</p>
+                        {loading && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
+                    </div>
+
+                    {status?.uploaded ? (
+                        <div className="mt-2">
+                            <div className="flex items-center gap-2 text-xs text-green-700 dark:text-green-400">
+                                <CheckCircle className="w-3.5 h-3.5" />
+                                <span>Credential file uploaded</span>
+                            </div>
+                            <p className="text-xs text-muted-foreground mt-1 font-mono truncate" title={status.path}>
+                                {status.path}
+                            </p>
+                            {status.uploaded_at && (
+                                <p className="text-xs text-muted-foreground mt-0.5">
+                                    Last updated {new Date(status.uploaded_at * 1000).toLocaleString()}
+                                </p>
+                            )}
+                            <div className="mt-3 flex flex-wrap gap-2">
+                                <button
+                                    type="button"
+                                    className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-input hover:bg-secondary"
+                                    onClick={() => setShowUploadField(true)}
+                                    disabled={submitting}
+                                >
+                                    <Upload className="w-3 h-3" /> Replace
+                                </button>
+                                <button
+                                    type="button"
+                                    className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-input text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
+                                    onClick={handleDelete}
+                                    disabled={submitting}
+                                >
+                                    <Trash2 className="w-3 h-3" /> Delete
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="mt-2">
+                            <p className="text-xs text-muted-foreground">
+                                No credential configured for this provider instance.
+                            </p>
+                            {!showUploadField && (
+                                <button
+                                    type="button"
+                                    className="mt-2 inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-input hover:bg-secondary"
+                                    onClick={() => setShowUploadField(true)}
+                                >
+                                    <Upload className="w-3 h-3" /> Upload {label}
+                                </button>
+                            )}
+                        </div>
+                    )}
+
+                    {showUploadField && (
+                        <UploadField
+                            label={label}
+                            placeholder={placeholder}
+                            value={secretInput}
+                            onChange={setSecretInput}
+                            onSubmit={handleUpload}
+                            onCancel={() => {
+                                setShowUploadField(false);
+                                setSecretInput('');
+                            }}
+                            submitting={submitting}
+                            helpText={helpText}
+                        />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+interface UploadFieldProps {
+    label: string;
+    placeholder?: string;
+    value: string;
+    onChange: (v: string) => void;
+    onSubmit: () => void;
+    onCancel: () => void;
+    submitting: boolean;
+    helpText?: React.ReactNode;
+}
+
+const UploadField: React.FC<UploadFieldProps> = ({
+    label,
+    placeholder,
+    value,
+    onChange,
+    onSubmit,
+    onCancel,
+    submitting,
+    helpText,
+}) => (
+    <div className="mt-3 border-t border-input pt-3 space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">
+            Paste {label}
+        </label>
+        <input
+            type="password"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full p-2 rounded border border-input bg-background font-mono text-sm"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={placeholder}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' && !submitting) {
+                    e.preventDefault();
+                    onSubmit();
+                }
+            }}
+        />
+        {helpText && <div className="text-xs text-muted-foreground">{helpText}</div>}
+        <div className="flex gap-2">
+            <button
+                type="button"
+                className="px-3 py-1.5 rounded bg-primary text-primary-foreground text-xs hover:bg-primary/90 disabled:opacity-50 inline-flex items-center gap-1"
+                onClick={onSubmit}
+                disabled={submitting || !value.trim()}
+            >
+                {submitting ? <Loader2 className="w-3 h-3 animate-spin" /> : <Upload className="w-3 h-3" />}
+                Save
+            </button>
+            <button
+                type="button"
+                className="px-3 py-1.5 rounded border border-input text-xs hover:bg-secondary"
+                onClick={onCancel}
+                disabled={submitting}
+            >
+                Cancel
+            </button>
+        </div>
+    </div>
+);
+
+export default ProviderCredentialsCard;

--- a/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
@@ -51,7 +51,26 @@ interface ProviderCredentialsCardProps {
      * "Find your key in the xAI console at console.x.ai".
      */
     helpText?: React.ReactNode;
+    /**
+     * Called after a successful upload or delete with a patch describing the
+     * field change. The parent form should merge this into its `providerForm`
+     * state so that any subsequent Save sends the new value back. Without this
+     * callback, the form's local state would be stale (still missing
+     * `api_key_file`/`agent_id_file`) and the next Save would write a stale
+     * provider entry, wiping the credential reference from the YAML.
+     *
+     * Patch shape: `{ api_key_file: "/path/to/file" }` after upload, or
+     *              `{ api_key_file: undefined }` after delete.
+     */
+    onConfigPatch?: (patch: Record<string, any>) => void;
 }
+
+/** Map credential-type → YAML field name the backend writes. Kept in sync with
+ *  `CREDENTIAL_NAME_TO_FIELD` in src/config/provider_instances.py. */
+const CREDENTIAL_FIELD: Record<string, string> = {
+    'api-key': 'api_key_file',
+    'agent-id': 'agent_id_file',
+};
 
 const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
     providerKey,
@@ -61,6 +80,7 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
     envVarFallback,
     inlineValue,
     helpText,
+    onConfigPatch,
 }) => {
     const { confirm } = useConfirmDialog();
     const [status, setStatus] = useState<CredentialStatus | null>(null);
@@ -97,7 +117,7 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
         setSubmitting(true);
         try {
             const fieldName = credentialType === 'api-key' ? 'api_key' : 'agent_id';
-            await axios.post(
+            const res = await axios.post(
                 `/api/config/providers/${encodeURIComponent(providerKey || '')}/credentials/${credentialType}`,
                 { [fieldName]: value },
             );
@@ -105,6 +125,14 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
             setSecretInput('');
             setShowUploadField(false);
             await fetchStatus();
+            // Notify the parent form so its in-memory state reflects the new
+            // field. Without this, a subsequent form Save would overwrite the
+            // YAML with stale data and strip the just-written reference.
+            const yamlField = CREDENTIAL_FIELD[credentialType];
+            const writtenPath = (res.data && (res.data as any).path) || undefined;
+            if (yamlField && onConfigPatch) {
+                onConfigPatch({ [yamlField]: writtenPath });
+            }
         } catch (e: any) {
             toast.error(e.response?.data?.detail || `Failed to save ${label}.`);
         } finally {
@@ -127,6 +155,10 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
             );
             toast.success(`${label} deleted.`);
             await fetchStatus();
+            const yamlField = CREDENTIAL_FIELD[credentialType];
+            if (yamlField && onConfigPatch) {
+                onConfigPatch({ [yamlField]: undefined });
+            }
         } catch (e: any) {
             toast.error(e.response?.data?.detail || `Failed to delete ${label}.`);
         } finally {
@@ -353,3 +385,22 @@ const UploadField: React.FC<UploadFieldProps> = ({
 );
 
 export default ProviderCredentialsCard;
+
+/**
+ * Helper for provider forms: apply a credential patch to the form's config and
+ * propagate via onChange. Keys with `undefined` values are deleted from the
+ * config (so the resulting YAML doesn't end up with `field: null` after a
+ * credential delete).
+ */
+export const applyCredentialPatch = (
+    config: Record<string, any>,
+    patch: Record<string, any>,
+    onChange: (next: Record<string, any>) => void,
+) => {
+    const next: Record<string, any> = { ...config };
+    Object.entries(patch).forEach(([k, v]) => {
+        if (v === undefined) delete next[k];
+        else next[k] = v;
+    });
+    onChange(next);
+};

--- a/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
+++ b/admin_ui/frontend/src/components/config/providers/ProviderCredentialsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import axios from 'axios';
 import { toast } from 'sonner';
 import { Upload, Trash2, CheckCircle, Loader2, KeyRound, ExternalLink } from 'lucide-react';
@@ -72,6 +72,23 @@ const CREDENTIAL_FIELD: Record<string, string> = {
     'agent-id': 'agent_id_file',
 };
 
+/**
+ * Normalize an axios error's `detail` field for display.
+ *
+ * The backend's DELETE endpoint returns a structured payload when a credential
+ * file is referenced by multiple providers (`{ message, references }`). Naively
+ * passing that object to toast.error renders as `[object Object]`. This helper
+ * extracts `.message` when the detail is an object.
+ */
+const formatErrorDetail = (err: any, fallback: string): string => {
+    const detail = err?.response?.data?.detail;
+    if (typeof detail === 'string') return detail;
+    if (detail && typeof detail === 'object' && typeof detail.message === 'string') {
+        return detail.message;
+    }
+    return fallback;
+};
+
 const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
     providerKey,
     credentialType,
@@ -88,6 +105,16 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
     const [showUploadField, setShowUploadField] = useState(false);
     const [secretInput, setSecretInput] = useState('');
     const [submitting, setSubmitting] = useState(false);
+
+    // Hold a ref to the latest `onConfigPatch` so async upload/delete handlers
+    // dispatch through the parent's most-recent callback (not the one captured
+    // when the request started). Pairs with each form's configRef pattern so
+    // patches build off the latest in-memory provider config — even if the
+    // user edited other fields while the request was in flight.
+    const onConfigPatchRef = useRef(onConfigPatch);
+    useEffect(() => {
+        onConfigPatchRef.current = onConfigPatch;
+    }, [onConfigPatch]);
 
     const fetchStatus = useCallback(async () => {
         if (!providerKey) return;
@@ -127,14 +154,16 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
             await fetchStatus();
             // Notify the parent form so its in-memory state reflects the new
             // field. Without this, a subsequent form Save would overwrite the
-            // YAML with stale data and strip the just-written reference.
+            // YAML with stale data and strip the just-written reference. Read
+            // through the ref so we always invoke the latest callback.
             const yamlField = CREDENTIAL_FIELD[credentialType];
             const writtenPath = (res.data && (res.data as any).path) || undefined;
-            if (yamlField && onConfigPatch) {
-                onConfigPatch({ [yamlField]: writtenPath });
+            const patchCb = onConfigPatchRef.current;
+            if (yamlField && patchCb) {
+                patchCb({ [yamlField]: writtenPath });
             }
         } catch (e: any) {
-            toast.error(e.response?.data?.detail || `Failed to save ${label}.`);
+            toast.error(formatErrorDetail(e, `Failed to save ${label}.`));
         } finally {
             setSubmitting(false);
         }
@@ -156,11 +185,15 @@ const ProviderCredentialsCard: React.FC<ProviderCredentialsCardProps> = ({
             toast.success(`${label} deleted.`);
             await fetchStatus();
             const yamlField = CREDENTIAL_FIELD[credentialType];
-            if (yamlField && onConfigPatch) {
-                onConfigPatch({ [yamlField]: undefined });
+            const patchCb = onConfigPatchRef.current;
+            if (yamlField && patchCb) {
+                patchCb({ [yamlField]: undefined });
             }
         } catch (e: any) {
-            toast.error(e.response?.data?.detail || `Failed to delete ${label}.`);
+            // Backend can return a structured detail like
+            //   { message: "Credential file is referenced by other providers", references: [...] }
+            // when the file is shared. Render the human-readable message.
+            toast.error(formatErrorDetail(e, `Failed to delete ${label}.`));
         } finally {
             setSubmitting(false);
         }
@@ -391,13 +424,24 @@ export default ProviderCredentialsCard;
  * propagate via onChange. Keys with `undefined` values are deleted from the
  * config (so the resulting YAML doesn't end up with `field: null` after a
  * credential delete).
+ *
+ * Takes a `configRef` (a React ref-like object with a `current` property) so
+ * the patch is built from the *latest* config at the moment the credential
+ * upload/delete settles — not from the snapshot captured when the parent's
+ * render closure was created. Without this, an upload that takes >100ms can
+ * complete with the user's intervening field edits already applied, and
+ * spreading a stale snapshot onto the latest state would silently clobber
+ * those edits.
+ *
+ * Pair this with each parent page's functional `setProviderForm` so the
+ * `onChange` (updateForm) step is also race-free.
  */
 export const applyCredentialPatch = (
-    config: Record<string, any>,
+    configRef: { current: Record<string, any> },
     patch: Record<string, any>,
     onChange: (next: Record<string, any>) => void,
 ) => {
-    const next: Record<string, any> = { ...config };
+    const next: Record<string, any> = { ...configRef.current };
     Object.entries(patch).forEach(([k, v]) => {
         if (v === undefined) delete next[k];
         else next[k] = v;

--- a/admin_ui/frontend/src/components/config/providers/TelnyxProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/TelnyxProviderForm.tsx
@@ -14,6 +14,8 @@ interface TelnyxConfig {
 interface TelnyxProviderFormProps {
     config: TelnyxConfig;
     onChange: (newConfig: TelnyxConfig) => void;
+    /** Unused here; accepted for prop-shape parity with full-agent forms. */
+    providerKey?: string;
 }
 
 const TelnyxProviderForm: React.FC<TelnyxProviderFormProps> = ({ config, onChange }) => {

--- a/admin_ui/frontend/src/pages/ConfigEditor.tsx
+++ b/admin_ui/frontend/src/pages/ConfigEditor.tsx
@@ -275,7 +275,11 @@ const ConfigEditor = () => {
 
     const renderProviderForm = () => {
         // Helper to update provider form state
-        const updateForm = (newValues: any) => setProviderForm({ ...providerForm, ...newValues });
+        // Functional setState so async callbacks (e.g. credential uploads
+        // resolving after the user has edited other fields) don't merge against
+        // a stale `providerForm` captured at render time.
+        const updateForm = (newValues: any) =>
+            setProviderForm((prev: any) => ({ ...prev, ...newValues }));
 
         // Common fields (Name)
         const commonFields = (

--- a/admin_ui/frontend/src/pages/ConfigEditor.tsx
+++ b/admin_ui/frontend/src/pages/ConfigEditor.tsx
@@ -361,11 +361,14 @@ const ConfigEditor = () => {
                 FormComponent = DeepgramProviderForm;
         }
 
+        // Per-instance credentials only work for saved YAML entries.
+        const credKey = isNewProvider ? undefined : (editingProvider || undefined);
+
         return (
             <div className="space-y-4">
                 {commonFields}
                 <div className="border-t pt-4">
-                    <FormComponent config={providerForm} onChange={updateForm} />
+                    <FormComponent config={providerForm} onChange={updateForm} providerKey={credKey} />
                 </div>
             </div>
         );

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -687,23 +687,26 @@ const ProvidersPage: React.FC = () => {
 
         // Check by provider NAME first (for full agents that have type='full')
         // This ensures Deepgram, Google Live, etc. use their specific forms
+        // Per-instance credentials require a saved YAML entry; pass `editingProvider`
+        // when editing an existing provider, undefined for unsaved new ones.
+        const credKey = isNewProvider ? undefined : (editingProvider || undefined);
         if (providerName === 'deepgram' || providerName.includes('deepgram')) {
-            return <DeepgramProviderForm config={providerForm} onChange={updateForm} />;
+            return <DeepgramProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
         }
         if (providerName === 'google_live' || providerName.includes('google') || providerName.includes('gemini')) {
-            return <GoogleLiveProviderForm config={providerForm} onChange={updateForm} providerKey={providerForm.name} />;
+            return <GoogleLiveProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
         }
         if (providerName.includes('azure')) {
             return <AzureProviderForm config={providerForm} onChange={updateForm} />;
         }
         if (providerName === 'openai_realtime' || providerName.includes('realtime')) {
-            return <OpenAIRealtimeProviderForm config={providerForm} onChange={updateForm} />;
+            return <OpenAIRealtimeProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
         }
         if (providerName === 'grok' || providerName.includes('grok') || providerForm.type === 'grok') {
-            return <GrokProviderForm config={providerForm} onChange={updateForm} />;
+            return <GrokProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
         }
         if (providerName.includes('elevenlabs')) {
-            return <ElevenLabsProviderForm config={providerForm} onChange={updateForm} />;
+            return <ElevenLabsProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
         }
         if (providerName.includes('telnyx') || providerName.includes('telenyx')) {
             return <TelnyxProviderForm config={providerForm} onChange={updateForm} />;
@@ -712,18 +715,18 @@ const ProvidersPage: React.FC = () => {
         // Fall back to type-based selection (for full agents only at this point)
         switch (providerForm.type) {
             case 'openai_realtime':
-                return <OpenAIRealtimeProviderForm config={providerForm} onChange={updateForm} />;
+                return <OpenAIRealtimeProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
             case 'deepgram':
-                return <DeepgramProviderForm config={providerForm} onChange={updateForm} />;
+                return <DeepgramProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
             case 'google_live':
-                return <GoogleLiveProviderForm config={providerForm} onChange={updateForm} providerKey={providerForm.name} />;
+                return <GoogleLiveProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
             case 'grok':
-                return <GrokProviderForm config={providerForm} onChange={updateForm} />;
+                return <GrokProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
             case 'openai':
                 return <OpenAIProviderForm config={providerForm} onChange={updateForm} />;
             case 'elevenlabs_agent':
             case 'elevenlabs':
-                return <ElevenLabsProviderForm config={providerForm} onChange={updateForm} />;
+                return <ElevenLabsProviderForm config={providerForm} onChange={updateForm} providerKey={credKey} />;
             case 'ollama':
                 return <OllamaProviderForm config={providerForm} onChange={updateForm} />;
             case 'telnyx':

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -665,7 +665,11 @@ const ProvidersPage: React.FC = () => {
     };
 
     const renderProviderForm = () => {
-        const updateForm = (newValues: any) => setProviderForm({ ...providerForm, ...newValues });
+        // Functional setState so async callbacks (e.g. credential uploads
+        // resolving after the user has edited other fields) don't merge against
+        // a stale `providerForm` captured at render time.
+        const updateForm = (newValues: any) =>
+            setProviderForm((prev: any) => ({ ...prev, ...newValues }));
 
         // Check provider name for specific forms, fallback to type
         const providerName = (providerForm.name || '').toLowerCase();

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -6,8 +6,28 @@ import { Save, Eye, EyeOff, RefreshCw, AlertTriangle, AlertCircle, CheckCircle, 
 import { ConfigSection } from '../../components/ui/ConfigSection';
 import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput, FormLabel, FormSelect, FormSwitch } from '../../components/ui/FormComponents';
+import { Link } from 'react-router-dom';
 
 import { useAuth } from '../../auth/AuthContext';
+
+const PROVIDER_CREDENTIAL_TYPES: Record<string, string[]> = {
+    openai_realtime: ['api-key'],
+    deepgram: ['api-key'],
+    google_live: ['api-key', 'vertex-json'],
+    elevenlabs_agent: ['api-key', 'agent-id'],
+    grok: ['api-key'],
+};
+
+interface PerInstanceCredentialRow {
+    providerKey: string;
+    kind: string;
+    credentialType: string;
+    state: 'file_uploaded' | 'env_var_ref' | 'not_configured' | 'inline_value';
+    path?: string;
+    envVar?: string;
+    inlineValue?: string;
+    uploadedAt?: number;
+}
 
 type EnvTab = 'ai-engine' | 'local-ai' | 'system';
 
@@ -64,6 +84,8 @@ const EnvPage = () => {
     const [smtpTestTo, setSmtpTestTo] = useState('');
     const [smtpTesting, setSmtpTesting] = useState(false);
     const [smtpTestResult, setSmtpTestResult] = useState<{success: boolean; message?: string; error?: string} | null>(null);
+    const [perInstanceRows, setPerInstanceRows] = useState<PerInstanceCredentialRow[]>([]);
+    const [perInstanceLoading, setPerInstanceLoading] = useState(false);
 
     const [error, setError] = useState<string | null>(null);
 
@@ -121,8 +143,97 @@ const EnvPage = () => {
     useEffect(() => {
         if (!authLoading && token) {
             fetchEnv();
+            fetchPerInstanceCredentials();
         }
     }, [authLoading, token]);
+
+    /**
+     * Enumerate all full-agent provider instances and probe each for credential status.
+     * Read-only audit — actual uploads happen on the Providers page.
+     */
+    const fetchPerInstanceCredentials = async () => {
+        setPerInstanceLoading(true);
+        try {
+            const yamlRes = await axios.get('/api/config/yaml');
+            // The /yaml endpoint returns {content: "<yaml string>"} or the parsed object.
+            let providers: Record<string, any> = {};
+            const raw = yamlRes.data?.content || yamlRes.data;
+            if (typeof raw === 'string') {
+                // Avoid pulling in js-yaml just for this — let the backend's /api/config
+                // endpoint give us a structured view if /yaml returned a string.
+                const cfgRes = await axios.get('/api/config');
+                providers = cfgRes.data?.providers || {};
+            } else {
+                providers = raw?.providers || {};
+            }
+
+            // For each provider entry, identify its kind and fetch credential status.
+            const entries = Object.entries(providers) as Array<[string, any]>;
+            const tasks = entries.map(async ([key, cfg]) => {
+                const explicitType = (cfg?.type || '').toLowerCase();
+                // Map either explicit type OR canonical YAML key to a full-agent kind.
+                const kind =
+                    explicitType in PROVIDER_CREDENTIAL_TYPES
+                        ? explicitType
+                        : key in PROVIDER_CREDENTIAL_TYPES
+                            ? key
+                            : null;
+                if (!kind) return [];
+
+                const credTypes = PROVIDER_CREDENTIAL_TYPES[kind];
+                const rows: PerInstanceCredentialRow[] = [];
+
+                // Best-effort: GET /credentials may 404 if the provider is being created or
+                // misconfigured. We render what we can from the YAML in that case.
+                let credStatus: any = {};
+                try {
+                    const res = await axios.get(`/api/config/providers/${encodeURIComponent(key)}/credentials`);
+                    credStatus = res.data?.credentials || {};
+                } catch {
+                    // Leave credStatus empty; classify rows from inline YAML below.
+                }
+
+                for (const credentialType of credTypes) {
+                    const status = credStatus[credentialType] || {};
+                    // Match the YAML field associated with this credential.
+                    const inlineField =
+                        credentialType === 'api-key' ? 'api_key' :
+                        credentialType === 'agent-id' ? 'agent_id' :
+                        credentialType === 'vertex-json' ? 'credentials_path' : null;
+                    const inlineValue = inlineField ? (cfg?.[inlineField] || '') : '';
+                    const isEnvRef = typeof inlineValue === 'string' && inlineValue.trim().startsWith('${');
+
+                    let state: PerInstanceCredentialRow['state'];
+                    if (status.uploaded) state = 'file_uploaded';
+                    else if (isEnvRef) state = 'env_var_ref';
+                    else if (inlineValue && typeof inlineValue === 'string' && inlineValue.trim()) state = 'inline_value';
+                    else state = 'not_configured';
+
+                    rows.push({
+                        providerKey: key,
+                        kind,
+                        credentialType,
+                        state,
+                        path: status.path,
+                        envVar: isEnvRef
+                            ? inlineValue.trim().replace(/^\$\{/, '').replace(/\}$/, '').split(':-')[0]
+                            : undefined,
+                        inlineValue: !isEnvRef && state === 'inline_value' ? '(inline value)' : undefined,
+                        uploadedAt: status.uploaded_at,
+                    });
+                }
+                return rows;
+            });
+
+            const all = (await Promise.all(tasks)).flat();
+            setPerInstanceRows(all);
+        } catch {
+            // Best-effort; leave the section empty.
+            setPerInstanceRows([]);
+        } finally {
+            setPerInstanceLoading(false);
+        }
+    };
 
     const fetchEnv = async () => {
         setLoading(true);
@@ -737,6 +848,73 @@ const EnvPage = () => {
                         />
                     </div>
                     </ConfigCard>
+                    </ConfigSection>
+
+                    {/* Per-Instance Provider Credentials (multi-tenant audit) */}
+                    <ConfigSection
+                        title="Per-Instance Provider Credentials"
+                        description="Status of credential files for each configured full-agent provider instance. Upload and edit on the Providers page."
+                    >
+                        <ConfigCard>
+                            {perInstanceLoading ? (
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground p-2">
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                    Loading provider credentials…
+                                </div>
+                            ) : perInstanceRows.length === 0 ? (
+                                <p className="text-sm text-muted-foreground p-2">
+                                    No full-agent providers configured yet. Visit{' '}
+                                    <Link to="/providers" className="text-primary hover:underline">Providers</Link>{' '}
+                                    to add one.
+                                </p>
+                            ) : (
+                                <div className="space-y-2">
+                                    {perInstanceRows.map((row) => {
+                                        const stateLabel = {
+                                            file_uploaded: { text: 'File uploaded', color: 'text-green-700 dark:text-green-400', icon: <CheckCircle className="w-3.5 h-3.5" /> },
+                                            env_var_ref: { text: `env var ${row.envVar}`, color: 'text-blue-700 dark:text-blue-400', icon: <CheckCircle className="w-3.5 h-3.5" /> },
+                                            inline_value: { text: 'inline value set', color: 'text-yellow-700 dark:text-yellow-400', icon: <AlertCircle className="w-3.5 h-3.5" /> },
+                                            not_configured: { text: 'not configured', color: 'text-red-700 dark:text-red-400', icon: <XCircle className="w-3.5 h-3.5" /> },
+                                        }[row.state];
+                                        return (
+                                            <div
+                                                key={`${row.providerKey}.${row.credentialType}`}
+                                                className="flex items-center gap-3 p-3 border border-input rounded-md hover:bg-muted/30 transition-colors"
+                                            >
+                                                <div className="flex-1 min-w-0">
+                                                    <div className="flex items-center gap-2 flex-wrap">
+                                                        <span className="font-mono text-sm font-medium">{row.providerKey}</span>
+                                                        <span className="text-xs text-muted-foreground">({row.kind})</span>
+                                                        <span className="text-xs text-muted-foreground">·</span>
+                                                        <span className="text-xs">{row.credentialType}</span>
+                                                    </div>
+                                                    <div className={`flex items-center gap-1 text-xs mt-1 ${stateLabel.color}`}>
+                                                        {stateLabel.icon}
+                                                        <span>{stateLabel.text}</span>
+                                                        {row.path && row.state === 'file_uploaded' && (
+                                                            <span className="text-muted-foreground font-mono truncate ml-2" title={row.path}>
+                                                                — {row.path}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                                <Link
+                                                    to="/providers"
+                                                    className="text-xs text-primary hover:underline whitespace-nowrap"
+                                                    title="Open the Providers page to edit this provider"
+                                                >
+                                                    Edit →
+                                                </Link>
+                                            </div>
+                                        );
+                                    })}
+                                    <p className="text-xs text-muted-foreground pt-2">
+                                        Files at <code>/app/project/secrets/providers/&lt;key&gt;/api-key</code> override
+                                        the env vars above. The Providers page is the source of truth for per-instance edits.
+                                    </p>
+                                </div>
+                            )}
+                        </ConfigCard>
                     </ConfigSection>
 
                     {/* Email Delivery (SMTP) */}

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -148,6 +148,17 @@ const EnvPage = () => {
     }, [authLoading, token]);
 
     /**
+     * Manual refresh hook used by the toolbar "Refresh" button and the
+     * error-state Retry button. Re-fetches BOTH the env-var values and the
+     * per-instance provider credential status so the audit section reflects
+     * provider/credential edits without remounting the page.
+     */
+    const refreshAll = () => {
+        fetchEnv();
+        fetchPerInstanceCredentials();
+    };
+
+    /**
      * Enumerate all full-agent provider instances and probe each for credential status.
      * Read-only audit — actual uploads happen on the Providers page.
      */
@@ -167,31 +178,36 @@ const EnvPage = () => {
                 providers = raw?.providers || {};
             }
 
-            // For each provider entry, identify its kind and fetch credential status.
+            // For each provider entry, probe the credentials endpoint. The backend
+            // returns the authoritative provider kind (it knows about legacy
+            // `type: full` entries, custom keys like `acme_voice`, and applies
+            // the same full-agent inference the engine uses) plus the list of
+            // credentials valid for that kind. Use that response — don't gate
+            // on a frontend whitelist of canonical keys, which would silently
+            // omit custom-keyed full-agent providers.
             const entries = Object.entries(providers) as Array<[string, any]>;
             const tasks = entries.map(async ([key, cfg]) => {
-                const explicitType = (cfg?.type || '').toLowerCase();
-                // Map either explicit type OR canonical YAML key to a full-agent kind.
-                const kind =
-                    explicitType in PROVIDER_CREDENTIAL_TYPES
-                        ? explicitType
-                        : key in PROVIDER_CREDENTIAL_TYPES
-                            ? key
-                            : null;
-                if (!kind) return [];
-
-                const credTypes = PROVIDER_CREDENTIAL_TYPES[kind];
-                const rows: PerInstanceCredentialRow[] = [];
-
-                // Best-effort: GET /credentials may 404 if the provider is being created or
-                // misconfigured. We render what we can from the YAML in that case.
                 let credStatus: any = {};
+                let kind: string | null = null;
                 try {
                     const res = await axios.get(`/api/config/providers/${encodeURIComponent(key)}/credentials`);
                     credStatus = res.data?.credentials || {};
+                    kind = (res.data?.type || null) as string | null;
                 } catch {
-                    // Leave credStatus empty; classify rows from inline YAML below.
+                    // 400/404 here means the backend doesn't recognise this entry as a
+                    // full-agent provider (modular providers, unknown kinds, in-flight
+                    // creations). Skip it — modular providers don't have per-instance
+                    // credential files in this design.
+                    return [];
                 }
+
+                if (!kind) return [];
+
+                // If the backend reports a kind we don't know about locally, fall back
+                // to api-key as the only credential to render (covers future provider
+                // kinds added server-side without a frontend update).
+                const credTypes = PROVIDER_CREDENTIAL_TYPES[kind] ?? ['api-key'];
+                const rows: PerInstanceCredentialRow[] = [];
 
                 for (const credentialType of credTypes) {
                     const status = credStatus[credentialType] || {};
@@ -481,7 +497,7 @@ const EnvPage = () => {
             <h3 className="text-lg font-semibold">Error Loading Configuration</h3>
             <p className="mt-2">{error}</p>
             <button
-                onClick={fetchEnv}
+                onClick={refreshAll}
                 className="mt-4 px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
             >
                 Retry
@@ -638,7 +654,7 @@ const EnvPage = () => {
                         Setup Wizard
                     </button>
                     <button
-                        onClick={fetchEnv}
+                        onClick={refreshAll}
                         className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2"
                     >
                         <RefreshCw className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary

Closes a gap surfaced during live multi-instance testing on voiprnd: when adding a duplicate full-agent provider (e.g. `acme_grok` alongside the canonical `grok` entry), there was **no place in the admin UI to set the per-instance API key**. The backend already supported per-instance credentials at `/app/project/secrets/providers/<key>/api-key`, but no frontend form invoked the upload endpoints, so duplicate provider entries persisted with no credentials wired up and silently fell through to the legacy single-tenant env var.

This PR adds a uniform paste-style credential uploader to every full-agent provider form, an audit surface on the Environment page, and fixes a subtle state-sync bug that was silently dropping `api_key_file` from the YAML after a credential upload.

## What's in

### New shared component
- **`ProviderCredentialsCard.tsx`** — paste-style API key uploader with three states:
  - **Env-var fallback** (legacy `\${XAI_API_KEY}` etc.) → links to Environment page + offers per-instance upload
  - **File uploaded** → path, last-modified, Replace / Delete buttons
  - **Not configured** → Upload button → paste field → POST `/api/config/providers/<key>/credentials/api-key`
  - For unsaved providers: shows a "save first" hint instead of a 404-prone upload form

### Wired into all 5 full-agent forms
- `GrokProviderForm` — `XAI_API_KEY` fallback
- `OpenAIRealtimeProviderForm` — `OPENAI_API_KEY` fallback
- `DeepgramProviderForm` — `DEEPGRAM_API_KEY` fallback
- `ElevenLabsProviderForm` — api-key + agent-id (`ELEVENLABS_API_KEY` / `ELEVENLABS_AGENT_ID`)
- `GoogleLiveProviderForm` — api-key path for Developer API mode; existing vertex-json uploader unchanged

`LocalProviderForm`, `OpenAIProviderForm`, `TelnyxProviderForm` accept `providerKey` as an unused optional prop so the shared switch dispatch type-checks.

### Env page audit surface
- New **"Per-Instance Provider Credentials"** section enumerates every full-agent provider entry and shows credential status: file uploaded / env-var reference / inline value / not configured. Read-only with "Edit →" links to `/providers`.

### Persistence bug fix (commit 2)
Live test on voiprnd surfaced a state-sync issue: after a successful credential upload, the backend YAML had `api_key_file` written, but the frontend `config` state was stale and didn't. A subsequent form Save then overwrote the YAML with stale data, **silently wiping the just-written credential reference**. The next call would fall back to the env var instead of using the per-instance file.

Root cause: `ProvidersPage.handleSaveProvider` spreads `existingData` (from frontend state) into the new provider entry, but `existingData` didn't have `api_key_file` because the upload happened out-of-band.

Fix: `ProviderCredentialsCard` now exposes an `onConfigPatch` callback that fires on upload/delete with the new field value (or `undefined` to delete). Each provider form wires it through `applyCredentialPatch()` to merge the change into its in-memory `config` state. Subsequent Saves now preserve `api_key_file` / `agent_id_file`.

## Out of scope (deferred)
- Backend-side defense-in-depth: the `/api/config/yaml` save endpoint could also be hardened to preserve credential references even when the frontend payload omits them. Frontend fix is sufficient for now; can add as belt-and-suspenders in a follow-up.

## Test plan

### Live-validated on voiprnd
- [x] Created `grok2` provider via Providers page UI
- [x] Pasted xAI API key into the new Credentials card → file landed at `/app/project/secrets/providers/grok2/api-key`
- [x] YAML local override gained `api_key_file: /app/project/secrets/providers/grok2/api-key`
- [x] Closed and re-saved the provider form → `api_key_file` survived the re-save (this is the bug commit 2 fixes; without it the field was getting stripped)
- [x] Engine restart picked up `api_key_file` (confirmed in startup log: `Local override applied to provider overridden_keys=['api_key_file', ...]`)
- [x] Real call via `AI_PROVIDER=grok2` dialplan → 40-second multi-turn conversation, clean hangup, post-call email + SMS hooks fired
- [x] RCA_CALL_END confirmed `provider_name: grok2`, `call_outcome: agent_hangup`, `media_rx_confirmed: true`

### Code
- [x] `npm run build` succeeds; `tsc --noEmit` clean for all touched files
- [x] No regressions in existing forms — `LocalProviderForm`, `OpenAIProviderForm`, `TelnyxProviderForm` accept the new prop as unused

## Reviewer notes

- The `onConfigPatch` pattern uses `undefined` to mean "delete this key" so a deleted credential becomes a missing key in the YAML rather than `field: null` after `yaml.dump`.
- `ProviderCredentialsCard` detects when `inlineValue` is a `\${ENV_VAR}` reference and routes the user to the Environment page instead of competing with the legacy env-var flow. Per-instance upload is still offered as a secondary action ("or upload a per-instance key file").
- `EnvPage.tsx` does a best-effort enumeration: it fetches `/api/config/yaml`, identifies full-agent entries via canonical key OR `type` field, then GETs `/api/config/providers/<key>/credentials` per entry. Errors are swallowed so a single 404 doesn't break the whole status section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-instance provider credentials: Upload and manage API keys and agent IDs for individual provider instances with status tracking
  * Credential management dashboard in the Environment/System tab with upload, replace, and delete capabilities
  * Environment variable fallback display showing per-instance credential precedence
  * Dedicated credentials sections added to provider configuration forms for streamlined credential entry

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->