### PR TITLE
docs(security): reconcile SECURITY.md with shipped compose health-bind reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **SECURITY.md / docker-compose health-bind reconciliation**: The SECURITY.md network table incorrectly implied the shipped deployment binds the ai-engine health server (port 15000) to localhost. In practice, `docker-compose.yml` sets `HEALTH_BIND_HOST=0.0.0.0` so the Admin UI container can reach `/sessions/stats` and `/reload`. Updated the table's Default Bind cell to reflect the code default vs. the shipped compose value, and added a blockquote note explaining the security implication and how to lock it down. Updated the docker-compose comment to cross-reference SECURITY.md.
+
 ## [6.5.4] - 2026-05-25
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,11 +81,18 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 **Default Configuration** (Secure - all services bind to localhost):
 | Service | Default Bind | Port | Remote Opt-in |
 |---------|-------------|------|---------------|
-| ai-engine Health | `127.0.0.1` | 15000 | `HEALTH_BIND_HOST=0.0.0.0` |
+| ai-engine Health | `127.0.0.1` (code) / `0.0.0.0` (shipped compose — see note) | 15000 | `HEALTH_BIND_HOST=0.0.0.0` |
 | Admin UI | `127.0.0.1` | 3003 | `UVICORN_HOST=0.0.0.0` |
 | Local AI Server | `127.0.0.1` | 8765 | `LOCAL_WS_HOST=0.0.0.0` |
 | RTP Server | `127.0.0.1` | 18080 | `EXTERNAL_MEDIA_RTP_HOST=0.0.0.0` |
 | AudioSocket | `127.0.0.1` | 8090 | `AUDIOSOCKET_HOST=0.0.0.0` |
+
+> **Shipped docker-compose note:** `docker-compose.yml` sets `HEALTH_BIND_HOST=0.0.0.0`
+> for the ai-engine health server (port 15000) so the Admin UI container can reach
+> `/sessions/stats` and `/reload`. On host-network deployments this exposes port 15000
+> on all host interfaces. The health server carries no secrets but does expose
+> operational state and a `/reload` trigger — firewall port 15000 from untrusted
+> networks, or override `HEALTH_BIND_HOST=127.0.0.1` if you do not use the Admin UI.
 
 **If Remote Access Required**:
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,7 +92,10 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 > `/sessions/stats` and `/reload`. On host-network deployments this exposes port 15000
 > on all host interfaces. The health server carries no secrets but does expose
 > operational state and a `/reload` trigger — firewall port 15000 from untrusted
-> networks, or override `HEALTH_BIND_HOST=127.0.0.1` if you do not use the Admin UI.
+> networks, or, if you do not use the Admin UI, set `HEALTH_BIND_HOST=127.0.0.1`
+> in the `ai_engine` service's `environment:` block in `docker-compose.yml`.
+> (Setting it only in `.env` has no effect: the compose `environment:` value takes
+> precedence over `env_file` — see the Docker Compose env-var precedence docs.)
 
 **If Remote Access Required**:
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - PYTHONUNBUFFERED=1
       # Note: TZ is loaded from .env via env_file directive above
       # Do NOT add TZ here with ${TZ:-default} - it prevents UI env changes from taking effect
-      # Enable health endpoint access from other containers (admin-ui needs /sessions/stats)
+      # Health endpoint binds 0.0.0.0 so admin_ui can reach /sessions/stats and /reload.
+      # Security implications + lockdown instructions: SECURITY.md "Shipped docker-compose note".
       - HEALTH_BIND_HOST=0.0.0.0
       # Note: ASTERISK_HOST is loaded from .env via env_file directive above
       # Do NOT add ASTERISK_HOST here - it prevents UI env changes from taking effect


### PR DESCRIPTION
## Summary
The SECURITY.md network table implied the shipped `docker-compose.yml` binds the ai-engine health server to localhost, but the shipped compose sets `HEALTH_BIND_HOST=0.0.0.0` so the Admin UI container can reach `/sessions/stats` and `/reload`. This documents that reality instead of silently contradicting it.

## Changes
- **SECURITY.md**: the ai-engine Health row now reads `127.0.0.1 (code) / 0.0.0.0 (shipped compose)` and a note explains the exposure (port 15000 on all interfaces in host-network deployments) and how to lock it down (firewall the port, or override `HEALTH_BIND_HOST=127.0.0.1` if not using the Admin UI).
- **docker-compose.yml**: the comment by `HEALTH_BIND_HOST` cross-links the SECURITY.md note.

## Testing
Docs-only; markdown rendering verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified discrepancies between configuration files regarding health endpoint binding defaults
  * Added security guidance on firewall rules and configuration override options for different deployment scenarios
  * Updated cross-references between security and deployment documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->