### PR TITLE
chore(release): prep 7.0.0 — CHANGELOG, Upgrade Notes, version touchpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2026-06-14
+
+> ### ⚠️ Upgrade Notes (read before upgrading from 6.x)
+> 7.0.0 introduces the **Agents** system and hardens security. A few changes need your attention:
+>
+> - **Default login removed.** On first start after upgrade, a one-time admin password is printed to the `admin_ui` container logs (`docker compose -p asterisk-ai-voice-agent logs admin_ui | grep PASSWORD`) and you'll be required to change it at first login. `admin`/`admin` no longer works — and on upgraded installs that still had the old default, it is automatically rotated to a one-time password on first start.
+> - **Config export no longer includes `.env` by default.** Use `GET /api/config/export?include_secrets=true` if you need the old behavior.
+> - **Contexts are now "Agents."** Your existing contexts are imported automatically into a new local database (`./data/operator/agents.db`) on first start — nothing to do, and your existing dialplans keep working (`AI_CONTEXT` is still supported; `AI_AGENT` is the new preferred variable). The **Contexts** page is now read-only; manage agents in the new **Agents** tab. Editing context entries directly in `ai-agent.yaml` no longer takes effect at runtime (you'll be warned in the logs and UI); use the Agents tab or the Migration Status page to re-import.
+> - **Rollback:** if anything goes wrong, stop the stack, delete `./data/operator/agents.db*`, and restart — the engine falls back to reading your YAML contexts as before. See [`docs/OPERATOR_MIGRATION.md`](docs/OPERATOR_MIGRATION.md).
+
 ### Fixed
 
 - **Dashboard reads canonical `CALL_HISTORY_DB_PATH` env var** (`admin_ui/backend/api/agents.py`): the module constant was reading the wrong env var name (`CALL_HISTORY_DB` instead of `CALL_HISTORY_DB_PATH`), causing all aggregate endpoints to silently read the wrong DB path on deployments that set a custom location. Aligned to the canonical name used by the engine's `CallHistoryStore`.

--- a/cli/cmd/agent/main.go
+++ b/cli/cmd/agent/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	version   = "6.5.0-dev" // Overridden at build time via -ldflags
+	version   = "7.0.0-dev" // Overridden at build time via -ldflags
 	buildTime = "unknown" // Overridden at build time via -ldflags
 	verbose   bool
 	noColor   bool

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,29 +1,42 @@
-# Asterisk AI Voice Agent - Installation Guide (v6.5.4)
+# Asterisk AI Voice Agent - Installation Guide (v7.0.0)
 
-This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v6.5.4 on your server.
+This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v7.0.0 on your server.
 
 ## Three Setup Paths
 
 Choose the path that best fits your experience level:
 
-## Upgrade to v6.5.4 (Existing Checkout)
+## Upgrade to v7.0.0 (Existing Checkout)
 
 This section is for operators upgrading an existing repo checkout (not a fresh install).
+
+> ### ⚠️ v7.0.0 is a major release with breaking changes — read first
+> Before upgrading from 6.x, review the **Upgrade Notes** at the top of the
+> [v7.0.0 CHANGELOG entry](../CHANGELOG.md) and the
+> [Agents migration guide](OPERATOR_MIGRATION.md). In short:
+> - **Default `admin`/`admin` login is removed** — a one-time admin password is printed to the
+>   `admin_ui` logs on first start and must be changed at first login.
+> - **`/api/config/export` no longer bundles `.env`** by default (pass `include_secrets=true`).
+> - **Your contexts auto-migrate into `agents.db`** on first start; the **Contexts** page becomes
+>   read-only (manage agents in the new **Agents** tab). Existing dialplans keep working
+>   (`AI_CONTEXT` still supported; `AI_AGENT` is preferred). Rollback = delete
+>   `./data/operator/agents.db*` and restart.
 
 ### 0) Backup (recommended)
 
 - Backup `.env`
 - Backup `config/ai-agent.yaml`
 - Backup `config/ai-agent.local.yaml` (if it exists — contains your operator overrides)
-- If you rely on Call History persistence, backup `./data` as well
+- If you rely on Call History persistence, backup `./data` as well (this now also holds
+  `./data/operator/agents.db`, your migrated agent configuration)
 
 ### 1) Pull the new release
 
-To upgrade to the tagged `v6.5.4` release (once the tag is published):
+To upgrade to the tagged `v7.0.0` release (once the tag is published):
 
 ```bash
 git fetch --tags
-git checkout v6.5.4
+git checkout v7.0.0
 ```
 
 If the tag is not published yet, track `main` temporarily:

--- a/docs/baselines/golden/v7.0.0-validation-matrix.md
+++ b/docs/baselines/golden/v7.0.0-validation-matrix.md
@@ -1,0 +1,39 @@
+# v7.0.0 Golden Baseline Validation Matrix
+
+Use this matrix before tagging `v7.0.0`. Each claimed provider × transport combination
+should have at least one real passing call with evidence (call ID + log/recording).
+
+## Status Legend
+
+- `PASS`: validated with call evidence
+- `PENDING`: not yet validated
+- `N/A`: intentionally not claimed for this release
+
+## Provider x Transport Matrix
+
+| Provider | Transport | Status | Call ID | Evidence |
+|---|---|---|---|---|
+| OpenAI Realtime | AudioSocket | PENDING | | |
+| OpenAI Realtime | ExternalMedia RTP | PENDING | | |
+| Google Live | AudioSocket | PENDING | | |
+| Deepgram Voice Agent | AudioSocket | PENDING | | |
+| Deepgram Voice Agent | ExternalMedia RTP | PENDING | | |
+| Local Hybrid Pipeline | AudioSocket | PENDING | | |
+
+## 7.0.0-specific checks (Agents system)
+
+These exercise the new Agents foundation introduced in 7.0.0. At least one call each
+should be validated before tag.
+
+| Check | Status | Call ID | Notes |
+|---|---|---|---|
+| Inbound call via `Set(AI_AGENT=<slug>)` routes + records `context_name` | PENDING | | New preferred channel variable |
+| Inbound call via legacy `Set(AI_CONTEXT=<slug>)` routes identically | PENDING | | Backward compatibility |
+| Migration: existing YAML contexts import into `agents.db` on first start | PENDING | | One-time, idempotent |
+| Rollback: delete `agents.db*` → engine serves calls from YAML | PENDING | | See OPERATOR_MIGRATION.md |
+| First-run admin password generated + forced rotation | PENDING | | Fresh + upgraded install |
+
+> Note: integration testing on the primary FreePBX/Asterisk box (2026-06-13) confirmed
+> `AI_AGENT`/`AI_CONTEXT` parity, the agents.db migration, per-agent stats, drift→reconcile,
+> default-promotion, support-bundle redaction, and `routing_method` capture on real calls.
+> Fill the provider×transport rows above with golden-baseline call evidence before tagging.


### PR DESCRIPTION
Release-prep for v7.0.0 (docs + version only, no code logic):
- CHANGELOG `[Unreleased]` → `## [7.0.0] - 2026-06-14` with the **Upgrade Notes** block (breaking changes: first-run password, .env export, Contexts read-only, agents.db migration).
- `cli/cmd/agent/main.go` dev version `6.5.0-dev` → `7.0.0-dev`.
- `docs/INSTALLATION.md` upgrade section → 7.0.0 with a breaking-changes callout.
- `docs/baselines/golden/v7.0.0-validation-matrix.md` scaffold.

Go CLI verified: `go build/vet/test ./...` clean (golang:1.23). Engine 1003 + admin_ui 62 green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v7.0.0 Release Documentation

* **Documentation**
  * Published v7.0.0 release notes documenting breaking changes to authentication, config export, and system migration
  * Updated upgrade guide with migration procedures and rollback instructions
  * Added validation baseline documentation for v7.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->