### PR TITLE
fix(providers): edit/save canonical Google Live with legacy type:full (#436)

### DIFF
--- a/.github/workflows/regression-hardening.yml
+++ b/.github/workflows/regression-hardening.yml
@@ -127,6 +127,11 @@ jobs:
         run: |
           npm ci
 
+      - name: Run frontend tests
+        working-directory: admin_ui/frontend
+        run: |
+          npm run test
+
       - name: Build frontend
         working-directory: admin_ui/frontend
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Frontend test runner (Vitest)** (`admin_ui/frontend`): added `vitest` with `npm run test` / `test:watch`, wired into CI (`.github/workflows/regression-hardening.yml` now runs `npm run test` before the frontend build). Establishes unit-test coverage for the admin UI; first suite covers provider-naming normalization (#436).
+
+### Fixed
+
+- **Provider editor: a canonical Google Live provider in legacy `type: full` form can be edited and saved again (#436)** (`admin_ui/frontend/src/utils/providerNaming.ts`, `admin_ui/frontend/src/pages/ProvidersPage.tsx`): a provider stored in the supported single-instance form `google_live: { type: full }` could not be edited — the editor only inferred a concrete full-agent kind when `type` was absent, so the disabled Provider Type selector showed *OpenAI Realtime* and **Save Changes** rejected the entry with `Select a full-agent provider type.` A new `getEffectiveFullAgentKind(provider, key)` resolves the concrete kind the way the engine does (explicit unambiguous kind → that; `type: full` or no `type` on a canonical key like `google_live`/`local` → the key; neutral custom keys are not name-guessed → `null`). The disabled selector now displays the resolved kind and save validation accepts it, while the persisted `type: full` is left unchanged so the YAML stays engine-valid. Regression-guarded in `admin_ui/frontend/src/utils/providerNaming.test.ts`.
+
 ## [7.0.1] - 2026-06-19
 
 > Maintenance release: hardening and bug fixes from a full post-7.0.0 audit. No breaking changes — upgrade in place. Validated against six live provider calls on the integration box (see `docs/baselines/golden/v7.0.1-validation-matrix.md`).

--- a/admin_ui/frontend/package-lock.json
+++ b/admin_ui/frontend/package-lock.json
@@ -41,7 +41,8 @@
                 "prettier": "^3.2.5",
                 "tailwindcss": "^3.4.1",
                 "typescript": "^5.2.2",
-                "vite": "^5.1.0"
+                "vite": "^5.1.0",
+                "vitest": "^1.6.1"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -878,6 +879,19 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/@jest/schemas": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+            "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.27.8"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1665,6 +1679,13 @@
                 "win32"
             ]
         },
+        "node_modules/@sinclair/typebox": {
+            "version": "0.27.10",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@tailwindcss/typography": {
             "version": "0.5.19",
             "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
@@ -2063,10 +2084,113 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+            "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "chai": "^4.3.10"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+            "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "1.6.1",
+                "p-limit": "^5.0.0",
+                "pathe": "^1.1.1"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/p-limit": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+            "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@vitest/runner/node_modules/yocto-queue": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+            "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "pretty-format": "^29.7.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+            "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^2.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+            "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "diff-sequences": "^29.6.3",
+                "estree-walker": "^3.0.3",
+                "loupe": "^2.3.7",
+                "pretty-format": "^29.7.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2084,6 +2208,19 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.3.5",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/ajv": {
@@ -2320,6 +2457,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -2496,6 +2643,16 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2595,6 +2752,25 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/chai": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+            "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.3",
+                "deep-eql": "^4.1.3",
+                "get-func-name": "^2.0.2",
+                "loupe": "^2.3.6",
+                "pathval": "^1.1.1",
+                "type-detect": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2650,6 +2826,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-func-name": "^2.0.2"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/chokidar": {
@@ -2752,6 +2941,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
             "dev": true,
             "license": "MIT"
         },
@@ -2879,6 +3075,19 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/deep-eql": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+            "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "type-detect": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2964,6 +3173,16 @@
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "license": "Apache-2.0"
+        },
+        "node_modules/diff-sequences": {
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+            "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -3562,6 +3781,16 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3570,6 +3799,30 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/extend": {
@@ -3847,6 +4100,16 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/get-func-name": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3891,6 +4154,19 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-symbol-description": {
@@ -4181,6 +4457,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16.17.0"
             }
         },
         "node_modules/ignore": {
@@ -4629,6 +4915,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-string": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
@@ -4890,6 +5189,23 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
+        "node_modules/local-pkg": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+            "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mlly": "^1.7.3",
+                "pkg-types": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4935,6 +5251,16 @@
                 "loose-envify": "cli.js"
             }
         },
+        "node_modules/loupe": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-func-name": "^2.0.1"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4952,6 +5278,16 @@
             "license": "ISC",
             "peerDependencies": {
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/markdown-table": {
@@ -5267,6 +5603,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -5874,6 +6217,19 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -5889,6 +6245,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/mlly": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^1.3.1",
+                "ufo": "^1.6.3"
+            }
+        },
+        "node_modules/mlly/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/monaco-editor": {
             "version": "0.55.0",
@@ -5967,6 +6343,35 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm-run-path/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/object-assign": {
@@ -6093,6 +6498,22 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/optionator": {
@@ -6247,6 +6668,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6282,6 +6720,25 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/pkg-types": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.1"
+            }
+        },
+        "node_modules/pkg-types/node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
@@ -6474,6 +6931,41 @@
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
+        },
+        "node_modules/pretty-format": {
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jest/schemas": "^29.6.3",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^18.0.0"
+            },
+            "engines": {
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -7178,6 +7670,26 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7217,10 +7729,24 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/state-local": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
             "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
@@ -7362,6 +7888,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7374,6 +7913,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strip-literal": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+            "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/style-to-js": {
             "version": "1.1.21",
@@ -7524,6 +8083,13 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7567,6 +8133,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+            "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+            "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -7637,6 +8223,16 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/type-fest": {
@@ -7743,6 +8339,13 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/ufo": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
@@ -8028,6 +8631,95 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+            "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.4",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+            "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "1.6.1",
+                "@vitest/runner": "1.6.1",
+                "@vitest/snapshot": "1.6.1",
+                "@vitest/spy": "1.6.1",
+                "@vitest/utils": "1.6.1",
+                "acorn-walk": "^8.3.2",
+                "chai": "^4.3.10",
+                "debug": "^4.3.4",
+                "execa": "^8.0.1",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.5",
+                "pathe": "^1.1.1",
+                "picocolors": "^1.0.0",
+                "std-env": "^3.5.0",
+                "strip-literal": "^2.0.0",
+                "tinybench": "^2.5.1",
+                "tinypool": "^0.8.3",
+                "vite": "^5.0.0",
+                "vite-node": "1.6.1",
+                "why-is-node-running": "^2.2.2"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "1.6.1",
+                "@vitest/ui": "1.6.1",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8131,6 +8823,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/admin_ui/frontend/package.json
+++ b/admin_ui/frontend/package.json
@@ -11,24 +11,26 @@
         "lint:fix": "eslint src --ext ts,tsx --fix",
         "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
         "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
-        "audit": "npm audit --audit-level=moderate"
+        "audit": "npm audit --audit-level=moderate",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
+        "@tailwindcss/typography": "^0.5.10",
         "axios": "^1.6.7",
         "clsx": "^2.1.0",
         "js-yaml": "^4.1.0",
         "lucide-react": "^0.330.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-markdown": "^9.0.1",
         "react-router-dom": "^6.22.0",
+        "remark-gfm": "^4.0.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.2.1",
-        "tailwindcss-animate": "^1.0.7",
-        "react-markdown": "^9.0.1",
-        "remark-gfm": "^4.0.0",
-        "@tailwindcss/typography": "^0.5.10"
+        "tailwindcss-animate": "^1.0.7"
     },
     "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -47,6 +49,7 @@
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.2.2",
-        "vite": "^5.1.0"
+        "vite": "^5.1.0",
+        "vitest": "^1.6.1"
     }
 }

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -24,7 +24,7 @@ import OpenAIProviderForm from '../components/config/providers/OpenAIProviderFor
 import ElevenLabsProviderForm from '../components/config/providers/ElevenLabsProviderForm';
 import TelnyxProviderForm from '../components/config/providers/TelnyxProviderForm';
 import AzureProviderForm from '../components/config/providers/AzureProviderForm';
-import { Capability, capabilityFromKey, ensureModularKey, isFullAgentProvider } from '../utils/providerNaming';
+import { Capability, capabilityFromKey, ensureModularKey, isFullAgentProvider, getEffectiveFullAgentKind } from '../utils/providerNaming';
 import { GOOGLE_LIVE_DEFAULT_MODEL } from '../utils/googleLiveModels';
 
 const stripModularSuffix = (name: string): string => (name || '').replace(/_(stt|llm|tts)$/i, '');
@@ -551,7 +551,12 @@ const ProvidersPage: React.FC = () => {
             finalName = ensureModularKey(stripModularSuffix(finalName), cap);
             capabilities = [cap];
         } else {
-            if (!FULL_AGENT_TYPES.includes(String(providerForm.type || '').toLowerCase())) {
+            // Resolve the concrete full-agent kind the way the engine does, so a
+            // canonical legacy entry (e.g. google_live: { type: full }) validates
+            // and saves without forcing a type change. #436
+            const fullAgentKey = isNewProvider ? finalName : (editingProvider || '');
+            const effectiveKind = getEffectiveFullAgentKind(providerForm, fullAgentKey);
+            if (!effectiveKind || !FULL_AGENT_TYPES.includes(effectiveKind)) {
                 toast.error('Select a full-agent provider type.');
                 return;
             }
@@ -1217,7 +1222,10 @@ const ProvidersPage: React.FC = () => {
                                     </div>
                                     <select
                                         className="w-full p-2 rounded border border-input bg-background"
-                                        value={providerForm.type || 'openai_realtime'}
+                                        // Show the resolved concrete kind so a canonical legacy
+                                        // entry (e.g. google_live: { type: full }) displays correctly
+                                        // instead of falling back to the first option. #436
+                                        value={getEffectiveFullAgentKind(providerForm, editingProvider || undefined) || providerForm.type || 'openai_realtime'}
                                         disabled={!isNewProvider}
                                         onChange={(e) => setProviderForm({ ...providerForm, type: e.target.value, capabilities: ['stt', 'llm', 'tts'] })}
                                     >

--- a/admin_ui/frontend/src/utils/providerNaming.test.ts
+++ b/admin_ui/frontend/src/utils/providerNaming.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getEffectiveFullAgentKind } from './providerNaming';
+
+/**
+ * Regression coverage for GitHub issue #436: a canonical Google Live provider
+ * stored in the supported legacy form `google_live: { type: full }` could not be
+ * edited or saved — the provider editor resolved its concrete adapter kind only
+ * when `type` was absent, so `type: full` was misrepresented (selector showed
+ * OpenAI Realtime) and rejected on save ("Select a full-agent provider type.").
+ *
+ * getEffectiveFullAgentKind resolves the concrete full-agent kind the same way
+ * the engine does, so the editor can display and validate it correctly.
+ */
+describe('getEffectiveFullAgentKind', () => {
+    it('resolves canonical google_live with legacy type:full to google_live (#436)', () => {
+        expect(getEffectiveFullAgentKind({ type: 'full' }, 'google_live')).toBe('google_live');
+    });
+
+    it('returns the concrete kind when an explicit full-agent type is set', () => {
+        expect(getEffectiveFullAgentKind({ type: 'google_live' }, 'google_live')).toBe('google_live');
+        expect(getEffectiveFullAgentKind({ type: 'openai_realtime' }, 'my_openai')).toBe('openai_realtime');
+    });
+
+    it('resolves canonical local with type:full to local (monolithic Local AI)', () => {
+        expect(getEffectiveFullAgentKind({ type: 'full' }, 'local')).toBe('local');
+    });
+
+    it('resolves the legacy single-instance form (canonical key, no type) to that kind', () => {
+        expect(getEffectiveFullAgentKind({}, 'grok')).toBe('grok');
+    });
+
+    it('does not name-guess a kind for a neutral custom key with type:full', () => {
+        expect(getEffectiveFullAgentKind({ type: 'full' }, 'my_custom_agent')).toBeNull();
+    });
+
+    it('returns null for a modular single-capability provider (type:local is not a full agent)', () => {
+        expect(getEffectiveFullAgentKind({ type: 'local', capabilities: ['stt'] }, 'local_stt')).toBeNull();
+    });
+});

--- a/admin_ui/frontend/src/utils/providerNaming.test.ts
+++ b/admin_ui/frontend/src/utils/providerNaming.test.ts
@@ -36,4 +36,10 @@ describe('getEffectiveFullAgentKind', () => {
     it('returns null for a modular single-capability provider (type:local is not a full agent)', () => {
         expect(getEffectiveFullAgentKind({ type: 'local', capabilities: ['stt'] }, 'local_stt')).toBeNull();
     });
+
+    it('resolves type:local WITH all three capabilities to local (monolithic Local full agent)', () => {
+        // The Provider Type dropdown's "Local" option saves type:'local' with full
+        // capabilities; this must remain a savable full agent (regression: #440 review).
+        expect(getEffectiveFullAgentKind({ type: 'local', capabilities: ['stt', 'llm', 'tts'] }, 'local')).toBe('local');
+    });
 });

--- a/admin_ui/frontend/src/utils/providerNaming.ts
+++ b/admin_ui/frontend/src/utils/providerNaming.ts
@@ -93,6 +93,42 @@ export const isFullAgentProvider = (provider: any, key?: string): boolean => {
 };
 
 /**
+ * Concrete full-agent kinds that are unambiguous from the `type` field alone.
+ * 'local' is intentionally excluded: `type: local` is modular (single-capability),
+ * while the monolithic Local AI full agent uses `type: full` on the `local` key.
+ */
+const UNAMBIGUOUS_FULL_AGENT_KINDS = [
+    'openai_realtime',
+    'deepgram',
+    'google_live',
+    'elevenlabs_agent',
+    'grok',
+];
+
+/**
+ * Resolve the concrete full-agent kind for a provider, mirroring how the engine
+ * interprets canonical legacy entries. Returns null when the provider is not a
+ * full agent or its kind cannot be determined without name-guessing.
+ *
+ * - explicit unambiguous full-agent `type` (e.g. google_live) → that type
+ * - `type: full` (or no `type`) on a canonical key (e.g. google_live, local) → the key
+ * - neutral custom keys are NOT guessed → null
+ *
+ * The disabled provider-type selector and save validation use this so a canonical
+ * `google_live: { type: full }` entry displays and saves as Google Live.
+ *
+ * @see GitHub issue #436
+ */
+export const getEffectiveFullAgentKind = (provider: any, key?: string): string | null => {
+    const type = (provider?.type || '').toLowerCase();
+    if (UNAMBIGUOUS_FULL_AGENT_KINDS.includes(type)) return type;
+    if ((type === 'full' || type === '') && key && CANONICAL_FULL_AGENT_KEYS.has(key)) {
+        return key;
+    }
+    return null;
+};
+
+/**
  * Provider types that have registered adapter factories in the engine.
  * Only these providers can be used in pipelines.
  * 

--- a/admin_ui/frontend/src/utils/providerNaming.ts
+++ b/admin_ui/frontend/src/utils/providerNaming.ts
@@ -111,6 +111,8 @@ const UNAMBIGUOUS_FULL_AGENT_KINDS = [
  * full agent or its kind cannot be determined without name-guessing.
  *
  * - explicit unambiguous full-agent `type` (e.g. google_live) → that type
+ * - `type: local` carrying all three capabilities (the monolithic Local AI
+ *   selection) → 'local'; single-capability local stays modular → null
  * - `type: full` (or no `type`) on a canonical key (e.g. google_live, local) → the key
  * - neutral custom keys are NOT guessed → null
  *
@@ -122,6 +124,13 @@ const UNAMBIGUOUS_FULL_AGENT_KINDS = [
 export const getEffectiveFullAgentKind = (provider: any, key?: string): string | null => {
     const type = (provider?.type || '').toLowerCase();
     if (UNAMBIGUOUS_FULL_AGENT_KINDS.includes(type)) return type;
+    // `type: local` is the monolithic Local AI full agent only when it carries all
+    // three capabilities (the "Local" Provider Type option); single-capability local
+    // is modular (local_stt / local_llm / local_tts).
+    const caps = provider?.capabilities || [];
+    if (type === 'local' && caps.includes('stt') && caps.includes('llm') && caps.includes('tts')) {
+        return 'local';
+    }
     if ((type === 'full' || type === '') && key && CANONICAL_FULL_AGENT_KEYS.has(key)) {
         return key;
     }


### PR DESCRIPTION
## Summary

Fixes #436. A provider stored in the supported single-instance form `google_live: { type: full }` could not be edited:

- The disabled **Provider Type** selector showed *OpenAI Realtime* instead of Google Live.
- **Save Changes** rejected the entry with `Select a full-agent provider type.`

Root cause: the editor only resolved a concrete full-agent kind when `type` was *absent*, so the canonical `type: full` form was both misrepresented (selector fell back to the first option) and rejected on save (validation accepted only concrete kinds, not `full`).

## Fix

- Add `getEffectiveFullAgentKind(provider, key)` in `admin_ui/frontend/src/utils/providerNaming.ts`, mirroring how the engine interprets canonical legacy entries:
  - explicit unambiguous full-agent `type` (e.g. `google_live`) → that type
  - `type: full` (or no `type`) on a canonical key (`google_live`, `local`, …) → the key
  - neutral custom keys are **not** name-guessed → `null`
- `ProvidersPage`: the disabled selector now displays the resolved kind, and save validation accepts it. The persisted `type: full` is **left unchanged**, so the YAML stays engine-valid — no silent adapter/type rewrite (addresses the "immutable type after creation" concern in #436).

## Tests / CI

- New Vitest suite `admin_ui/frontend/src/utils/providerNaming.test.ts` — 6 cases incl. the exact `google_live` + `type: full` case, `local` + `type: full`, the no-type canonical form, and the no-name-guess / modular negatives. Written **test-first** (RED → GREEN).
- Introduced **Vitest** to the frontend (`npm run test` / `test:watch`) and wired it into CI — `regression-hardening.yml` now runs the suite before the frontend build, so this can't silently regress.
- `tsc + vite build` clean.

## Verification status

- ✅ Resolver logic (incl. the reported case) unit-tested · clean build · CI test guard.
- ⏳ **Manual browser confirmation pending.** Deployed to the voiprnd dev box (`admin_ui` rebuilt from this branch) and ready for a 2-minute check: edit a `google_live` entry with `type: full` → the selector reads *Google Live*, an unrelated field saves without the validation error, and the persisted YAML remains engine-valid (tracker evidence items 2–5). Not completed in-session as it required a logged-in dev session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Vitest-based frontend test runner (including `test` and `test:watch`) and integrated it into CI so tests run before the frontend build.

* **Bug Fixes**
  * Fixed the Provider editor to resolve and validate full-agent “concrete kinds” using effective naming logic, ensuring legacy configurations (e.g., canonical entries) render correctly and can be edited/saved without validation errors.

* **Tests**
  * Added coverage for provider kind resolution and regression scenarios for legacy provider naming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->