### PR TITLE
  Expose v7 Agents API in OpenAPI and add call-record agent aliases

### DIFF
--- a/admin_ui/backend/agents_store.py
+++ b/admin_ui/backend/agents_store.py
@@ -70,7 +70,7 @@ class AgentsStore:
         """Close the underlying sqlite connection. Safe to call more than once."""
         try:
             self.conn.close()
-        except Exception:
+        except sqlite3.Error:
             pass
 
     def __enter__(self):

--- a/admin_ui/backend/agents_store.py
+++ b/admin_ui/backend/agents_store.py
@@ -66,6 +66,20 @@ class AgentsStore:
         try: os.chmod(db_path, 0o600)
         except OSError: pass
 
+    def close(self):
+        """Close the underlying sqlite connection. Safe to call more than once."""
+        try:
+            self.conn.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
     # -- reads -------------------------------------------------------------
     def get_by_slug(self, slug):  # -> dict | None
         r = self.conn.execute("SELECT * FROM agents WHERE slug=?", (slug,)).fetchone()

--- a/admin_ui/backend/api/agents.py
+++ b/admin_ui/backend/api/agents.py
@@ -53,7 +53,65 @@ class AgentPatch(BaseModel):
     notes: str | None = None
     is_active: bool | None = None
 
-@router.get("/agents")
+class AgentOut(BaseModel):
+    """Full agent row as stored in agents.db. Declares every column so attaching this
+    as a response_model never drops a field (wire-compatible with the raw rows we
+    returned before). The is_* flags stay int 0/1 — existing consumers depend on that
+    shape, so they are NOT coerced to bool."""
+    id: str
+    slug: str
+    display_name: str
+    extension: str | None = None
+    role_label: str | None = None
+    provider: str
+    voice: str | None = None
+    greeting: str | None = None
+    prompt: str
+    tools_json: str | None = None
+    mcp_json: str | None = None
+    audio_profile: str | None = None
+    extra_json: str | None = None
+    is_operator_managed: int
+    is_active: int
+    is_default: int
+    source_file: str | None = None
+    created_at: str
+    updated_at: str
+    notes: str | None = None
+
+class AgentSummaryResponse(BaseModel):
+    active_agents: int
+    active_calls: int
+    total_routed: int
+    total_transfers: int
+
+class AgentStatsBatchItem(BaseModel):
+    slug: str
+    calls: int
+    transfers: int
+    avg_duration_seconds: float
+    last_call: str | None = None
+
+class DistributionItem(BaseModel):
+    context_name: str
+    count: int
+
+class RoutingMethodsResponse(BaseModel):
+    ai_agent: int
+    ai_context: int
+    default: int
+    unknown: int
+
+class AgentStatsResponse(BaseModel):
+    calls_30d: int
+    last_call: str | None = None
+
+class DialplanResponse(BaseModel):
+    dialplan: str
+    extension: str
+    stasis_app: str
+
+@router.get("/agents", response_model=list[AgentOut])
 def list_agents():
     return _store().list_all()
 
@@ -62,7 +120,7 @@ def templates():
     with open(TEMPLATES_PATH) as f:
         return json.load(f)
 
-@router.get("/agents/summary")
+@router.get("/agents/summary", response_model=AgentSummaryResponse)
 async def summary():
     """KPI summary: active agents, active calls (from engine), total routed, total transfers."""
     store = _store()
@@ -107,7 +165,7 @@ async def summary():
         "total_transfers": total_transfers,
     }
 
-@router.get("/agents/stats-batch")
+@router.get("/agents/stats-batch", response_model=list[AgentStatsBatchItem])
 def stats_batch():
     """Per-agent call stats for all agents in the store."""
     store = _store()
@@ -150,7 +208,7 @@ def stats_batch():
             })
     return result
 
-@router.get("/agents/distribution")
+@router.get("/agents/distribution", response_model=list[DistributionItem])
 def distribution():
     """Call distribution by context_name, ordered by count desc. Excludes NULL/empty names."""
     if not os.path.exists(CALL_HISTORY_DB):
@@ -166,7 +224,7 @@ def distribution():
         return []
     return [{"context_name": ctx, "count": cnt} for ctx, cnt in rows]
 
-@router.get("/agents/routing-methods")
+@router.get("/agents/routing-methods", response_model=RoutingMethodsResponse)
 def routing_methods():
     """Routing method breakdown: ai_agent, ai_context, default, unknown (NULL/other)."""
     result = {"ai_agent": 0, "ai_context": 0, "default": 0, "unknown": 0}
@@ -206,7 +264,7 @@ def _engine_ok(provider, extra_json) -> bool:
         extra = {}
     return bool(isinstance(extra, dict) and str(extra.get("pipeline") or "").strip())
 
-@router.post("/agents", status_code=201)
+@router.post("/agents", status_code=201, response_model=AgentOut)
 def create_agent(body: AgentIn, request: Request):
     data = body.model_dump()
     if not _engine_ok(data.get("provider"), data.get("extra_json")):
@@ -217,7 +275,7 @@ def create_agent(body: AgentIn, request: Request):
     except ValueError as e:
         raise HTTPException(422, str(e)) from e
 
-@router.patch("/agents/{slug}")
+@router.patch("/agents/{slug}", response_model=AgentOut)
 def patch_agent(slug: str, body: AgentPatch):
     store = _store()
     existing = store.get_by_slug(slug)
@@ -241,7 +299,7 @@ def patch_agent(slug: str, body: AgentPatch):
             store.update(promoted, notes=None)  # no-op write keeps updated_at honest
     return store.update(slug, **fields) if fields else store.get_by_slug(slug)
 
-@router.post("/agents/{slug}/default")
+@router.post("/agents/{slug}/default", response_model=AgentOut)
 def set_default(slug: str):
     store = _store()
     if not store.get_by_slug(slug):
@@ -261,7 +319,17 @@ def delete_agent(slug: str, request: Request):
     else:
         store.delete(slug)
 
-@router.get("/agents/{slug}/stats")
+# NOTE: declared AFTER all literal /agents/... GET routes (templates, summary,
+# stats-batch, distribution, routing-methods) so the {slug} path param does not
+# shadow them. FastAPI matches in declaration order.
+@router.get("/agents/{slug}", response_model=AgentOut)
+def get_agent(slug: str):
+    row = _store().get_by_slug(slug)
+    if not row:
+        raise HTTPException(404, "agent not found")
+    return row
+
+@router.get("/agents/{slug}/stats", response_model=AgentStatsResponse)
 def stats(slug: str):
     if not _store().get_by_slug(slug):
         raise HTTPException(404)
@@ -274,7 +342,7 @@ def stats(slug: str):
                          (slug,)).fetchone()[0]
     return {"calls_30d": calls, "last_call": last}
 
-@router.get("/agents/{slug}/dialplan")
+@router.get("/agents/{slug}/dialplan", response_model=DialplanResponse)
 def dialplan(slug: str):
     row = _store().get_by_slug(slug)
     if not row:

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -248,11 +248,12 @@ def _agent_name_map() -> Dict[str, str]:
     avoid N+1 lookups."""
     try:
         from agents_store import AgentsStore
-        return {
-            a["slug"]: a.get("display_name")
-            for a in AgentsStore().list_all()
-            if a.get("slug")
-        }
+        with AgentsStore() as store:  # close the sqlite connection promptly
+            return {
+                a["slug"]: a.get("display_name")
+                for a in store.list_all()
+                if a.get("slug")
+            }
     except Exception:
         return {}
 

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -95,10 +95,11 @@ class CallRecordSummaryResponse(BaseModel):
     context_name: Optional[str] = None
     routing_method: Optional[str] = None  # 'ai_agent' | 'ai_context' | 'default' | None
     # Additive v7 aliases (do not replace context_name/routing_method):
-    # both are populated only when the call was explicitly routed via AI_AGENT
-    # (routing_method == 'ai_agent'); otherwise both are null. agent_name is a
-    # best-effort display-name lookup, null if agents.db is unavailable or the
-    # slug has no matching agent.
+    # agent_slug mirrors the resolved agent (context_name) whenever the call was
+    # routed to one -- ai_agent, ai_context or default routing -- and is null for
+    # unknown/None routing. routing_method still tells you *how* it was selected.
+    # agent_name is a best-effort display-name lookup, null if agents.db is
+    # unavailable or the slug has no matching agent.
     agent_slug: Optional[str] = None
     agent_name: Optional[str] = None
     outcome: str = "completed"
@@ -261,16 +262,19 @@ def _agent_name_map() -> Dict[str, str]:
 def _resolve_agent(record, agent_names: Optional[Dict[str, str]]):
     """Compute the additive (agent_slug, agent_name) aliases for a record.
 
-    Both are populated ONLY when the call was explicitly routed via AI_AGENT
-    (routing_method == 'ai_agent'); for ai_context/default/unknown they are both None
-    so integrations don't infer explicit agent routing from context/default fallbacks.
-    agent_name is a best-effort display-name lookup keyed on context_name (the resolved
-    agent slug) and is None when the agents DB is unavailable or has no matching slug."""
+    These reflect the resolved agent whenever the call was routed to one, so
+    integrations can consume the selected agent uniformly: agent_slug mirrors
+    context_name (the resolved agent slug) for ai_agent, ai_context and default
+    routing. routing_method remains the field that explains *how* the agent was
+    selected. For unknown/None routing they stay None.
+
+    agent_name is a best-effort display-name lookup keyed on the slug and is None
+    when the agents DB is unavailable or has no matching slug."""
     routing_method = getattr(record, "routing_method", None)
     context_name = record.context_name
-    if routing_method != "ai_agent":
+    if routing_method not in ("ai_agent", "ai_context", "default") or not context_name:
         return None, None
-    agent_name = (agent_names or {}).get(context_name) if context_name else None
+    agent_name = (agent_names or {}).get(context_name)
     return context_name, agent_name
 
 

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -94,6 +94,13 @@ class CallRecordSummaryResponse(BaseModel):
     pipeline_name: Optional[str] = None
     context_name: Optional[str] = None
     routing_method: Optional[str] = None  # 'ai_agent' | 'ai_context' | 'default' | None
+    # Additive v7 aliases (do not replace context_name/routing_method):
+    # both are populated only when the call was explicitly routed via AI_AGENT
+    # (routing_method == 'ai_agent'); otherwise both are null. agent_name is a
+    # best-effort display-name lookup, null if agents.db is unavailable or the
+    # slug has no matching agent.
+    agent_slug: Optional[str] = None
+    agent_name: Optional[str] = None
     outcome: str = "completed"
     error_message: Optional[str] = None
     avg_turn_latency_ms: float = 0.0
@@ -116,6 +123,9 @@ class CallRecordResponse(BaseModel):
     pipeline_components: dict = {}
     context_name: Optional[str] = None
     routing_method: Optional[str] = None  # 'ai_agent' | 'ai_context' | 'default' | None
+    # Additive v7 aliases (see CallRecordSummaryResponse for semantics).
+    agent_slug: Optional[str] = None
+    agent_name: Optional[str] = None
     conversation_history: list = []
     outcome: str = "completed"
     transfer_destination: Optional[str] = None
@@ -229,8 +239,43 @@ def _normalize_phase_tool_calls(entries: list, phase: str) -> list:
     return normalized
 
 
-def _record_to_response(record) -> CallRecordResponse:
+def _agent_name_map() -> Dict[str, str]:
+    """Best-effort {slug: display_name} from the operator agents.db.
+
+    Never raises: a missing, locked, or unreadable agents.db (e.g. headless/YAML-only
+    installs) just yields an empty map, so call-history responses still serve with
+    agent_name=None. Build this once per request and pass it into the converters to
+    avoid N+1 lookups."""
+    try:
+        from agents_store import AgentsStore
+        return {
+            a["slug"]: a.get("display_name")
+            for a in AgentsStore().list_all()
+            if a.get("slug")
+        }
+    except Exception:
+        return {}
+
+
+def _resolve_agent(record, agent_names: Optional[Dict[str, str]]):
+    """Compute the additive (agent_slug, agent_name) aliases for a record.
+
+    Both are populated ONLY when the call was explicitly routed via AI_AGENT
+    (routing_method == 'ai_agent'); for ai_context/default/unknown they are both None
+    so integrations don't infer explicit agent routing from context/default fallbacks.
+    agent_name is a best-effort display-name lookup keyed on context_name (the resolved
+    agent slug) and is None when the agents DB is unavailable or has no matching slug."""
+    routing_method = getattr(record, "routing_method", None)
+    context_name = record.context_name
+    if routing_method != "ai_agent":
+        return None, None
+    agent_name = (agent_names or {}).get(context_name) if context_name else None
+    return context_name, agent_name
+
+
+def _record_to_response(record, agent_names: Optional[Dict[str, str]] = None) -> CallRecordResponse:
     """Convert a CallRecord to a response model."""
+    agent_slug, agent_name = _resolve_agent(record, agent_names)
     return CallRecordResponse(
         id=record.id,
         call_id=record.call_id,
@@ -244,6 +289,8 @@ def _record_to_response(record) -> CallRecordResponse:
         pipeline_components=record.pipeline_components or {},
         context_name=record.context_name,
         routing_method=getattr(record, "routing_method", None),
+        agent_slug=agent_slug,
+        agent_name=agent_name,
         conversation_history=record.conversation_history or [],
         outcome=record.outcome,
         transfer_destination=record.transfer_destination,
@@ -265,8 +312,9 @@ def _record_to_response(record) -> CallRecordResponse:
     )
 
 
-def _record_to_summary_response(record) -> CallRecordSummaryResponse:
+def _record_to_summary_response(record, agent_names: Optional[Dict[str, str]] = None) -> CallRecordSummaryResponse:
     """Convert a CallRecord to a summary response model."""
+    agent_slug, agent_name = _resolve_agent(record, agent_names)
     return CallRecordSummaryResponse(
         id=record.id,
         call_id=record.call_id,
@@ -279,6 +327,8 @@ def _record_to_summary_response(record) -> CallRecordSummaryResponse:
         pipeline_name=record.pipeline_name,
         context_name=record.context_name,
         routing_method=getattr(record, "routing_method", None),
+        agent_slug=agent_slug,
+        agent_name=agent_name,
         outcome=record.outcome,
         error_message=record.error_message,
         avg_turn_latency_ms=record.avg_turn_latency_ms,
@@ -415,9 +465,10 @@ async def list_calls(
     )
     
     total_pages = (total + page_size - 1) // page_size if total > 0 else 1
-    
+
+    agent_names = _agent_name_map()  # one best-effort lookup for the whole page
     return CallListResponse(
-        calls=[_record_to_summary_response(r) for r in records],
+        calls=[_record_to_summary_response(r, agent_names) for r in records],
         total=total,
         page=page,
         page_size=page_size,
@@ -501,7 +552,7 @@ async def get_call(record_id: str):
     if not record:
         raise HTTPException(status_code=404, detail="Call record not found")
     
-    return _record_to_response(record)
+    return _record_to_response(record, _agent_name_map())
 
 
 @router.get("/calls/{record_id}/transcript")
@@ -920,10 +971,11 @@ async def export_calls_json(
     )
     
     # Convert to JSON-serializable format
+    agent_names = _agent_name_map()
     data = {
         "exported_at": datetime.now().isoformat(),
         "total_records": len(records),
-        "records": [_record_to_response(r).model_dump() for r in records]
+        "records": [_record_to_response(r, agent_names).model_dump() for r in records]
     }
     
     json_content = json.dumps(data, indent=2)

--- a/admin_ui/backend/main.py
+++ b/admin_ui/backend/main.py
@@ -154,7 +154,7 @@ Most endpoints require JWT authentication. Obtain a token via `POST /api/auth/lo
 |---------|-----------|
 | **AI Engine Health Server** (port 15000) | `/health`, `/metrics`, `/live`, `/ready`, `/reload` |
 """,
-    version="6.2.0",
+    version="7.0.0",
     docs_url="/docs" if _enable_api_docs else None,
     redoc_url="/redoc" if _enable_api_docs else None,
     openapi_url="/openapi.json" if _enable_api_docs else None,
@@ -164,6 +164,7 @@ Most endpoints require JWT authentication. Obtain a token via `POST /api/auth/lo
         {"name": "system", "description": "System operations, containers, updates, health"},
         {"name": "wizard", "description": "Setup wizard and local AI model downloads"},
         {"name": "local-ai", "description": "Local AI server management"},
+        {"name": "agents", "description": "Agents (v7) — CRUD, per-agent stats, dialplan snippets, templates, and YAML→DB migration status"},
         {"name": "calls", "description": "Call history and analytics"},
         {"name": "outbound", "description": "Outbound campaigns and lead management"},
         {"name": "tools", "description": "Tool catalog and HTTP tool testing"},

--- a/admin_ui/backend/tests/test_agents_api.py
+++ b/admin_ui/backend/tests/test_agents_api.py
@@ -342,3 +342,49 @@ def test_reconcile_adds_new_yaml_context(client, tmp_path, monkeypatch):
     assert r.status_code == 200
     assert any(c == ["added", "newctx"] or tuple(c) == ("added", "newctx") for c in r.json()["changed"])
     assert any(a["slug"] == "newctx" and a["is_operator_managed"] == 0 for a in client.get("/api/agents").json())
+
+
+# --- v7 Agents OpenAPI follow-up -------------------------------------------------
+
+def test_get_agent_by_slug(client):
+    client.post("/api/agents", json={"display_name": "Sales", "provider": "x",
+                                     "prompt": "p", "extension": "801"})
+    r = client.get("/api/agents/sales")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["slug"] == "sales" and body["display_name"] == "Sales"
+    # wire-compat: flags stay int 0/1, not bool
+    assert body["is_active"] in (0, 1) and isinstance(body["is_active"], int)
+
+def test_get_agent_by_slug_404(client):
+    assert client.get("/api/agents/does-not-exist").status_code == 404
+
+def test_slug_route_does_not_shadow_literal_routes(client):
+    # /agents/templates and friends must still resolve as literals, not as {slug}.
+    assert client.get("/api/agents/templates").status_code == 200
+    assert isinstance(client.get("/api/agents/templates").json(), list)
+    assert "ai_agent" in client.get("/api/agents/routing-methods").json()
+
+def test_openapi_surfaces_agents_schema(client):
+    """response_model wiring must produce typed schemas (not empty) in the spec."""
+    spec = client.get("/openapi.json").json()
+    assert "/api/agents/{slug}" in spec["paths"]
+    assert "AgentOut" in spec["components"]["schemas"]
+    agent_out = spec["components"]["schemas"]["AgentOut"]
+    # every stored column is declared so no field is silently dropped
+    for col in ("id", "slug", "display_name", "provider", "prompt",
+                "is_active", "is_default", "is_operator_managed",
+                "created_at", "updated_at"):
+        assert col in agent_out["properties"], col
+    # list endpoint returns an array of AgentOut, not a bare object
+    list_schema = spec["paths"]["/api/agents"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    assert list_schema.get("type") == "array"
+
+def test_main_app_openapi_version_and_tag():
+    """version literal + agents tag description live in main.py. Skips when the full
+    backend deps (docker, etc.) aren't installed in this environment."""
+    main = pytest.importorskip("main")
+    assert main.app.version == "7.0.0"
+    spec = main.app.openapi()
+    tags = {t["name"]: t.get("description", "") for t in spec.get("tags", [])}
+    assert "agents" in tags and tags["agents"]

--- a/admin_ui/backend/tests/test_agents_api.py
+++ b/admin_ui/backend/tests/test_agents_api.py
@@ -387,4 +387,4 @@ def test_main_app_openapi_version_and_tag():
     assert main.app.version == "7.0.0"
     spec = main.app.openapi()
     tags = {t["name"]: t.get("description", "") for t in spec.get("tags", [])}
-    assert "agents" in tags and tags["agents"]
+    assert tags.get("agents")  # present with a non-empty description

--- a/admin_ui/backend/tests/test_agents_api.py
+++ b/admin_ui/backend/tests/test_agents_api.py
@@ -380,10 +380,25 @@ def test_openapi_surfaces_agents_schema(client):
     list_schema = spec["paths"]["/api/agents"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
     assert list_schema.get("type") == "array"
 
+def _load_backend_main():
+    """Load admin_ui/backend/main.py by path so it can't be shadowed by the
+    repo-root main.py (the CLI entrypoint, which has no `app`). Skips when the
+    full backend deps (docker, etc.) aren't installed in this environment."""
+    import importlib.util
+    from pathlib import Path
+
+    main_path = Path(__file__).resolve().parents[1] / "main.py"
+    spec = importlib.util.spec_from_file_location("admin_ui_backend_main", main_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # missing optional backend deps in this environment
+        pytest.skip(f"admin_ui backend main.py not importable: {exc}")
+    return module
+
 def test_main_app_openapi_version_and_tag():
-    """version literal + agents tag description live in main.py. Skips when the full
-    backend deps (docker, etc.) aren't installed in this environment."""
-    main = pytest.importorskip("main")
+    """version literal + agents tag description live in admin_ui/backend/main.py."""
+    main = _load_backend_main()
     assert main.app.version == "7.0.0"
     spec = main.app.openapi()
     tags = {t["name"]: t.get("description", "") for t in spec.get("tags", [])}

--- a/admin_ui/backend/tests/test_calls_agent_aliases.py
+++ b/admin_ui/backend/tests/test_calls_agent_aliases.py
@@ -44,6 +44,9 @@ def test_both_aliases_none_for_non_ai_agent_routing():
 def test_aliases_null_when_no_context_or_no_match():
     r = calls_api._record_to_summary_response(_rec(context_name=None, routing_method=None), {})
     assert r.agent_slug is None and r.agent_name is None
+    # ai_agent branch but no context_name -> both aliases stay null
+    r_no_ctx = calls_api._record_to_response(_rec(context_name=None, routing_method="ai_agent"), {})
+    assert r_no_ctx.agent_slug is None and r_no_ctx.agent_name is None
     r2 = calls_api._record_to_response(_rec(context_name="ghost", routing_method="ai_agent"), {})
     assert r2.agent_slug == "ghost"            # slug echoes context even with no name match
     assert r2.agent_name is None

--- a/admin_ui/backend/tests/test_calls_agent_aliases.py
+++ b/admin_ui/backend/tests/test_calls_agent_aliases.py
@@ -1,0 +1,63 @@
+"""v7 additive call-history aliases: agent_slug / agent_name.
+
+These exercise the pure converter logic in api.calls directly (no call-history DB,
+no docker), proving the aliases are additive and that context_name/routing_method
+are never altered."""
+from types import SimpleNamespace
+from api import calls as calls_api
+
+
+def _rec(**over):
+    base = dict(
+        id="r1", call_id="c1", caller_number=None, caller_name=None,
+        start_time=None, end_time=None, duration_seconds=0.0,
+        provider_name="openai", pipeline_name=None, pipeline_components={},
+        context_name="sales", routing_method="ai_agent",
+        conversation_history=[], outcome="completed", transfer_destination=None,
+        error_message=None, tool_calls=[], pre_call_tool_calls=[],
+        post_call_tool_calls=[], avg_turn_latency_ms=0.0, max_turn_latency_ms=0.0,
+        total_turns=0, caller_audio_format="ulaw", codec_alignment_ok=True,
+        barge_in_count=0, created_at=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_agent_slug_set_only_for_ai_agent():
+    names = {"sales": "Sales Agent"}
+    r = calls_api._record_to_summary_response(_rec(routing_method="ai_agent"), names)
+    assert r.context_name == "sales"          # unchanged
+    assert r.routing_method == "ai_agent"      # unchanged
+    assert r.agent_slug == "sales"
+    assert r.agent_name == "Sales Agent"
+
+
+def test_both_aliases_none_for_non_ai_agent_routing():
+    names = {"sales": "Sales Agent"}
+    for rm in ("ai_context", "default", "unknown", None):
+        r = calls_api._record_to_response(_rec(routing_method=rm), names)
+        assert r.agent_slug is None and r.agent_name is None, rm
+        assert r.context_name == "sales"       # unchanged
+        assert r.routing_method == rm           # unchanged
+
+
+def test_aliases_null_when_no_context_or_no_match():
+    r = calls_api._record_to_summary_response(_rec(context_name=None, routing_method=None), {})
+    assert r.agent_slug is None and r.agent_name is None
+    r2 = calls_api._record_to_response(_rec(context_name="ghost", routing_method="ai_agent"), {})
+    assert r2.agent_slug == "ghost"            # slug echoes context even with no name match
+    assert r2.agent_name is None
+
+
+def test_converters_work_without_a_name_map():
+    # default arg path (e.g. CSV/legacy callers) must not raise and still set slug
+    r = calls_api._record_to_response(_rec())
+    assert r.agent_slug == "sales" and r.agent_name is None
+
+
+def test_agent_name_map_never_raises(monkeypatch):
+    # a broken / missing agents.db must degrade to an empty map, not an exception
+    def _boom(*a, **k):
+        raise RuntimeError("db locked")
+    monkeypatch.setattr("agents_store.AgentsStore", _boom, raising=False)
+    assert calls_api._agent_name_map() == {}

--- a/admin_ui/backend/tests/test_calls_agent_aliases.py
+++ b/admin_ui/backend/tests/test_calls_agent_aliases.py
@@ -23,18 +23,19 @@ def _rec(**over):
     return SimpleNamespace(**base)
 
 
-def test_agent_slug_set_only_for_ai_agent():
+def test_agent_slug_set_for_resolved_agent_routing():
     names = {"sales": "Sales Agent"}
-    r = calls_api._record_to_summary_response(_rec(routing_method="ai_agent"), names)
-    assert r.context_name == "sales"          # unchanged
-    assert r.routing_method == "ai_agent"      # unchanged
-    assert r.agent_slug == "sales"
-    assert r.agent_name == "Sales Agent"
+    for rm in ("ai_agent", "ai_context", "default"):
+        r = calls_api._record_to_summary_response(_rec(routing_method=rm), names)
+        assert r.context_name == "sales"          # unchanged
+        assert r.routing_method == rm              # unchanged -- still explains how
+        assert r.agent_slug == "sales", rm
+        assert r.agent_name == "Sales Agent", rm
 
 
-def test_both_aliases_none_for_non_ai_agent_routing():
+def test_both_aliases_none_for_unresolved_routing():
     names = {"sales": "Sales Agent"}
-    for rm in ("ai_context", "default", "unknown", None):
+    for rm in ("unknown", None):
         r = calls_api._record_to_response(_rec(routing_method=rm), names)
         assert r.agent_slug is None and r.agent_name is None, rm
         assert r.context_name == "sales"       # unchanged

--- a/docs/contributing/api-reference.md
+++ b/docs/contributing/api-reference.md
@@ -115,11 +115,12 @@ curl -H "Authorization: Bearer eyJ..." \
 > **Agent on a call record (v7).** Each call record reports the resolved agent as
 > `context_name` (the agent/context slug) plus `routing_method`
 > (`ai_agent` \| `ai_context` \| `default` \| `null`). v7.0.x adds two **additive**
-> aliases so integrations need not infer this: `agent_slug` and `agent_name`. Both are
-> populated **only when the call was explicitly routed via `AI_AGENT`**
-> (`routing_method == "ai_agent"`); for `ai_context`/`default`/`unknown` both are
-> `null`. `agent_name` is a best-effort display-name lookup and is `null` when the
-> agents database is unavailable or has no matching agent. `context_name` and
+> aliases so integrations need not infer this: `agent_slug` and `agent_name`.
+> `agent_slug` mirrors the resolved agent (`context_name`) **whenever the call was
+> routed to one** — `ai_agent`, `ai_context` or `default` routing — and is `null`
+> only for `unknown`/`null` routing. `routing_method` still tells you *how* the agent
+> was selected. `agent_name` is a best-effort display-name lookup and is `null` when
+> the agents database is unavailable or has no matching agent. `context_name` and
 > `routing_method` are unchanged.
 
 ### Agents (`/api/agents`)

--- a/docs/contributing/api-reference.md
+++ b/docs/contributing/api-reference.md
@@ -112,6 +112,46 @@ curl -H "Authorization: Bearer eyJ..." \
 | GET | `/api/calls/export/csv` | Export calls as CSV |
 | GET | `/api/calls/export/json` | Export calls as JSON |
 
+> **Agent on a call record (v7).** Each call record reports the resolved agent as
+> `context_name` (the agent/context slug) plus `routing_method`
+> (`ai_agent` \| `ai_context` \| `default` \| `null`). v7.0.x adds two **additive**
+> aliases so integrations need not infer this: `agent_slug` and `agent_name`. Both are
+> populated **only when the call was explicitly routed via `AI_AGENT`**
+> (`routing_method == "ai_agent"`); for `ai_context`/`default`/`unknown` both are
+> `null`. `agent_name` is a best-effort display-name lookup and is `null` when the
+> agents database is unavailable or has no matching agent. `context_name` and
+> `routing_method` are unchanged.
+
+### Agents (`/api/agents`)
+The Agents system (v7) is the operator surface for managing AI agents. Manage agents
+over HTTP here; see also [`docs/AGENTS.md`](../AGENTS.md).
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/agents` | List all agents |
+| GET | `/api/agents/{slug}` | Get a single agent by slug |
+| POST | `/api/agents` | Create an agent (requires a provider **or** a pipeline) |
+| PATCH | `/api/agents/{slug}` | Update an agent (partial; `is_active` can promote default) |
+| DELETE | `/api/agents/{slug}` | Delete an agent (promotes a new default if needed) |
+| POST | `/api/agents/{slug}/default` | Make this agent the default |
+| GET | `/api/agents/{slug}/stats` | Per-agent stats (calls in last 30d, last call) |
+| GET | `/api/agents/{slug}/dialplan` | Generate an `extensions_custom.conf` snippet |
+| GET | `/api/agents/templates` | List starter agent templates |
+| GET | `/api/agents/summary` | Dashboard KPIs (active agents, active calls, routed, transfers) |
+| GET | `/api/agents/stats-batch` | Per-agent stats for all agents in one response |
+| GET | `/api/agents/distribution` | Call counts grouped by agent, descending |
+| GET | `/api/agents/routing-methods` | Routing-method breakdown (`ai_agent`/`ai_context`/`default`/`unknown`) |
+| GET | `/api/agents-migration/status` | YAML→DB migration result and drift state |
+| POST | `/api/agents-migration/reconcile` | Re-import YAML context changes into the DB |
+| POST | `/api/agents-migration/acknowledge` | Keep the DB as-is and clear the drift flag |
+
+> **`AI_AGENT` is a dialplan/runtime channel variable, not an HTTP parameter.** Set
+> `AI_AGENT=<slug>` (or the legacy `AI_CONTEXT=<slug>`) in your Asterisk dialplan to
+> route a call to a specific agent — see `GET /api/agents/{slug}/dialplan` for a
+> ready-to-paste snippet. External integrations should manage agents via the Agents
+> API above and read the agent that handled a call from the call-record fields
+> (`context_name` / `agent_slug` / `agent_name` / `routing_method`).
+
 ### Outbound (`/api/outbound`, `/api/campaigns`, `/api/leads`, `/api/recordings`)
 | Method | Endpoint | Description |
 |--------|----------|-------------|


### PR DESCRIPTION
## Summary

Follow-up for #427.

This surfaces the v7 Agents API as a documented OpenAPI contract
and adds additive call-history agent aliases for integrations.

- Adds typed response models for `/api/agents` endpoints.
- Adds `GET /api/agents/{slug}` for direct lookup by slug.
- Adds the missing `agents` OpenAPI tag description.
- Updates OpenAPI metadata version from `6.2.0` to `7.0.0`.
- Adds additive call-record fields: `agent_slug` and `agent_name`.
- Preserves existing `context_name` and `routing_method`.
- Documents that `AI_AGENT` / legacy `AI_CONTEXT` are dialplan/runtime variables.

## Compatibility

All call-history changes are additive only. No existing response fields were removed or renamed.

`agent_slug` mirrors the resolved agent slug (`context_name`) when the call was routed to an agent through:

- `routing_method == "ai_agent"`
- `routing_method == "ai_context"`
- `routing_method == "default"`

For `unknown` / `null` routing, `agent_slug` and `agent_name` remain `null`.

`agent_name` is a best-effort display-name lookup from `agents.db`; it remains `null` if the agents database is unavailable or the slug has no matching agent.

Existing `agents.db` integer flags remain `0/1` integers:

- `is_active`
- `is_default`
- `is_operator_managed`

## Tests

Maintainer verification on latest PR head `1152ae71`:

- `PYTHONPATH=admin_ui/backend:. python -m pytest admin_ui/backend/tests/test_agents_api.py admin_ui/backend/tests/test_calls_agent_aliases.py admin_ui/backend/tests/test_agents_store.py admin_ui/backend/tests/test_export_agents_yaml.py` -> 47 passed
- `py_compile agents.py calls.py main.py agents_store.py` -> OK
- GitHub checks passing: Analyze Python Code, Docker size check, CodeQL, build, dev artifacts, CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Call record responses now optionally include `agent_slug` and `agent_name` for resolved agent routing.
  * Agent endpoints (CRUD, stats, distribution, routing methods, and dialplan) now return validated, strongly-typed payloads.
* **Bug Fixes**
  * Fixed `{slug}` routing to avoid shadowing literal agent routes.
* **Documentation**
  * Updated v7 API docs with call-record agent identification and the full Agents endpoint catalog.
* **Tests**
  * Added/extended contract tests for Agents and call-record alias behavior, including OpenAPI version/tag checks.
* **Chores**
  * Improved agent data store cleanup with safe, idempotent closing and context support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
