### PR TITLE
Clarify ViciDial support as experimental

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,16 +91,16 @@ ASTERISK_ARI_PASSWORD=asterisk
 # Dialplan context used for the AMD hop (engine uses ARI continueInDialplan):
 # AAVA_OUTBOUND_AMD_CONTEXT=aava-outbound-amd
 #
-# PBX type controls FreePBX-specific channel vars (AMPUSER/FROMEXTEN):
-#   freepbx (default) | vicidial | generic
+# PBX type controls FreePBX-specific channel vars (AMPUSER/FROMEXTEN).
+#   freepbx (default) | vicidial (experimental/community-tested) | generic
 # AAVA_OUTBOUND_PBX_TYPE=freepbx
 #
 # Asterisk dialplan context for Local/ channel origination:
-#   FreePBX: from-internal (default) | ViciDial: default | custom context
+#   FreePBX: from-internal (default) | ViciDial experimental notes: default | custom context
 # AAVA_OUTBOUND_DIAL_CONTEXT=from-internal
 #
 # Dial prefix prepended to phone number before routing (carrier selection):
-#   FreePBX: empty (default) | ViciDial: e.g. 911 (matches carrier pattern in dialplan)
+#   FreePBX: empty (default) | ViciDial experimental notes: e.g. 911 (matches carrier pattern in dialplan)
 # AAVA_OUTBOUND_DIAL_PREFIX=
 #
 # Channel technology for internal extension probing:

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ For older releases, expand **Previous Versions** below. Full release notes in [C
 
 #### v6.1.1 - Operator Config & Live Agent Transfer
 - Operator config overrides (`ai-agent.local.yaml`), live agent transfer tool
-- ViciDial compatibility, Asterisk config discovery in Admin UI
+- Experimental ViciDial community-tested configuration notes, Asterisk config discovery in Admin UI
 - OpenAI Realtime GA API, Email system overhaul, NAT/GPU support
 
 #### v5.3.1 - Phase Tools & Stability

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -2106,22 +2106,22 @@ const EnvPage = () => {
                                     onChange={(e) => updateEnv('AAVA_OUTBOUND_PBX_TYPE', e.target.value)}
                                     options={[
                                         { value: 'freepbx', label: 'FreePBX' },
-                                        { value: 'vicidial', label: 'ViciDial' },
+                                        { value: 'vicidial', label: 'ViciDial (experimental)' },
                                         { value: 'generic', label: 'Generic Asterisk' },
                                     ]}
-                                    tooltip="Controls FreePBX-specific channel vars (AMPUSER/FROMEXTEN). ViciDial and generic skip them."
+                                    tooltip="Controls FreePBX-specific channel vars (AMPUSER/FROMEXTEN). ViciDial mode is experimental/community-tested and not production-reviewed by ViciDial maintainers."
                                 />
                                 <FormInput
                                     label="Dial Context"
                                     value={env['AAVA_OUTBOUND_DIAL_CONTEXT'] || 'from-internal'}
                                     onChange={(e) => updateEnv('AAVA_OUTBOUND_DIAL_CONTEXT', e.target.value)}
-                                    tooltip="Asterisk dialplan context for Local/ origination. FreePBX: from-internal, ViciDial: default."
+                                    tooltip="Asterisk dialplan context for Local/ origination. FreePBX: from-internal. Experimental ViciDial notes commonly use default."
                                 />
                                 <FormInput
                                     label="Dial Prefix"
                                     value={env['AAVA_OUTBOUND_DIAL_PREFIX'] || ''}
                                     onChange={(e) => updateEnv('AAVA_OUTBOUND_DIAL_PREFIX', e.target.value)}
-                                    tooltip="Prefix prepended to phone number for carrier routing. ViciDial example: 911."
+                                    tooltip="Prefix prepended to phone number for carrier routing. Experimental ViciDial notes use examples like 911."
                                 />
                                 <FormSelect
                                     label="Channel Tech"
@@ -2133,7 +2133,7 @@ const EnvPage = () => {
                                         { value: 'sip', label: 'SIP only (chan_sip)' },
                                         { value: 'local_only', label: 'Local only (no probing)' },
                                     ]}
-                                    tooltip="Channel technology for internal extension probing. ViciDial uses SIP (chan_sip)."
+                                    tooltip="Channel technology for internal extension probing. Experimental ViciDial notes typically use SIP (chan_sip)."
                                 />
                                 <FormInput
                                     label="Media Directory"

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -115,7 +115,7 @@ contexts:
 
       - AI receptionist with extension routing and ring group support
 
-      - Outbound campaigns and sales with ViciDial integration
+      - Outbound campaigns and sales with experimental ViciDial community-tested notes
 
       - Multilingual support for global businesses
 
@@ -128,7 +128,7 @@ contexts:
 
       - Live agent transfer with real-time extension status checks
 
-      - AI-native outbound campaign dialer with ViciDial and FreePBX support
+      - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
 
       - MCP tool server support for extensible AI capabilities
 
@@ -314,7 +314,7 @@ contexts:
 
       - AI receptionist with extension routing and ring group support
 
-      - Outbound campaigns and sales with ViciDial integration
+      - Outbound campaigns and sales with experimental ViciDial community-tested notes
 
       - Multilingual support for global businesses
 
@@ -327,7 +327,7 @@ contexts:
 
       - Live agent transfer with real-time extension status checks
 
-      - AI-native outbound campaign dialer with ViciDial and FreePBX support
+      - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
 
       - MCP tool server support for extensible AI capabilities
 
@@ -503,8 +503,10 @@ contexts:
       - Outbound campaign dialer (v1): single-node, scheduled campaigns, CSV lead import,
         voicemail detection + prerecorded voicemail drop, manual recycle for retries
 
-      - ViciDial integration: set AAVA_OUTBOUND_PBX_TYPE=vicidial to use ViciDial's dialer
-        with AAVA's AI voice handling. Configurable dial context, prefix, and channel tech.
+      - ViciDial notes: experimental/community-tested configuration exists for
+        AAVA_OUTBOUND_PBX_TYPE=vicidial. It is not production-reviewed by ViciDial
+        maintainers; production ViciDial deployments should prefer a ViciDial-native
+        Remote Agent design.
 
       - Also supports FreePBX and generic Asterisk setups via AAVA_OUTBOUND_PBX_TYPE
 
@@ -517,8 +519,9 @@ contexts:
 
       OBJECTIONS / COMPARISONS (be balanced):
 
-      - If they mention Vicidial: acknowledge it's powerful for predictive dialing; AAVA now
-        integrates with ViciDial directly so they can use both together
+      - If they mention Vicidial: acknowledge it's powerful for predictive dialing.
+        Explain that AAVA has experimental community-tested ViciDial notes, but
+        production use should be designed around ViciDial Remote Agents.
 
       - If they worry about trunks/callerid: explain it uses their existing outbound routes/trunks
 
@@ -597,7 +600,7 @@ contexts:
 
       - AI receptionist with extension routing and ring group support
 
-      - Outbound campaigns and sales with ViciDial integration
+      - Outbound campaigns and sales with experimental ViciDial community-tested notes
 
       - Multilingual support for global businesses
 
@@ -610,7 +613,7 @@ contexts:
 
       - Live agent transfer with real-time extension status checks
 
-      - AI-native outbound campaign dialer with ViciDial and FreePBX support
+      - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
 
       - MCP tool server support for extensible AI capabilities
 
@@ -842,7 +845,7 @@ contexts:
 
       - AI receptionist with extension routing and ring group support
 
-      - Outbound campaigns and sales with ViciDial integration
+      - Outbound campaigns and sales with experimental ViciDial community-tested notes
 
       - Multilingual support for global businesses
 
@@ -855,7 +858,7 @@ contexts:
 
       - Live agent transfer with real-time extension status checks
 
-      - AI-native outbound campaign dialer with ViciDial and FreePBX support
+      - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
 
       - MCP tool server support for extensible AI capabilities
 
@@ -1033,7 +1036,7 @@ contexts:
 
       - AI receptionist with extension routing and ring group support
 
-      - Outbound campaigns and sales with ViciDial integration
+      - Outbound campaigns and sales with experimental ViciDial community-tested notes
 
       - Multilingual support for global businesses
 
@@ -1046,7 +1049,7 @@ contexts:
 
       - Live agent transfer with real-time extension status checks
 
-      - AI-native outbound campaign dialer with ViciDial and FreePBX support
+      - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
 
       - MCP tool server support for extensible AI capabilities
 

--- a/config/contexts/demo-project-expert.yaml
+++ b/config/contexts/demo-project-expert.yaml
@@ -18,7 +18,7 @@ system_prompt: |
   - Admin UI with Setup Wizard at port 3003 for visual configuration and live system topology
   - Phase tools for pre-call lookups, in-call HTTP actions, and post-call webhooks
   - Live agent transfer with real-time extension status checks
-  - AI-native outbound campaign dialer with ViciDial and FreePBX support
+  - AI-native outbound campaign dialer with FreePBX support and experimental ViciDial community-tested notes
   - MCP tool server support for extensible AI capabilities
   - NAT and split-horizon support for remote and cloud deployments
   - SMTP and Resend email with HTML templates for call summaries
@@ -84,7 +84,7 @@ system_prompt: |
   - Appointment booking and scheduling with calendar integration
   - After-hours call handling with voicemail and live agent transfer
   - AI receptionist with extension routing and ring group support
-  - Outbound campaigns and sales with ViciDial integration
+  - Outbound campaigns and sales with experimental ViciDial community-tested notes
   - Multilingual support for global businesses
   - Healthcare patient interactions (with local hybrid for HIPAA compliance)
   

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -147,9 +147,9 @@ Outbound calling is implemented as an **engine-driven scheduler + SQLite + ARI o
 |----------|---------|-------------|
 | `AAVA_OUTBOUND_EXTENSION_IDENTITY` | `6789` | Extension identity for FreePBX routing (sets `AMPUSER` + `CALLERID(num)` on originate) |
 | `AAVA_OUTBOUND_AMD_CONTEXT` | `aava-outbound-amd` | Dialplan context name used for AMD hop (`continueInDialplan`) |
-| `AAVA_OUTBOUND_PBX_TYPE` | `freepbx` | PBX-specific channel vars: `freepbx` \| `vicidial` \| `generic` |
+| `AAVA_OUTBOUND_PBX_TYPE` | `freepbx` | PBX-specific channel vars: `freepbx` \| `vicidial` experimental/community-tested \| `generic` |
 | `AAVA_OUTBOUND_DIAL_CONTEXT` | `from-internal` | Asterisk dialplan context for `Local/` channel origination |
-| `AAVA_OUTBOUND_DIAL_PREFIX` | (empty) | Dial prefix prepended to phone number for carrier selection (e.g. `911` for ViciDial) |
+| `AAVA_OUTBOUND_DIAL_PREFIX` | (empty) | Dial prefix prepended to phone number for carrier selection (e.g. `911` in the experimental ViciDial notes) |
 | `AAVA_OUTBOUND_CHANNEL_TECH` | `auto` | Channel tech for extension probing: `auto` \| `pjsip` \| `sip` \| `local_only` |
 | `AAVA_MEDIA_DIR` | `/mnt/asterisk_media/ai-generated` | Where the Admin UI uploads voicemail drop `.ulaw` files |
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -254,7 +254,7 @@ docker compose -p asterisk-ai-voice-agent up -d --build --force-recreate
 New in v6.1.1:
 - Operator config overrides via `config/ai-agent.local.yaml` (optional, git-ignored)
 - Live agent transfer tool (opt-in via tool allowlist)
-- ViciDial outbound dialer compatibility (opt-in via `.env`)
+- Experimental ViciDial outbound dialer configuration notes (opt-in via `.env`)
 
 ## v5.x to v6.0.0
 

--- a/docs/MILESTONE_HISTORY.md
+++ b/docs/MILESTONE_HISTORY.md
@@ -46,7 +46,7 @@ Archive of completed development milestones for the Asterisk AI Voice Agent. For
 | v6.5.1 | May 2026 | CPU-demo profile (Faster-Whisper `tiny.en` + Piper + Qwen 0.5B) wired through Admin UI; runtime Device/Compute selectors; Filler Audio + LLM/TTS Overlap runtime toggles; local provider hot-path hardening (no per-frame `_reconnect` blocking). |
 | v6.5.0 | May 2026 | Local LLM tool-gated response (`tool_context`/`tool_result` v2 protocol), Deepgram Flux v2 + nova-3 default, Gemini 3.1 verified, Admin UI Flux tuning panel, #351 / #370 fixes |
 | v6.4.2 | Apr 2026 | Calendar improvements, custom (community) model entries via Admin UI, Vertex AI onboarding script |
-| v6.1.1 | Feb 2026 | Operator config overrides, live agent transfer, ViciDial compatibility, Admin UI Asterisk audit |
+| v6.1.1 | Feb 2026 | Operator config overrides, live agent transfer, experimental ViciDial configuration notes, Admin UI Asterisk audit |
 | v6.0.0 | Feb 2026 | OpenAI Realtime GA API, email system overhaul, NAT/GPU support, Google Live improvements |
 | v5.3.1 | Jan 2026 | Phase tools (pre/in/post-call HTTP), extension status checking, Deepgram language config |
 | v5.0.0 | Jan 2026 | Outbound Campaign Dialer (Alpha), Groq Speech, Ollama improvements, attended transfer |

--- a/docs/Vicidial-Setup.md
+++ b/docs/Vicidial-Setup.md
@@ -1,18 +1,27 @@
-# ViciDial Integration Guide
+# Experimental ViciDial Integration Notes
 
-Complete guide for integrating Asterisk AI Voice Agent with ViciDial for inbound and outbound AI-powered calling.
+Community-tested notes for exploring Asterisk AI Voice Agent with ViciDial in non-production environments.
+
+> **Status: Experimental / Community-Tested**
+>
+> This guide reflects a limited setup tested with community users who requested a ViciDial path. It has not been reviewed or endorsed by ViciDial maintainers and should not be treated as production-ready ViciDial integration guidance.
+>
+> A ViciDial maintainer has raised concerns that direct AAVA/ARI origination through ViciDial dialplan contexts may bypass ViciDial's normal call-control, reporting, hangup processing, and compliance safeguards.
+>
+> For production ViciDial environments, the safer intended direction is for ViciDial to own call origination/routing and hand connected calls to AAVA through ViciDial Remote Agents, with follow-up transfer/control handled through ViciDial's Agent API such as `ra_call_control`.
 
 ## 1. Overview
 
-ViciDial is a popular open-source contact center suite built on Asterisk. AAVA integrates with ViciDial using the **Asterisk REST Interface (ARI)**, the same mechanism used for FreePBX — but ViciDial has different dialplan conventions, channel technologies, and routing patterns that require specific configuration.
+ViciDial is a popular open-source contact center suite built on Asterisk. These notes describe an experimental AAVA path that uses the **Asterisk REST Interface (ARI)**, the same mechanism used for FreePBX, against a ViciDial-style Asterisk environment. ViciDial has its own dialplan conventions, channel technologies, routing patterns, reporting, and call-state lifecycle, so validate carefully before using any part of this outside a lab.
 
-This guide covers:
+These notes cover:
 
 - Inbound call routing (DID → AI agent)
-- Outbound campaign dialing (AAVA scheduler → ViciDial carrier trunks)
+- Experimental outbound campaign dialing (AAVA scheduler → ViciDial carrier trunks)
 - Environment variable configuration
 - Dialplan contexts required in `extensions.conf`
 - Troubleshooting common issues
+- Future production direction using ViciDial Remote Agents
 
 ### Key Differences: ViciDial vs FreePBX
 
@@ -22,7 +31,7 @@ This guide covers:
 | Dial prefix | None (trunk selected by route) | Carrier prefix (e.g. `911`, `913`) |
 | Channel technology | PJSIP (`pjsip` module) | SIP (`chan_sip`) |
 | Extension routing vars | `AMPUSER`, `FROMEXTEN` | Not used |
-| Call origination | ARI only | AMI (ViciDial native) + ARI (AAVA) |
+| Call origination | ARI only | AMI (ViciDial native); ARI/AAVA path below is experimental |
 | Trunk configuration | FreePBX GUI → Trunks | `/etc/asterisk/sip.conf` peers |
 
 ## 2. Prerequisites
@@ -93,7 +102,7 @@ You should see `chan_sip.so` loaded. If you also see `res_pjsip.so`, both are av
 
 ## 3. Dialplan Configuration
 
-Add these two contexts to your `/etc/asterisk/extensions.conf`. They handle inbound AI agent calls and outbound campaign AMD (Answering Machine Detection) handoff.
+For lab testing, add these two contexts to your `/etc/asterisk/extensions.conf`. They handle inbound AI agent calls and an experimental outbound campaign AMD (Answering Machine Detection) handoff.
 
 ### 3.1 Inbound Context: `[from-ai-agent]`
 
@@ -115,7 +124,7 @@ exten => s,1,NoOp(AI Agent Call)
 
 ### 3.2 Outbound AMD Context: `[aava-outbound-amd]`
 
-This context is the handoff point after an outbound call is answered. AAVA originates the call, the dialplan processes AMD, then hands the call to the Stasis application.
+This context is the experimental handoff point after an outbound call is answered. AAVA originates the call, the dialplan processes AMD, then hands the call to the Stasis application.
 
 #### Option A: Direct Connect (No AMD)
 
@@ -133,7 +142,7 @@ exten => s,1,NoOp(AAVA Outbound Direct Connect)
 
 #### Option B: Full AMD with Voicemail Drop and Consent Gate
 
-Production-grade setup with answering machine detection, voicemail drop, and optional DTMF consent gate:
+More complete test setup with answering machine detection, voicemail drop, and optional DTMF consent gate:
 
 ```ini
 [aava-outbound-amd]
@@ -180,7 +189,7 @@ asterisk -rx "dialplan reload"
 
 ## 4. Environment Variable Configuration
 
-Add these to your `.env` file in the AAVA project root. These tell the `ai_engine` how to originate outbound calls through ViciDial's Asterisk dialplan.
+For lab testing, add these to your `.env` file in the AAVA project root. These tell the `ai_engine` how to originate outbound calls through ViciDial's Asterisk dialplan.
 
 ### 4.1 ARI Connection (same as FreePBX)
 
@@ -190,10 +199,10 @@ ASTERISK_ARI_PASSWORD=your_secure_password_here
 ASTERISK_ARI_PORT=8088
 ```
 
-### 4.2 ViciDial-Specific Outbound Settings
+### 4.2 Experimental ViciDial Outbound Settings
 
 ```env
-# Tell AAVA this is a ViciDial system (skips FreePBX-specific AMPUSER/FROMEXTEN vars)
+# Experimental/community-tested only; skips FreePBX-specific AMPUSER/FROMEXTEN vars
 AAVA_OUTBOUND_PBX_TYPE=vicidial
 
 # ViciDial's outbound dial context (usually "default", which includes carrier routes)
@@ -240,18 +249,18 @@ Use the same prefix, or the one that routes through your preferred carrier.
 
 | Variable | Default | ViciDial Value | Description |
 | --- | --- | --- | --- |
-| `AAVA_OUTBOUND_PBX_TYPE` | `freepbx` | `vicidial` | Controls FreePBX-specific channel vars. Set to `vicidial` or `generic` for non-FreePBX systems. |
+| `AAVA_OUTBOUND_PBX_TYPE` | `freepbx` | `vicidial` | Controls FreePBX-specific channel vars. `vicidial` is experimental/community-tested; `generic` is available for non-FreePBX systems. |
 | `AAVA_OUTBOUND_DIAL_CONTEXT` | `from-internal` | `default` | Asterisk dialplan context for `Local/` channel origination. |
 | `AAVA_OUTBOUND_DIAL_PREFIX` | *(empty)* | e.g. `913` | Prefix prepended to phone number. Must match a carrier pattern in your dialplan. |
 | `AAVA_OUTBOUND_CHANNEL_TECH` | `auto` | `sip` | Channel technology for internal extension probing. `auto` tries PJSIP then SIP. `sip` for chan_sip only. `local_only` skips probing. |
 | `AAVA_OUTBOUND_EXTENSION_IDENTITY` | `6789` | e.g. `1000` | Extension identity for caller ID on outbound calls. |
 | `AAVA_OUTBOUND_AMD_CONTEXT` | `aava-outbound-amd` | `aava-outbound-amd` | Dialplan context for AMD hop (usually same for both). |
 
-These settings are also configurable via the **Admin UI** → **System** → **Environment Variables** → **Outbound Campaign** section.
+These settings are also configurable via the **Admin UI** → **System** → **Environment Variables** → **Outbound Campaign** section. The Admin UI labels this path as experimental.
 
 ## 5. How Outbound Dialing Works
 
-When AAVA's outbound scheduler fires a campaign call, the following happens:
+In the experimental ARI-originated path, when AAVA's outbound scheduler fires a campaign call, the following happens:
 
 ```text
 1. ai_engine reads campaign + lead from DB
@@ -269,6 +278,8 @@ When AAVA's outbound scheduler fires a campaign call, the following happens:
 6. AMD context hands channel to Stasis(asterisk-ai-voice-agent)
 7. ai_engine handles AI conversation (greeting, STT, LLM, TTS)
 ```
+
+> **Important:** This flow may bypass parts of ViciDial's normal call-control, reporting, hangup processing, and compliance handling. Treat it as a community-tested lab path, not a ViciDial-native production design.
 
 ### Call Flow Diagram
 
@@ -300,7 +311,7 @@ git pull origin main
 
 # Copy example env and configure
 cp .env.example .env
-# Edit .env with your ARI credentials and ViciDial-specific settings (see Section 4)
+# Edit .env with your ARI credentials and experimental ViciDial settings (see Section 4)
 ```
 
 ### 6.2 Add Dialplan Contexts
@@ -448,22 +459,33 @@ docker logs ai_engine 2>&1 | grep "AudioSocket"
 
 Ensure port 8090/TCP is accessible from Asterisk to the ai_engine container.
 
-## 9. Admin UI Configuration
+## 9. Recommended Future Direction
 
-The ViciDial-specific settings are available in the Admin UI under **System** → **Environment Variables** → **Outbound Campaign (Alpha)**:
+The intended production direction is a ViciDial-native Remote Agent design:
 
-- **PBX Type**: Select "ViciDial"
+1. ViciDial owns inbound/outbound call handling, campaign logic, routing, reporting, compliance behavior, and hangup processing.
+2. When a call is connected, ViciDial sends it to a Remote Agent extension.
+3. That extension invokes AAVA for the AI voice interaction.
+4. When the AI interaction is complete, AAVA uses ViciDial's Agent API, such as `ra_call_control`, to transfer the call to an Ingroup or external destination.
+
+This design should be reviewed with ViciDial maintainers or the official ViciDial forum before replacing these experimental notes.
+
+## 10. Admin UI Configuration
+
+The experimental ViciDial-specific settings are available in the Admin UI under **System** → **Environment Variables** → **Outbound Campaign (Alpha)**:
+
+- **PBX Type**: Select "ViciDial (experimental)"
 - **Dial Context**: Set to your ViciDial outbound context (usually `default`)
 - **Dial Prefix**: Set to your carrier prefix (e.g. `913`)
 - **Channel Tech**: Select "SIP only (chan_sip)" for ViciDial
 
 Changes made in the Admin UI are saved to the `.env` file and take effect after restarting the ai_engine container.
 
-## 10. Files Reference
+## 11. Files Reference
 
 | File | Purpose |
 | --- | --- |
-| `.env` | Environment variables including ViciDial-specific outbound settings |
+| `.env` | Environment variables including experimental ViciDial-specific outbound settings |
 | `.env.example` | Documented example with all available variables |
 | `src/engine.py` | Core engine — outbound origination logic, endpoint selection, channel vars |
 | `config/ai-agent.yaml` | AI context definitions, provider configuration, audio profiles |
@@ -473,7 +495,7 @@ Changes made in the Admin UI are saved to the `.env` file and take effect after 
 | `/etc/asterisk/http.conf` | Asterisk HTTP server (required for ARI) |
 | `/etc/asterisk/extensions-vicidial.conf` | ViciDial carrier route patterns (read-only reference) |
 
-## 11. Related Documentation
+## 12. Related Documentation
 
 - [INSTALLATION.md](INSTALLATION.md) — First-time installation
 - [Configuration-Reference.md](Configuration-Reference.md) — Full configuration reference

--- a/src/engine.py
+++ b/src/engine.py
@@ -284,7 +284,8 @@ class Engine:
         self._outbound_amd_context = str(os.getenv("AAVA_OUTBOUND_AMD_CONTEXT", "aava-outbound-amd")).strip() or "aava-outbound-amd"
         self._outbound_pjsip_endpoint_cache: Dict[str, Dict[str, Any]] = {}
         self._outbound_pjsip_endpoint_cache_ttl_seconds = float(os.getenv("AAVA_OUTBOUND_PJSIP_ENDPOINT_CACHE_TTL_SECONDS", "300") or "300")
-        # ViciDial / generic PBX compatibility (defaults preserve FreePBX behavior)
+        # Generic PBX routing plus experimental/community-tested ViciDial notes.
+        # Defaults preserve FreePBX behavior.
         self._outbound_dial_context = str(os.getenv("AAVA_OUTBOUND_DIAL_CONTEXT", "from-internal")).strip() or "from-internal"
         self._outbound_dial_prefix = str(os.getenv("AAVA_OUTBOUND_DIAL_PREFIX", "")).strip()
         self._outbound_channel_tech = str(os.getenv("AAVA_OUTBOUND_CHANNEL_TECH", "auto")).strip().lower() or "auto"
@@ -1394,7 +1395,7 @@ class Engine:
             logger.error("Outbound scheduler crashed", exc_info=True)
 
     async def _outbound_originate_attempt(self, campaign: Dict[str, Any], lead: Dict[str, Any], attempt_id: str) -> None:
-        """Originate a leased+marked lead via configurable Local/ routing (FreePBX, ViciDial, generic)."""
+        """Originate a leased+marked lead via configurable Local/ routing."""
         campaign_id = str(campaign.get("id") or "")
         lead_id = str(lead.get("id") or "")
         phone = str(lead.get("phone_number") or "").strip()
@@ -1567,9 +1568,10 @@ class Engine:
         """
         Choose best endpoint for outbound dialing.
 
-        Configurable via env vars for FreePBX, ViciDial, or generic Asterisk:
+        Configurable via env vars for FreePBX, generic Asterisk, or the experimental
+        ViciDial community-tested notes:
         - AAVA_OUTBOUND_DIAL_CONTEXT  (default: from-internal)
-        - AAVA_OUTBOUND_DIAL_PREFIX   (default: empty — ViciDial uses e.g. '911')
+        - AAVA_OUTBOUND_DIAL_PREFIX   (default: empty; ViciDial notes use e.g. '911')
         - AAVA_OUTBOUND_CHANNEL_TECH  (auto | pjsip | sip | local_only)
 
         When channel_tech is 'auto', probes PJSIP then SIP for internal extensions.


### PR DESCRIPTION
## Summary

- Reframe ViciDial documentation as experimental/community-tested rather than production-ready support
- Add maintainer-raised concerns and the preferred Remote Agent / `ra_call_control` direction to the ViciDial notes
- Update Admin UI labels/tooltips, env docs, release notes, demo prompt copy, and code comments to use the same experimental wording

## Context

Addresses the concerns raised in #405 without removing the existing community-tested path or making breaking behavior changes.

## Validation

- `git diff --check`
- Targeted search confirmed old confident phrases like "ViciDial compatibility", "integrates directly", and "production-grade setup" are no longer present in the touched surfaces

Note: `npm --prefix admin_ui/frontend run lint` still fails on existing repo lint debt unrelated to this PR, including `src/utils/ansi.tsx` `no-control-regex` plus existing warnings. The touched UI file reports warnings only, no errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ViciDial support is experimental and community-tested throughout configuration guides and documentation.
  * Enhanced outbound dialer configuration reference with expanded explanations and warnings.

* **Chores**
  * Updated UI labels and tooltips to reflect experimental ViciDial status.
  * Updated configuration prompts for consistency across system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->