### PR TITLE
chore: hard-ignore CLAUDE.md/CLAUDE.local.md on all branches

### DIFF
--- a/.github/workflows/block-dev-artifacts.yml
+++ b/.github/workflows/block-dev-artifacts.yml
@@ -30,6 +30,7 @@ jobs:
             "AVA\.mdc$"
             "Agents\.md$"
             "CLAUDE\.md$"
+            "CLAUDE\.local\.md$"
             "Gemini\.md$"
             "examples/"
             "docs/contributing/OPERATOR_CONTRIBUTOR_GUIDE\.md$"

--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,11 @@ venv/
 # (Allow these specific artifacts to track on `develop` when needed.)
 !Agents.md
 !Gemini.md
-!CLAUDE.md
+# CLAUDE.md / CLAUDE.local.md — hard-ignored on ALL branches (2026-06-12).
+# Personal AI-assistant context stays local-only and must never reach GitHub,
+# including develop. (Previously `!CLAUDE.md` allowed develop-branch tracking.)
+CLAUDE.md
+CLAUDE.local.md
 
 # Local diagnostics bundles
 server_diagnostics/


### PR DESCRIPTION
## Summary
- Replace the `!CLAUDE.md` gitignore negation with explicit ignores for `CLAUDE.md` and `CLAUDE.local.md` — personal AI-assistant context files stay local-only on every branch, not just staging/main.
- Extend the `block-dev-artifacts` CI gate to also block `CLAUDE.local.md` as defense-in-depth.

## Why
The previous design allowed CLAUDE.md to track on `develop` (public branch) with only the staging/main CI gate as protection. These files are per-maintainer local context and should never be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to block accidental commits of local configuration files to main and staging branches.
  * Updated repository ignore rules to ensure local-only configuration files remain local across all branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->