### PR TITLE
Upgrade MiniMax LLM adapter default to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,7 +162,7 @@ TELNYX_API_KEY=
 # MiniMax LLM (OpenAI-compatible API)
 # Get your API key at: https://platform.minimax.io/
 # Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
-# Models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+# Models: MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed
 MINIMAX_API_KEY=
 
 # Microsoft Azure Speech Service (STT & TTS)

--- a/README.md
+++ b/README.md
@@ -361,9 +361,9 @@ For older releases, expand **Previous Versions** below. Full release notes in [C
 ### Additional LLM Providers
 
 - **MiniMax LLM** (High-Performance Cost-Effective)
-   - Local STT/TTS + MiniMax M2.7 LLM with enhanced reasoning and coding.
+   - Local STT/TTS + MiniMax M3 LLM with enhanced reasoning and coding.
    - OpenAI-compatible API with tool-calling support.
-   - Models: `MiniMax-M2.7` (default, latest flagship), `MiniMax-M2.7-highspeed` (low-latency), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+   - Models: `MiniMax-M3` (default, latest flagship), `MiniMax-M2.7` (previous flagship), `MiniMax-M2.7-highspeed` (low-latency).
    - Activate: set `MINIMAX_API_KEY` in `.env`, then configure `providers.minimax_llm` in `config/ai-agent.yaml` (see the `minimax_llm` section with `enabled: true`).
    - *Best for: Long-context conversations, cost-effective high-performance LLM.*
 

--- a/admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx
@@ -78,8 +78,8 @@ const PROVIDER_OPTIONS: Record<string, Record<string, string[]>> = {
         ],
     },
     minimax: {
-        chat_model: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
-        model: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+        chat_model: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+        model: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     },
 };
 

--- a/admin_ui/frontend/src/config/modularProviderSubtypes.ts
+++ b/admin_ui/frontend/src/config/modularProviderSubtypes.ts
@@ -81,7 +81,7 @@ const LLM_SUBTYPES: ProviderSubtype[] = [
     yamlType: 'minimax',
     fields: [
       { key: 'chat_base_url', label: 'API Base URL', type: 'text', required: true, default: 'https://api.minimax.io/v1', placeholder: 'https://api.minimax.io/v1' },
-      { key: 'chat_model', label: 'Model', type: 'combobox', required: true, suggestions: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5'] },
+      { key: 'chat_model', label: 'Model', type: 'combobox', required: true, suggestions: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
       { key: 'api_key', label: 'API Key', type: 'text', required: true, placeholder: '${MINIMAX_API_KEY}' },
       { key: 'temperature', label: 'Temperature', type: 'number', required: false, default: 0.7 },
       { key: 'response_timeout_sec', label: 'Response Timeout (sec)', type: 'number', required: false, default: 30 },

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -1692,8 +1692,8 @@ providers:
       - llm
     chat_base_url: https://api.minimax.io/v1
     # Domestic (China) URL: https://api.minimaxi.com/v1
-    chat_model: MiniMax-M2.7
-    # Alternatives: MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+    chat_model: MiniMax-M3
+    # Alternatives: MiniMax-M2.7, MiniMax-M2.7-highspeed
     enabled: false
     # API key comes from MINIMAX_API_KEY env var
     temperature: 1.0

--- a/docs/Provider-MiniMax-Setup.md
+++ b/docs/Provider-MiniMax-Setup.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-MiniMax provides OpenAI-compatible Chat Completions for its M2.7 family of models with enhanced reasoning and coding capabilities. Suitable for AI voice agents needing large-context LLM capabilities with tool calling support.
+MiniMax provides OpenAI-compatible Chat Completions for its M3 / M2.7 family of models with enhanced reasoning and coding capabilities. Suitable for AI voice agents needing large-context LLM capabilities with tool calling support.
 
-**Performance**: 204K context window | OpenAI-compatible API | Tool calling supported
+**Performance**: Large context window | OpenAI-compatible API | Tool calling supported
 
 **Why MiniMax?**
-- **Large context**: 204K token context window for complex conversations
+- **Large context**: Long-context window for complex conversations
 - **OpenAI-compatible**: Standard Chat Completions API format
 - **Speed option**: `MiniMax-M2.7-highspeed` variant for latency-sensitive calls
 - **Tool calling**: Native function calling via OpenAI-style `tools` parameter
@@ -50,7 +50,7 @@ providers:
     capabilities: [llm]
     chat_base_url: "https://api.minimax.io/v1"
     # For China domestic access: https://api.minimaxi.com/v1
-    chat_model: MiniMax-M2.7
+    chat_model: MiniMax-M3
     temperature: 1.0
     response_timeout_sec: 30
 
@@ -61,7 +61,7 @@ pipelines:
     tts: local_tts
     options:
       llm:
-        model: MiniMax-M2.7
+        model: MiniMax-M3
         temperature: 1.0
         max_tokens: 150
       stt:
@@ -81,10 +81,9 @@ active_pipeline: minimax_hybrid
 
 | Model | Description | Best For |
 |-------|-------------|----------|
-| `MiniMax-M2.7` | Default, latest flagship with enhanced reasoning | General-purpose voice workflows |
+| `MiniMax-M3` | Default, latest flagship | General-purpose voice workflows |
+| `MiniMax-M2.7` | Previous flagship, retained for compatibility | Workloads pinned to the prior generation |
 | `MiniMax-M2.7-highspeed` | High-speed version of M2.7 | Latency-sensitive calls |
-| `MiniMax-M2.5` | Previous generation, 204K context | Legacy compatibility |
-| `MiniMax-M2.5-highspeed` | Previous generation, lower latency | Legacy latency-sensitive calls |
 
 ### 5. Tool Calling
 
@@ -121,7 +120,7 @@ asterisk -rx "dialplan reload"
 1. Navigate to the Admin UI provider configuration page
 2. Add a new LLM provider with type `minimax`
 3. Set the API key (or reference `MINIMAX_API_KEY` from `.env`)
-4. Select model (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, or `MiniMax-M2.5-highspeed`)
+4. Select model (`MiniMax-M3`, `MiniMax-M2.7`, or `MiniMax-M2.7-highspeed`)
 5. Create or update a pipeline to use `minimax_llm` as the LLM component
 
 ### 9. Test Call

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 - **[xAI Grok Voice Agent Setup](Provider-Grok-Setup.md)** - Grok realtime full-agent provider (μ-law @ 8 kHz, 30-min cap)
 - **[Telnyx AI Inference Setup](Provider-Telnyx-Setup.md)** - OpenAI-compatible LLM via Telnyx
 - **[Azure Speech Service Setup](Provider-Azure-Setup.md)** - Azure STT & TTS pipeline adapters
-- **[MiniMax LLM Setup](Provider-MiniMax-Setup.md)** - MiniMax M2.7 LLM via OpenAI-compatible API
+- **[MiniMax LLM Setup](Provider-MiniMax-Setup.md)** - MiniMax M3 LLM via OpenAI-compatible API
 - **[Multi-Instance Full-Agent Providers](Multi-Instance-Full-Agent-Providers.md)** - Run multiple instances of the same provider type with isolated credentials
 
 ## Local AI & GPU Setup

--- a/src/config.py
+++ b/src/config.py
@@ -295,8 +295,8 @@ class MiniMaxLLMProviderConfig(BaseModel):
     Canonical defaults for the MiniMax LLM pipeline adapter.
 
     MiniMax exposes an OpenAI-compatible Chat Completions endpoint.
-    Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed,
-    MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context).
+    Supported models: MiniMax-M3 (default), MiniMax-M2.7,
+    MiniMax-M2.7-highspeed.
 
     Key constraints:
       - temperature must be in (0.0, 1.0]; 0 is rejected.
@@ -308,7 +308,7 @@ class MiniMaxLLMProviderConfig(BaseModel):
     api_key: Optional[str] = None
 
     chat_base_url: str = Field(default="https://api.minimax.io/v1")
-    chat_model: str = Field(default="MiniMax-M2.7")
+    chat_model: str = Field(default="MiniMax-M3")
 
     temperature: float = Field(default=1.0)
     max_tokens: Optional[int] = None

--- a/src/pipelines/minimax.py
+++ b/src/pipelines/minimax.py
@@ -1,15 +1,15 @@
 """
 MiniMax LLM pipeline adapter (OpenAI-compatible Chat Completions).
 
-MiniMax provides OpenAI-compatible endpoints for its M2.7 family of models.
-This adapter uses the OpenAI Chat Completions format with MiniMax-specific
-constraints (e.g. temperature must be in (0.0, 1.0], response_format unsupported).
+MiniMax provides OpenAI-compatible endpoints for its M3 / M2.7 family of
+models. This adapter uses the OpenAI Chat Completions format with
+MiniMax-specific constraints (e.g. temperature must be in (0.0, 1.0],
+response_format unsupported).
 
 Supported models:
-  - MiniMax-M2.7            (default, latest flagship with enhanced reasoning)
+  - MiniMax-M3              (default, latest flagship)
+  - MiniMax-M2.7            (previous flagship, retained for compatibility)
   - MiniMax-M2.7-highspeed  (high-speed version for low-latency scenarios)
-  - MiniMax-M2.5            (previous generation, 204K context)
-  - MiniMax-M2.5-highspeed  (previous generation, faster)
 
 API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
 """

--- a/tests/test_pipeline_minimax_adapter.py
+++ b/tests/test_pipeline_minimax_adapter.py
@@ -19,7 +19,7 @@ def _build_app_config() -> AppConfig:
         "minimax_llm": {
             "api_key": "test-minimax-key",
             "chat_base_url": "https://api.minimax.io/v1",
-            "chat_model": "MiniMax-M2.7",
+            "chat_model": "MiniMax-M3",
             "temperature": 1.0,
             "response_timeout_sec": 10.0,
             "type": "minimax",
@@ -39,7 +39,7 @@ def _build_app_config() -> AppConfig:
         default_provider="minimax",
         providers=providers,
         asterisk={"host": "127.0.0.1", "username": "ari", "password": "secret"},
-        llm={"initial_greeting": "hi", "prompt": "You are a helpful assistant.", "model": "MiniMax-M2.7"},
+        llm={"initial_greeting": "hi", "prompt": "You are a helpful assistant.", "model": "MiniMax-M3"},
         audio_transport="audiosocket",
         downstream_mode="stream",
         pipelines=pipelines,
@@ -158,7 +158,7 @@ async def test_minimax_llm_chat_completion():
     assert response.tool_calls == []
 
     request = fake_session.requests[0]
-    assert request["json"]["model"] == "MiniMax-M2.7"
+    assert request["json"]["model"] == "MiniMax-M3"
     assert request["url"] == "https://api.minimax.io/v1/chat/completions"
     assert request["headers"]["Authorization"] == "Bearer test-minimax-key"
 


### PR DESCRIPTION
## Summary

This PR upgrades the `minimax_llm` pipeline adapter to default to **`MiniMax-M3`**, the latest MiniMax flagship model, while retaining `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` for backwards compatibility. The older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` entries are removed from the supported model lists.

## What changed

| Layer | File(s) | Change |
|---|---|---|
| Engine | `src/config.py` | `MiniMaxLLMProviderConfig.chat_model` default → `MiniMax-M3`; docstring refreshed |
| Engine | `src/pipelines/minimax.py` | Module docstring model list refreshed |
| Config | `config/ai-agent.yaml` | `providers.minimax_llm.chat_model` default → `MiniMax-M3`; alternatives comment updated |
| Tests | `tests/test_pipeline_minimax_adapter.py` | `_build_app_config` fixture and primary assertion bumped to `MiniMax-M3`; existing high-speed test still covers `MiniMax-M2.7-highspeed` |
| Docs | `docs/Provider-MiniMax-Setup.md`, `docs/README.md`, `README.md`, `.env.example` | User-facing model tables and defaults refreshed |
| Admin UI | `admin_ui/frontend/src/components/config/providers/GenericProviderForm.tsx`, `admin_ui/frontend/src/config/modularProviderSubtypes.ts` | Model-picker suggestions for the `minimax` provider type refreshed |

## What is intentionally **not** changed

- `chat_base_url` (`https://api.minimax.io/v1`) — unchanged
- Temperature clamping behaviour — unchanged
- TTS / Azure / OpenAI / Telnyx providers — untouched
- Historical entries in `CHANGELOG.md`, `docs/MIGRATION.md`, `CONTRIBUTORS.md` — preserved as-is (they describe past v6.3.2 release context)

## Test plan

- [x] `pytest tests/test_pipeline_minimax_adapter.py -v` — all 15 tests pass locally (including `test_minimax_llm_chat_completion` asserting `MiniMax-M3` as default and `test_minimax_llm_highspeed_model` for the retained `M2.7-highspeed` variant)
- [x] `MiniMaxLLMProviderConfig()` instantiated with no args yields `chat_model='MiniMax-M3'`
- [x] `config/ai-agent.yaml` parses cleanly via `yaml.safe_load` and `providers.minimax_llm.chat_model == 'MiniMax-M3'`
- [ ] Maintainer to verify CI green and Admin UI dropdowns render the new suggestion list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MiniMax provider setup and configuration documentation to reflect M3 as the new default model.

* **Chores**
  * Updated MiniMax LLM provider defaults to use MiniMax-M3 as the primary model.
  * Removed support for deprecated MiniMax-M2.5 model variants; MiniMax-M2.7 and M2.7-highspeed remain available as alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->