### PR TITLE
docs(readme): professionalize contributing section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Contributing section tone**: replaced the overpromising "AVA writes the code for you" opener in `README.md` with an honest description of non-code contribution paths. Softened matching "AVA writes the …" phrasings in `docs/ROADMAP.md` to "AVA helps you write the …" register.
+
 ## [6.5.4] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -668,7 +668,9 @@ The `preflight.sh` script handles initial setup:
 
 ## 🤝 Contributing
 
-**You don't need to know how to code.** Our AI assistant AVA writes the code for you — just describe what you want to build.
+**You don't need to be a developer to contribute.** File feature ideas, report bugs
+with logs attached, improve documentation, or share your dialplan recipes — these are
+as valuable as code. If you do want to write code, see the Contributing Guide below.
 
 <!-- TODO: Add YouTube video link once recorded -->
 <!-- **Watch the 5-minute walkthrough:** [YouTube Video](https://youtube.com/...) -->

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -120,15 +120,15 @@ Great for first-time contributors. **AVA helps you with all of these** — just 
 | Report and document edge cases in call flows | Testing + writing | You make real calls every day |
 | Translate a setup guide to your language | Any language | Help non-English speakers |
 
-#### AI-Assisted Code Tasks (AVA Writes the Code)
+#### AI-Assisted Code Tasks (AVA Helps You Write the Code)
 
 | Task | Contribution Area | Why YOU Can Do This |
 |------|-------------------|---------------------|
-| Add a new STT/TTS/LLM pipeline adapter | [open issues: pipeline adapter](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues?q=is%3Aopen+is%3Aissue+pipeline+adapter) — see also `docs/contributing/pipeline-development.md` | You know which providers work best — AVA writes the adapter |
+| Add a new STT/TTS/LLM pipeline adapter | [open issues: pipeline adapter](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues?q=is%3Aopen+is%3Aissue+pipeline+adapter) — see also `docs/contributing/pipeline-development.md` | You know which providers work best — AVA helps you write the adapter |
 | Add a pre-call CRM lookup hook | [open issues: pre-call hooks](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues?q=is%3Aopen+is%3Aissue+pre-call) — see also `docs/contributing/tool-development.md` | You have a CRM — AVA integrates it |
 | Add a post-call webhook (Slack, Discord, n8n) | [open issues: post-call hooks](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues?q=is%3Aopen+is%3Aissue+post-call) — see also `docs/TOOL_CALLING_GUIDE.md` (HTTP tools) | You use these tools daily — AVA connects them |
 | Add an in-call appointment checker | [open issues: in-call hooks](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues?q=is%3Aopen+is%3Aissue+in-call) — see also `docs/Google-calendar-tool.md` | You book appointments by phone — AVA builds it |
-| Test coverage for `src/tools/telephony/` | Python, pytest | You understand voicemail — AVA writes the tests |
+| Test coverage for `src/tools/telephony/` | Python, pytest | You understand voicemail — AVA helps you write the tests |
 | Improve error messages in `agent doctor` | Go CLI | You've seen the confusing errors — AVA fixes them |
 | Admin UI accessibility audit (Lighthouse/axe) | React, CSS | Run the audit, AVA fixes what it finds |
 | JSON Schema for `ai-agent.yaml` | JSON Schema, YAML | Define what's valid in the config you use daily |


### PR DESCRIPTION
## Summary
Professionalizes the Contributing section. Replaces the "you don't need to know how to code — AVA writes the code for you" opener with an honest, welcoming framing: feature ideas, bug reports with logs, docs, and dialplan recipes are valued, with a clear path for those who do want to write code. Softens the same overpromise in `docs/ROADMAP.md`.

## Changes
- **README.md**: new Contributing opener.
- **docs/ROADMAP.md**: "AVA writes the code" phrasings softened to an assistive register (minimal wording edits, no restructuring).

## Testing
Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to clarify that coding experience isn’t required and to invite broader non-code participation.
  * Expanded accepted contribution types to include feature ideas, bug reports with logs, documentation improvements, and recipe sharing.
  * Refreshed tone and phrasing in contributing/roadmap materials for clearer, more consistent AI-assisted messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->