### PR TITLE
fix: align modular streaming STT audio contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Modular streaming STT now declares the engine's actual 16 kHz audio contract (#458)** (`src/engine.py`, `src/pipelines/{azure,deepgram,deepgram_flux,local}.py`, Admin UI pipeline forms): the pipeline runner already normalized inbound STT audio to raw PCM16-LE mono 16 kHz, but streaming STT providers could still be opened with stale/default 8 kHz metadata. Azure Realtime now receives the explicit 16 kHz `AudioStreamFormat`, and Deepgram streaming, Deepgram Flux, and Local streaming STT validate the same canonical contract. The Admin UI now shows the modular STT stream format as managed (`PCM16-LE · mono · 16 kHz`) instead of exposing conflicting `stream_format` edits, and docs clarify that Audio Profiles handle wire/full-agent negotiation while modular streaming STT uses the engine-normalized bus. Regression coverage was added for Azure, Deepgram, Flux, Local alias handling, runner lifecycle propagation, and frontend STT option normalization.
+
 ## [7.1.1] - 2026-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Modular streaming STT now declares the engine's actual 16 kHz audio contract (#458)** (`src/engine.py`, `src/pipelines/{azure,deepgram,deepgram_flux,local}.py`, Admin UI pipeline forms): the pipeline runner already normalized inbound STT audio to raw PCM16-LE mono 16 kHz, but streaming STT providers could still be opened with stale/default 8 kHz metadata. Azure Realtime now receives the explicit 16 kHz `AudioStreamFormat`, and Deepgram streaming, Deepgram Flux, and Local streaming STT validate the same canonical contract. The Admin UI now shows the modular STT stream format as managed (`PCM16-LE · mono · 16 kHz`) instead of exposing conflicting `stream_format` edits, and docs clarify that Audio Profiles handle wire/full-agent negotiation while modular streaming STT uses the engine-normalized bus. Regression coverage was added for Azure, Deepgram, Flux, Local alias handling, runner lifecycle propagation, and frontend STT option normalization.
 ### Added
 
 - **Managed Tools REST API** (`/api/tools`): authenticated CRUD endpoints for
@@ -18,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same validated local-override persistence path as the raw YAML editor, reject
   reserved names and invalid tool shapes, and are covered by the Admin backend
   CI suite.
+
+### Fixed
+
+- **Modular streaming STT now declares the engine's actual 16 kHz audio contract (#458)** (`src/engine.py`, `src/pipelines/{azure,deepgram,deepgram_flux,local}.py`, Admin UI pipeline forms): the pipeline runner already normalized inbound STT audio to raw PCM16-LE mono 16 kHz, but streaming STT providers could still be opened with stale/default 8 kHz metadata. Azure Realtime now receives the explicit 16 kHz `AudioStreamFormat`, and Deepgram streaming, Deepgram Flux, and Local streaming STT validate the same canonical contract. The Admin UI now shows the modular STT stream format as managed (`PCM16-LE · mono · 16 kHz`) instead of exposing conflicting `stream_format` edits, and docs clarify that Audio Profiles handle wire/full-agent negotiation while modular streaming STT uses the engine-normalized bus. Regression coverage was added for Azure, Deepgram, Flux, Local alias handling, runner lifecycle propagation, and frontend STT option normalization.
 
 ## [7.1.1] - 2026-06-21
 

--- a/admin_ui/frontend/src/components/config/PipelineForm.tsx
+++ b/admin_ui/frontend/src/components/config/PipelineForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { FormInput, FormLabel, FormSwitch, FormSelect } from '../ui/FormComponents';
 import { ensureModularKey, isFullAgentProvider, isRegisteredProvider, capabilityFromKey } from '../../utils/providerNaming';
+import { getSttStreamingMode } from '../../utils/sttAudioContract';
 import { CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
 
 interface LocalAIStatus {
@@ -226,6 +227,9 @@ const PipelineForm: React.FC<PipelineFormProps> = ({ config, providers, onChange
     const isOllamaLlm = llmKey.includes('ollama');
     const isAzureStt = sttKey.includes('azure');
     const isAzureTts = ttsKey.includes('azure');
+    const sttStreamingMode = getSttStreamingMode(sttKey, providers || {});
+    const sttStreamingEnabled = sttStreamingMode === 'required'
+        || (sttStreamingMode === 'optional' && (localConfig.options?.stt?.streaming ?? true));
 
     const timestampGranularities = Array.isArray(localConfig.options?.stt?.timestamp_granularities)
         ? localConfig.options?.stt?.timestamp_granularities
@@ -301,14 +305,26 @@ const PipelineForm: React.FC<PipelineFormProps> = ({ config, providers, onChange
                 </div>
 
                 <div className="space-y-3">
-                    <FormSwitch
-                        id="pipeline-stt-streaming"
-                        label="Streaming STT"
-                        checked={localConfig.options?.stt?.streaming ?? true}
-                        onChange={(e) => updateSTTOptions({ streaming: e.target.checked })}
-                        description="Recommended. Enables low-latency, two-way conversation."
-                        tooltip="When enabled, supported STT adapters stream audio continuously. When disabled, STT runs in buffered chunk mode."
-                    />
+                    {sttStreamingMode === 'buffered' ? (
+                        <div className="rounded-lg border border-border bg-card/50 p-3 text-sm">
+                            <div className="font-medium">Buffered STT</div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                                This adapter receives complete PCM16 audio buffers with the sample rate supplied by the engine.
+                            </p>
+                        </div>
+                    ) : (
+                        <FormSwitch
+                            id="pipeline-stt-streaming"
+                            label="Streaming STT"
+                            checked={sttStreamingEnabled}
+                            disabled={sttStreamingMode === 'required'}
+                            onChange={(e) => updateSTTOptions({ streaming: e.target.checked })}
+                            description={sttStreamingMode === 'required'
+                                ? 'Required by this STT adapter.'
+                                : 'Recommended. Enables low-latency, two-way conversation.'}
+                            tooltip="Streaming adapters receive the engine-managed PCM16 mono 16 kHz audio bus."
+                        />
+                    )}
 
                     <div className="flex items-center justify-between">
                         <button
@@ -319,7 +335,9 @@ const PipelineForm: React.FC<PipelineFormProps> = ({ config, providers, onChange
                             {showAdvancedSTT ? 'Hide Advanced' : 'Show Advanced'}
                         </button>
                         <div className="text-xs text-muted-foreground">
-                            Defaults: chunk_ms=160, stream_format=pcm16_16k
+                            {sttStreamingEnabled
+                                ? 'Engine input: PCM16-LE · mono · 16 kHz'
+                                : 'Buffered input: engine-described PCM16'}
                         </div>
                     </div>
 
@@ -330,14 +348,21 @@ const PipelineForm: React.FC<PipelineFormProps> = ({ config, providers, onChange
                                 type="number"
                                 value={localConfig.options?.stt?.chunk_ms ?? 160}
                                 onChange={(e) => updateSTTOptions({ chunk_ms: parseInt(e.target.value || '160', 10) })}
-                                tooltip="How often we flush accumulated audio frames to the STT streaming sender. 160ms is a good default."
+                                tooltip={sttStreamingEnabled
+                                    ? 'How often accumulated frames are sent to streaming STT. Flux recommends 80ms; other adapters default to 160ms.'
+                                    : 'How much audio is buffered before a transcription request.'}
                             />
-                            <FormInput
-                                label="stream_format"
-                                value={localConfig.options?.stt?.stream_format ?? 'pcm16_16k'}
-                                onChange={(e) => updateSTTOptions({ stream_format: e.target.value })}
-                                tooltip="Input audio format for streaming STT. For Local STT this should usually be pcm16_16k."
-                            />
+                            {sttStreamingEnabled && (
+                                <div className="space-y-2">
+                                    <FormLabel>Streaming audio format</FormLabel>
+                                    <div className="rounded-md border border-input bg-muted/40 px-3 py-2 text-sm font-mono">
+                                        pcm16_16k · linear16 · mono
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        Managed by the engine so provider metadata always matches the audio bytes.
+                                    </p>
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>

--- a/admin_ui/frontend/src/components/config/providers/AzureProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/AzureProviderForm.tsx
@@ -161,7 +161,7 @@ const AzureProviderForm: React.FC<AzureProviderFormProps> = ({ config, onChange 
                                     />
                                     <div>
                                         <span className="block font-medium text-sm">Real-Time</span>
-                                        <span className="block text-xs text-muted-foreground">Low-latency, one-shot REST API</span>
+                                        <span className="block text-xs text-muted-foreground">Low-latency continuous Speech SDK stream</span>
                                     </div>
                                 </label>
                                 <label className="flex items-center gap-2 border p-3 rounded-lg cursor-pointer hover:bg-accent has-[:checked]:bg-accent has-[:checked]:border-primary flex-1">

--- a/admin_ui/frontend/src/pages/PipelinesPage.tsx
+++ b/admin_ui/frontend/src/pages/PipelinesPage.tsx
@@ -12,6 +12,7 @@ import { ConfigCard } from '../components/ui/ConfigCard';
 import { Modal } from '../components/ui/Modal';
 import PipelineForm from '../components/config/PipelineForm';
 import { ensureModularKey, isFullAgentProvider } from '../utils/providerNaming';
+import { normalizeSttOptions } from '../utils/sttAudioContract';
 import { usePendingChanges } from '../hooks/usePendingChanges';
 
 const PipelinesPage = () => {
@@ -78,29 +79,6 @@ const PipelinesPage = () => {
             pipeline?.options?.llm?.model ||
             '';
         return compactModelLabel(llmLabel) || 'default model';
-    };
-
-    const normalizeSttOptions = (sttKey: string, sttOptions: any) => {
-        const opts = (sttOptions && typeof sttOptions === 'object') ? sttOptions : {};
-
-        if (sttKey === 'local_stt') {
-            return {
-                streaming: true,
-                chunk_ms: 160,
-                stream_format: 'pcm16_16k',
-                mode: 'stt',
-            };
-        }
-
-        const normalized: any = {};
-        normalized.chunk_ms = typeof opts.chunk_ms === 'number' ? opts.chunk_ms : 4000;
-        if (typeof opts.response_format === 'string') normalized.response_format = opts.response_format;
-        if (typeof opts.temperature === 'number') normalized.temperature = opts.temperature;
-        if (typeof opts.language === 'string') normalized.language = opts.language;
-        if (typeof opts.prompt === 'string') normalized.prompt = opts.prompt;
-        if (opts.request_timeout_sec != null) normalized.request_timeout_sec = opts.request_timeout_sec;
-        if (opts.timeout_sec != null) normalized.timeout_sec = opts.timeout_sec;
-        return normalized;
     };
 
     useEffect(() => {
@@ -360,7 +338,10 @@ const PipelinesPage = () => {
         if (!isNewPipeline && existingData?.stt && mergedPipeline.stt && existingData.stt !== mergedPipeline.stt) {
             const existingSttOpts = (existingData.options || {}).stt || {};
             const nextSttOpts = (mergedPipeline.options || {}).stt || existingSttOpts;
-            mergedPipeline.options = { ...(mergedPipeline.options || {}), stt: normalizeSttOptions(mergedPipeline.stt, nextSttOpts) };
+            mergedPipeline.options = {
+                ...(mergedPipeline.options || {}),
+                stt: normalizeSttOptions(mergedPipeline.stt, nextSttOpts, providers),
+            };
         }
 
         // Keep only portable LLM options when LLM provider changes (avoid carrying provider-specific base_url/model).
@@ -383,7 +364,11 @@ const PipelinesPage = () => {
         // Always normalize STT options for the selected STT provider. This prevents stale cloud STT keys
         // (e.g., response_format/temperature/chunk_ms=4000) from breaking local_stt when users swap providers.
         mergedPipeline.options = { ...(mergedPipeline.options || {}) };
-        mergedPipeline.options.stt = normalizeSttOptions(mergedPipeline.stt, (mergedPipeline.options || {}).stt);
+        mergedPipeline.options.stt = normalizeSttOptions(
+            mergedPipeline.stt,
+            (mergedPipeline.options || {}).stt,
+            providers,
+        );
 
         newConfig.pipelines[pipelineName] = mergedPipeline;
 

--- a/admin_ui/frontend/src/pages/PipelinesPage.tsx
+++ b/admin_ui/frontend/src/pages/PipelinesPage.tsx
@@ -340,7 +340,9 @@ const PipelinesPage = () => {
             const nextSttOpts = (mergedPipeline.options || {}).stt || existingSttOpts;
             mergedPipeline.options = {
                 ...(mergedPipeline.options || {}),
-                stt: normalizeSttOptions(mergedPipeline.stt, nextSttOpts, providers),
+                stt: normalizeSttOptions(mergedPipeline.stt, nextSttOpts, providers, {
+                    preserveStreamingChoice: false,
+                }),
             };
         }
 

--- a/admin_ui/frontend/src/utils/sttAudioContract.test.ts
+++ b/admin_ui/frontend/src/utils/sttAudioContract.test.ts
@@ -44,6 +44,35 @@ describe('modular STT audio contract', () => {
         expect(options.chunk_ms).toBe(80);
     });
 
+    it('ignores stale buffered streaming flags when switching to optional streaming STT', () => {
+        const options = normalizeSttOptions(
+            'local_stt',
+            {
+                streaming: false,
+                chunk_ms: 4000,
+            },
+            {},
+            { preserveStreamingChoice: false }
+        );
+        expect(options).toMatchObject({
+            streaming: true,
+            chunk_ms: 160,
+            stream_format: PIPELINE_STT_STREAM_FORMAT,
+            sample_rate: PIPELINE_STT_SAMPLE_RATE_HZ,
+            mode: 'stt',
+        });
+    });
+
+    it('preserves an explicit streaming-off choice for the same optional streaming STT', () => {
+        const options = normalizeSttOptions('local_stt', {
+            streaming: false,
+            chunk_ms: 4000,
+        });
+        expect(options.streaming).toBe(false);
+        expect(options.chunk_ms).toBe(4000);
+        expect(options).not.toHaveProperty('stream_format');
+    });
+
     it('does not attach raw streaming format fields to buffered providers', () => {
         const options = normalizeSttOptions('openai_stt', {
             stream_format: 'pcm16_8k',

--- a/admin_ui/frontend/src/utils/sttAudioContract.test.ts
+++ b/admin_ui/frontend/src/utils/sttAudioContract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getSttStreamingMode,
+    normalizeSttOptions,
+    PIPELINE_STT_SAMPLE_RATE_HZ,
+    PIPELINE_STT_STREAM_FORMAT,
+} from './sttAudioContract';
+
+describe('modular STT audio contract', () => {
+    it('detects Azure alias mode from the configured variant', () => {
+        expect(getSttStreamingMode('azure_stt', { azure_stt: { variant: 'realtime' } })).toBe(
+            'optional'
+        );
+        expect(getSttStreamingMode('azure_stt', { azure_stt: { variant: 'fast' } })).toBe(
+            'buffered'
+        );
+    });
+
+    it('replaces conflicting legacy streaming metadata with the engine format', () => {
+        const options = normalizeSttOptions('azure_stt_realtime', {
+            streaming: true,
+            chunk_ms: 4000,
+            stream_format: 'pcm16_8k',
+            sample_rate: 8000,
+            language: 'zh-TW',
+        });
+        expect(options).toMatchObject({
+            streaming: true,
+            chunk_ms: 160,
+            stream_format: PIPELINE_STT_STREAM_FORMAT,
+            sample_rate: PIPELINE_STT_SAMPLE_RATE_HZ,
+            encoding: 'linear16',
+            channels: 1,
+            language: 'zh-TW',
+        });
+    });
+
+    it('forces Flux streaming and uses the provider-recommended default chunk size', () => {
+        const options = normalizeSttOptions('deepgram_flux_stt', {
+            streaming: false,
+            chunk_ms: 4000,
+        });
+        expect(options.streaming).toBe(true);
+        expect(options.chunk_ms).toBe(80);
+    });
+
+    it('does not attach raw streaming format fields to buffered providers', () => {
+        const options = normalizeSttOptions('openai_stt', {
+            stream_format: 'pcm16_8k',
+            sample_rate: 8000,
+        });
+        expect(options.streaming).toBe(false);
+        expect(options).not.toHaveProperty('stream_format');
+        expect(options).not.toHaveProperty('sample_rate');
+    });
+});

--- a/admin_ui/frontend/src/utils/sttAudioContract.ts
+++ b/admin_ui/frontend/src/utils/sttAudioContract.ts
@@ -1,0 +1,97 @@
+export type SttStreamingMode = 'buffered' | 'optional' | 'required';
+type SttOptions = Record<string, unknown>;
+type ProviderConfigMap = Record<string, { variant?: unknown } | undefined>;
+
+export const PIPELINE_STT_STREAM_FORMAT = 'pcm16_16k';
+export const PIPELINE_STT_SAMPLE_RATE_HZ = 16000;
+
+export function getSttStreamingMode(
+    sttKey: string,
+    providers: ProviderConfigMap = {}
+): SttStreamingMode {
+    const key = String(sttKey || '')
+        .trim()
+        .toLowerCase();
+    if (key === 'deepgram_flux_stt') return 'required';
+    if (key === 'local_stt' || key === 'deepgram_stt' || key === 'azure_stt_realtime') {
+        return 'optional';
+    }
+    if (key === 'azure_stt') {
+        const variant = String(providers?.azure_stt?.variant || 'realtime')
+            .trim()
+            .toLowerCase();
+        return variant === 'fast' ? 'buffered' : 'optional';
+    }
+    return 'buffered';
+}
+
+function asSttOptions(options: unknown): SttOptions {
+    return options && typeof options === 'object' && !Array.isArray(options)
+        ? (options as SttOptions)
+        : {};
+}
+
+function portableSttOptions(options: unknown): SttOptions {
+    const source = asSttOptions(options);
+    const portable: SttOptions = {};
+    for (const key of [
+        'language',
+        'prompt',
+        'request_timeout_sec',
+        'timeout_sec',
+        'response_format',
+        'temperature',
+        'timestamp_granularities',
+        'vad_silence_ms',
+        'vad_silence_timeout_ms',
+        'vad_initial_silence_timeout_ms',
+        'eot_threshold',
+        'eager_eot_threshold',
+        'eot_timeout_ms',
+    ]) {
+        if (source[key] != null) portable[key] = source[key];
+    }
+    return portable;
+}
+
+export function normalizeSttOptions(
+    sttKey: string,
+    options: unknown,
+    providers: ProviderConfigMap = {}
+): SttOptions {
+    const source = asSttOptions(options);
+    const normalized = portableSttOptions(source);
+    const mode = getSttStreamingMode(sttKey, providers);
+
+    if (mode === 'buffered') {
+        normalized.streaming = false;
+        normalized.chunk_ms =
+            typeof source.chunk_ms === 'number' && Number.isFinite(source.chunk_ms)
+                ? source.chunk_ms
+                : 4000;
+        return normalized;
+    }
+
+    const streaming = mode === 'required' ? true : source.streaming !== false;
+    normalized.streaming = streaming;
+    if (!streaming) {
+        normalized.chunk_ms =
+            typeof source.chunk_ms === 'number' && Number.isFinite(source.chunk_ms)
+                ? source.chunk_ms
+                : 4000;
+        return normalized;
+    }
+
+    const defaultChunkMs = String(sttKey || '').toLowerCase() === 'deepgram_flux_stt' ? 80 : 160;
+    const configuredChunkMs = Number(source.chunk_ms);
+    normalized.chunk_ms =
+        Number.isFinite(configuredChunkMs) && configuredChunkMs >= 80 && configuredChunkMs <= 1000
+            ? configuredChunkMs
+            : defaultChunkMs;
+    normalized.stream_format = PIPELINE_STT_STREAM_FORMAT;
+    normalized.sample_rate = PIPELINE_STT_SAMPLE_RATE_HZ;
+    normalized.encoding = 'linear16';
+    normalized.channels = 1;
+    if (String(sttKey || '').toLowerCase() === 'local_stt') normalized.mode = 'stt';
+    return normalized;
+}

--- a/admin_ui/frontend/src/utils/sttAudioContract.ts
+++ b/admin_ui/frontend/src/utils/sttAudioContract.ts
@@ -1,6 +1,9 @@
 export type SttStreamingMode = 'buffered' | 'optional' | 'required';
 type SttOptions = Record<string, unknown>;
 type ProviderConfigMap = Record<string, { variant?: unknown } | undefined>;
+type NormalizeSttOptionsConfig = {
+    preserveStreamingChoice?: boolean;
+};
 
 export const PIPELINE_STT_STREAM_FORMAT = 'pcm16_16k';
 export const PIPELINE_STT_SAMPLE_RATE_HZ = 16000;
@@ -57,11 +60,13 @@ function portableSttOptions(options: unknown): SttOptions {
 export function normalizeSttOptions(
     sttKey: string,
     options: unknown,
-    providers: ProviderConfigMap = {}
+    providers: ProviderConfigMap = {},
+    config: NormalizeSttOptionsConfig = {}
 ): SttOptions {
     const source = asSttOptions(options);
     const normalized = portableSttOptions(source);
     const mode = getSttStreamingMode(sttKey, providers);
+    const preserveStreamingChoice = config.preserveStreamingChoice !== false;
 
     if (mode === 'buffered') {
         normalized.streaming = false;
@@ -72,7 +77,7 @@ export function normalizeSttOptions(
         return normalized;
     }
 
-    const streaming = mode === 'required' ? true : source.streaming !== false;
+    const streaming = mode === 'required' ? true : !preserveStreamingChoice || source.streaming !== false;
     normalized.streaming = streaming;
     if (!streaming) {
         normalized.chunk_ms =

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -37,6 +37,12 @@ Some pipeline LLMs can be overly eager to emit `hangup_call`. A per-pipeline gua
 - `pipelines.<name>.options.llm.hangup_call_guardrail_mode`: `relaxed`/`normal`/`strict` (unset = use global hangup policy mode)
 - `pipelines.<name>.options.llm.hangup_call_guardrail_markers.end_call`: list of caller phrases that count as end-of-call intent (unset/empty = use global hangup policy defaults)
 
+Streaming modular STT uses an engine-managed raw PCM16-LE mono 16 kHz bus.
+`stream_format`, `encoding`, `sample_rate`, and `channels` are written by the
+Admin UI for clarity but are not independently negotiable. Conflicting legacy
+values are normalized at runtime and logged. Audio Profiles continue to control
+wire/full-agent negotiation and do not change the modular STT bus format.
+
 ### Golden Baselines
 See the validated configurations in `config/`:
 - `ai-agent.golden-openai.yaml` - OpenAI Realtime (monolithic, fastest)

--- a/docs/Provider-Azure-Setup.md
+++ b/docs/Provider-Azure-Setup.md
@@ -122,7 +122,7 @@ Azure STT supports two variants controlled by the `variant` field:
 
 | Variant | Method | Best For |
 |---------|--------|----------|
-| `realtime` (default) | REST POST with binary WAV | General telephony STT, low-latency single utterances |
+| `realtime` (default) | Continuous Speech SDK push stream | Live, low-latency conversations |
 | `fast` | Fast Transcription API (multipart POST) | Batch-style transcription, longer audio segments |
 
 Switch variants in YAML:

--- a/docs/Provider-Azure-Setup.md
+++ b/docs/Provider-Azure-Setup.md
@@ -96,6 +96,12 @@ pipelines:
 active_pipeline: azure_hybrid
 ```
 
+Streaming modular STT audio is normalized by the engine to headerless PCM16-LE,
+mono, at 16 kHz. The Admin UI manages this format automatically. Legacy
+`stream_format` or `sample_rate` values that conflict with the engine bus are
+ignored at runtime with a warning so Azure always receives metadata matching
+the submitted audio bytes.
+
 ### 5. Configure Asterisk Dialplan
 
 Add to `/etc/asterisk/extensions_custom.conf`:

--- a/docs/Provider-Deepgram-Setup.md
+++ b/docs/Provider-Deepgram-Setup.md
@@ -86,7 +86,7 @@ providers:
 >
 > **Valid ranges (Pydantic-enforced at config load):** `eot_threshold` 0.5–0.9, `eager_eot_threshold` 0.3–0.9, with `eager_eot_threshold` strictly less than `eot_threshold` when both are set. Out-of-range or inverted values fail fast at startup rather than becoming opaque provider-side failures.
 >
-> **Standalone Flux pipeline path (advanced)** — the standalone Flux pipeline adapter at `src/pipelines/deepgram_flux.py` (registered as `deepgram_flux_stt`) supports the same tuning knobs for hybrid pipelines (Flux STT + non-Deepgram LLM/TTS). Use this only when you need Flux STT decoupled from Deepgram's Voice Agent.
+> **Standalone Flux pipeline path (advanced)** — the standalone Flux pipeline adapter at `src/pipelines/deepgram_flux.py` (registered as `deepgram_flux_stt`) supports the same tuning knobs for hybrid pipelines (Flux STT + non-Deepgram LLM/TTS). Use this only when you need Flux STT decoupled from Deepgram's Voice Agent. The engine supplies raw `linear16`, mono, 16 kHz audio and the Admin UI defaults new Flux pipelines to Deepgram's recommended 80 ms chunk size.
 
 ### 4. Configure Asterisk Dialplan
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -81,6 +81,14 @@ from src.tools.telephony.hangup_policy import (
 
 logger = get_logger(__name__)
 
+# Modular STT uses one canonical, headerless audio bus. Transport-specific
+# audio is converted to this format before it enters the pipeline queue.
+PIPELINE_STT_SAMPLE_RATE_HZ = 16000
+PIPELINE_STT_STREAM_FORMAT = "pcm16_16k"
+PIPELINE_STT_ENCODING = "linear16"
+PIPELINE_STT_CHANNELS = 1
+PIPELINE_STT_BYTES_PER_SAMPLE = 2
+
 # -----------------------------------------------------------------------------
 # Environment variable resolution helper
 # -----------------------------------------------------------------------------
@@ -7031,10 +7039,15 @@ class Engine:
                 if q:
                     try:
                         pcm16 = pcm_bytes
-                        if pcm16 and pcm_rate != 16000:
+                        if pcm16 and pcm_rate != PIPELINE_STT_SAMPLE_RATE_HZ:
                             try:
                                 state = self._resample_state_pipeline16k.get(caller_channel_id)
-                                pcm16, state = resample_audio(pcm16, pcm_rate, 16000, state=state)
+                                pcm16, state = resample_audio(
+                                    pcm16,
+                                    pcm_rate,
+                                    PIPELINE_STT_SAMPLE_RATE_HZ,
+                                    state=state,
+                                )
                                 self._resample_state_pipeline16k[caller_channel_id] = state
                             except (TypeError, ValueError, IndexError):
                                 pcm16 = pcm_bytes
@@ -7632,10 +7645,15 @@ class Engine:
                 if q:
                     try:
                         pcm16 = pcm_bytes
-                        if pcm16 and pcm_rate != 16000:
+                        if pcm16 and pcm_rate != PIPELINE_STT_SAMPLE_RATE_HZ:
                             try:
                                 state = self._resample_state_pipeline16k.get(caller_channel_id)
-                                pcm16, state = resample_audio(pcm16, pcm_rate, 16000, state=state)
+                                pcm16, state = resample_audio(
+                                    pcm16,
+                                    pcm_rate,
+                                    PIPELINE_STT_SAMPLE_RATE_HZ,
+                                    state=state,
+                                )
                                 self._resample_state_pipeline16k[caller_channel_id] = state
                             except (TypeError, ValueError, IndexError):
                                 pcm16 = pcm_bytes
@@ -8550,7 +8568,7 @@ class Engine:
                 q = self._pipeline_queues.get(caller_channel_id)
                 if q:
                     try:
-                        q.put_nowait(pcm_16k)  # Pipeline expects PCM16@16kHz
+                        q.put_nowait(pcm_16k)  # Canonical modular STT bus.
                         logger.debug("RTP audio routed to pipeline queue", call_id=caller_channel_id, bytes=len(pcm_16k))
                     except Exception as exc:
                         logger.warning("Pipeline queue full or unavailable (RTP)", call_id=caller_channel_id, error=str(exc))
@@ -10590,10 +10608,83 @@ class Engine:
                         )
             except Exception:
                 logger.debug("Outbound custom_vars injection failed (pipeline)", call_id=call_id, exc_info=True)
+
+            # Resolve the STT runtime contract before open_call(). This is
+            # required for adapters such as Deepgram Flux that create their
+            # streaming connection during open_call rather than start_stream.
+            raw_stt_options = pipeline.stt_options or {}
+            stt_options: Dict[str, Any] = dict(raw_stt_options)
+            streaming_explicit = "streaming" in raw_stt_options
+            chunk_ms_explicit = "chunk_ms" in raw_stt_options
+            streaming_methods_available = all(
+                callable(getattr(pipeline.stt_adapter, attr, None))
+                for attr in ("start_stream", "send_audio", "iter_results", "stop_stream")
+            )
+            streaming_supported = bool(
+                getattr(pipeline.stt_adapter, "supports_streaming", False)
+                and streaming_methods_available
+            )
+
+            if getattr(pipeline, "stt_key", "") == "local_stt":
+                stt_options.setdefault("streaming", True)
+                stt_options.setdefault("mode", stt_options.get("mode") or "stt")
+                if not chunk_ms_explicit or stt_options.get("chunk_ms") in (None, "", 0):
+                    stt_options["chunk_ms"] = 160
+                if not streaming_explicit:
+                    try:
+                        if int(stt_options.get("chunk_ms", 160)) > 1000:
+                            stt_options["chunk_ms"] = 160
+                    except Exception:
+                        stt_options["chunk_ms"] = 160
+
+            requested_streaming = bool(stt_options.get("streaming", True))
+            if requested_streaming and streaming_supported:
+                configured_format = stt_options.get("stream_format")
+                configured_rate = stt_options.get("sample_rate")
+                configured_encoding = stt_options.get("encoding")
+                accepted_formats = {None, "", "pcm16", "pcm16_16k", "pcm16-16k", "linear16"}
+                accepted_encodings = {None, "", "pcm16", "pcm16le", "linear16"}
+                configured_rate_invalid = False
+                try:
+                    configured_rate_int = int(configured_rate) if configured_rate not in (None, "") else None
+                except (TypeError, ValueError):
+                    configured_rate_int = None
+                    configured_rate_invalid = True
+
+                if (
+                    str(configured_format).strip().lower() not in accepted_formats
+                    if configured_format is not None
+                    else False
+                ) or configured_rate_invalid or configured_rate_int not in (None, PIPELINE_STT_SAMPLE_RATE_HZ) or (
+                    str(configured_encoding).strip().lower() not in accepted_encodings
+                    if configured_encoding is not None
+                    else False
+                ):
+                    logger.warning(
+                        "Streaming STT configuration conflicts with canonical pipeline audio; using engine format",
+                        call_id=call_id,
+                        component=getattr(pipeline.stt_adapter, "component_key", "unknown"),
+                        configured_stream_format=configured_format,
+                        configured_sample_rate_hz=configured_rate,
+                        configured_encoding=configured_encoding,
+                        effective_stream_format=PIPELINE_STT_STREAM_FORMAT,
+                        effective_sample_rate_hz=PIPELINE_STT_SAMPLE_RATE_HZ,
+                        effective_encoding=PIPELINE_STT_ENCODING,
+                    )
+
+                # Use a per-call copy so stored pipeline configuration remains
+                # unchanged while every streaming lifecycle method sees the
+                # actual bytes carried by the engine queue.
+                stt_options.update({
+                    "stream_format": PIPELINE_STT_STREAM_FORMAT,
+                    "sample_rate": PIPELINE_STT_SAMPLE_RATE_HZ,
+                    "encoding": PIPELINE_STT_ENCODING,
+                    "channels": PIPELINE_STT_CHANNELS,
+                })
             
             # Open per-call state for adapters (best-effort)
             try:
-                await pipeline.stt_adapter.open_call(call_id, pipeline.stt_options)
+                await pipeline.stt_adapter.open_call(call_id, stt_options)
             except Exception:
                 logger.debug("STT open_call failed", call_id=call_id, exc_info=True)
             else:
@@ -10783,31 +10874,11 @@ class Engine:
                         )
                         break
 
-            # Accumulate into ~160ms chunks for STT while keeping ingestion responsive
-            bytes_per_ms = 32  # 16k Hz * 2 bytes / 1000 ms
+            # Accumulate into provider-sized chunks while keeping ingestion responsive.
+            bytes_per_ms = (
+                PIPELINE_STT_SAMPLE_RATE_HZ * PIPELINE_STT_BYTES_PER_SAMPLE // 1000
+            )
             base_commit_ms = 160
-            # NOTE: In pipeline mode, users frequently swap STT providers in the UI. Local STT is designed
-            # for low-latency streaming, but buffered cloud STT settings (e.g., chunk_ms=4000) can linger
-            # and cause queue overflows and "no transcript" behavior. Keep explicit config behavior when
-            # present, but make local_stt robust when omitted/misaligned.
-            raw_stt_options = pipeline.stt_options or {}
-            stt_options: Dict[str, Any] = dict(raw_stt_options)
-            streaming_explicit = "streaming" in raw_stt_options
-            chunk_ms_explicit = "chunk_ms" in raw_stt_options
-
-            if getattr(pipeline, "stt_key", "") == "local_stt":
-                stt_options.setdefault("streaming", True)
-                stt_options.setdefault("stream_format", stt_options.get("stream_format") or "pcm16_16k")
-                stt_options.setdefault("mode", stt_options.get("mode") or "stt")
-                if not chunk_ms_explicit or stt_options.get("chunk_ms") in (None, "", 0):
-                    stt_options["chunk_ms"] = 160
-                if not streaming_explicit:
-                    try:
-                        if int(stt_options.get("chunk_ms", 160)) > 1000:
-                            stt_options["chunk_ms"] = 160
-                    except Exception:
-                        stt_options["chunk_ms"] = 160
-
             stt_chunk_ms = int(stt_options.get("chunk_ms", base_commit_ms)) if stt_options else base_commit_ms
             commit_ms = max(stt_chunk_ms, 80)
             commit_bytes = bytes_per_ms * commit_ms
@@ -10823,10 +10894,6 @@ class Engine:
 
             use_streaming = bool(stt_options.get("streaming", True))
             if use_streaming:
-                streaming_supported = all(
-                    hasattr(pipeline.stt_adapter, attr)
-                    for attr in ("start_stream", "send_audio", "iter_results", "stop_stream")
-                )
                 if not streaming_supported:
                     logger.warning(
                         "Streaming STT requested but adapter does not support streaming APIs; falling back to chunked mode",
@@ -10834,7 +10901,7 @@ class Engine:
                         component=getattr(pipeline.stt_adapter, "component_key", "unknown"),
                     )
                     use_streaming = False
-            stream_format = stt_options.get("stream_format", "pcm16_16k")
+            stream_format = stt_options.get("stream_format", PIPELINE_STT_STREAM_FORMAT)
             if use_streaming:
                 try:
                     logger.info(
@@ -10882,7 +10949,7 @@ class Engine:
                         transcript = await pipeline.stt_adapter.transcribe(
                             call_id,
                             audio_chunk,
-                            16000,
+                            PIPELINE_STT_SAMPLE_RATE_HZ,
                             stt_options,
                         )
                     except Exception:
@@ -11939,7 +12006,12 @@ class Engine:
                 stop_called = False
 
                 try:
-                    await pipeline.stt_adapter.start_stream(call_id, stt_options)
+                    await pipeline.stt_adapter.start_stream(
+                        call_id,
+                        stt_options,
+                        sample_rate_hz=PIPELINE_STT_SAMPLE_RATE_HZ,
+                        fmt=PIPELINE_STT_STREAM_FORMAT,
+                    )
                     stt_send_task = asyncio.create_task(stt_sender())
                     stt_recv_task = asyncio.create_task(stt_receiver())
                     dialog_task = asyncio.create_task(dialog_worker())

--- a/src/pipelines/azure.py
+++ b/src/pipelines/azure.py
@@ -551,6 +551,8 @@ class AzureSTTRealtimeAdapter(STTComponent):
     Uses the official Azure Speech SDK for robust streaming and low latency.
     """
 
+    supports_streaming = True
+
     def __init__(
         self,
         component_key: str,
@@ -611,8 +613,9 @@ class AzureSTTRealtimeAdapter(STTComponent):
         self,
         call_id: str,
         options: Dict[str, Any],
-        sample_rate_hz: int = 8000,
-        fmt: str = "pcm16",
+        *,
+        sample_rate_hz: int,
+        fmt: str,
     ) -> None:
         """Initialize the Azure Speech Recognizer stream for this call."""
         if not speechsdk:
@@ -645,18 +648,13 @@ class AzureSTTRealtimeAdapter(STTComponent):
         speech_config.set_property(speechsdk.PropertyId.SpeechServiceConnection_InitialSilenceTimeoutMs, initial_timeout_ms)
 
         # 2. Setup Push Stream
-        # SDK expects 1 channel, 16-bit, native sample rate.
-        # The engine normalises pipeline audio to 16 kHz PCM upstream, so we
-        # expect sample_rate_hz to already be 16000.  Log a warning if that
-        # assumption is violated instead of silently mutating the value.
-        st_fmt = options.get("stream_format", "pcm16_16k")
-        if st_fmt == "pcm16_16k" and sample_rate_hz != 16000:
-            logger.warning(
-                "Azure STT Realtime: stream_format is pcm16_16k but received sample_rate_hz=%d; "
-                "audio quality may be degraded if bytes are not actually 16 kHz",
-                sample_rate_hz,
-                call_id=call_id,
-            )
+        # Azure PushAudioInputStream consumes raw PCM and cannot infer its
+        # format. The engine supplies the authoritative modular STT bus format.
+        normalized_fmt = str(fmt or "").strip().lower()
+        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+            raise ValueError(f"Unsupported Azure streaming STT format: {fmt!r}")
+        if int(sample_rate_hz) <= 0:
+            raise ValueError("Azure streaming STT sample_rate_hz must be positive")
 
         stream_format = speechsdk.audio.AudioStreamFormat(samples_per_second=sample_rate_hz, bits_per_sample=16, channels=1)
         push_stream = speechsdk.audio.PushAudioInputStream(stream_format=stream_format)
@@ -707,7 +705,13 @@ class AzureSTTRealtimeAdapter(STTComponent):
             "sample_rate": sample_rate_hz
         }
         
-        logger.info("Azure STT SDK Stream started", call_id=call_id)
+        logger.info(
+            "Azure STT SDK Stream started",
+            call_id=call_id,
+            stream_format=normalized_fmt,
+            sample_rate_hz=sample_rate_hz,
+            channels=1,
+        )
 
     async def send_audio(self, call_id: str, audio_bytes: bytes, fmt: str = "pcm16") -> None:
         """Push a chunk of PCM audio to the Azure SDK stream."""

--- a/src/pipelines/base.py
+++ b/src/pipelines/base.py
@@ -270,6 +270,11 @@ class Component(ABC):
 class STTComponent(Component):
     """Speech-to-text component."""
 
+    # Streaming adapters opt in explicitly. The engine must not infer support
+    # from incidental method names because buffered-only adapters share this
+    # base class.
+    supports_streaming: bool = False
+
     @abstractmethod
     async def transcribe(
         self,

--- a/src/pipelines/base.py
+++ b/src/pipelines/base.py
@@ -27,6 +27,14 @@ except ImportError:
     websockets = None
 
 
+STREAMING_STT_FORMAT_ALIASES: frozenset[str] = frozenset({
+    "pcm16",
+    "pcm16_16k",
+    "pcm16-16k",
+    "linear16",
+})
+
+
 @dataclass
 class LLMResponse:
     """Standard response from an LLM, containing text and/or tool calls."""

--- a/src/pipelines/deepgram.py
+++ b/src/pipelines/deepgram.py
@@ -23,7 +23,7 @@ import websockets
 from ..audio import convert_pcm16le_to_target_format, mulaw_to_pcm16le, resample_audio
 from ..config import AppConfig, DeepgramProviderConfig
 from ..logging_config import get_logger
-from .base import STTComponent, TTSComponent
+from .base import STREAMING_STT_FORMAT_ALIASES, STTComponent, TTSComponent
 
 logger = get_logger(__name__)
 
@@ -402,7 +402,7 @@ class DeepgramSTTAdapter(STTComponent):
             path = parsed.path.rstrip("/") + "/v1/listen"
 
         normalized_fmt = str(fmt or "").strip().lower()
-        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+        if normalized_fmt not in STREAMING_STT_FORMAT_ALIASES:
             raise ValueError(f"Unsupported Deepgram streaming STT format: {fmt!r}")
         if int(sample_rate_hz) <= 0:
             raise ValueError("Deepgram streaming STT sample_rate_hz must be positive")

--- a/src/pipelines/deepgram.py
+++ b/src/pipelines/deepgram.py
@@ -105,6 +105,8 @@ class DeepgramSTTAdapter(STTComponent):
     Note: This is separate from src/providers/deepgram.py (monolithic full agent).
     """
 
+    supports_streaming = True
+
     def __init__(
         self,
         component_key: str,
@@ -362,7 +364,14 @@ class DeepgramSTTAdapter(STTComponent):
 
     # Streaming Methods (for streaming: true mode) --------------------------------
 
-    async def start_stream(self, call_id: str, options: Dict[str, Any]) -> None:
+    async def start_stream(
+        self,
+        call_id: str,
+        options: Dict[str, Any],
+        *,
+        sample_rate_hz: int,
+        fmt: str,
+    ) -> None:
         """Open WebSocket streaming connection to Deepgram."""
         session = self._sessions.get(call_id)
         if not session:
@@ -392,12 +401,19 @@ class DeepgramSTTAdapter(STTComponent):
         else:
             path = parsed.path.rstrip("/") + "/v1/listen"
 
-        # Build query parameters
+        normalized_fmt = str(fmt or "").strip().lower()
+        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+            raise ValueError(f"Unsupported Deepgram streaming STT format: {fmt!r}")
+        if int(sample_rate_hz) <= 0:
+            raise ValueError("Deepgram streaming STT sample_rate_hz must be positive")
+
+        # Raw audio requires encoding and sample_rate query parameters that
+        # describe the bytes actually sent by the engine.
         query_params = {
             "model": merged.get("model", "nova-2"),
             "language": merged.get("language", "en-US"),
-            "encoding": merged.get("encoding", "linear16"),
-            "sample_rate": str(merged.get("sample_rate", 16000)),
+            "encoding": "linear16",
+            "sample_rate": str(sample_rate_hz),
             "channels": "1",
         }
         existing = dict(parse_qsl(parsed.query))
@@ -447,6 +463,8 @@ class DeepgramSTTAdapter(STTComponent):
             "Deepgram STT streaming session opened",
             call_id=call_id,
             model=merged.get("model"),
+            encoding="linear16",
+            sample_rate_hz=sample_rate_hz,
         )
 
     async def send_audio(

--- a/src/pipelines/deepgram_flux.py
+++ b/src/pipelines/deepgram_flux.py
@@ -30,7 +30,7 @@ import websockets
 
 from ..config import AppConfig, DeepgramProviderConfig
 from ..logging_config import get_logger
-from .base import STTComponent
+from .base import STREAMING_STT_FORMAT_ALIASES, STTComponent
 
 logger = get_logger(__name__)
 
@@ -275,7 +275,7 @@ class DeepgramFluxSTTAdapter(STTComponent):
         For Flux, the stream is already active after open_call, so this is a no-op.
         """
         normalized_fmt = str(fmt or "").strip().lower()
-        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+        if normalized_fmt not in STREAMING_STT_FORMAT_ALIASES:
             raise ValueError(f"Unsupported Deepgram Flux streaming STT format: {fmt!r}")
         session = self._sessions.get(call_id)
         if not session:

--- a/src/pipelines/deepgram_flux.py
+++ b/src/pipelines/deepgram_flux.py
@@ -85,6 +85,8 @@ class DeepgramFluxSTTAdapter(STTComponent):
     - Turn detection via EndOfTurn events
     - Optional EagerEndOfTurn for early LLM triggering
     """
+
+    supports_streaming = True
     
     def __init__(
         self,
@@ -258,20 +260,41 @@ class DeepgramFluxSTTAdapter(STTComponent):
             session_id=session.session_id,
         )
     
-    async def start_stream(self, call_id: str, options: Dict[str, Any]) -> None:
+    async def start_stream(
+        self,
+        call_id: str,
+        options: Dict[str, Any],
+        *,
+        sample_rate_hz: int,
+        fmt: str,
+    ) -> None:
         """
         Start streaming session (already opened in open_call).
         
         This method is called by the pipeline runner when using streaming mode.
         For Flux, the stream is already active after open_call, so this is a no-op.
         """
+        normalized_fmt = str(fmt or "").strip().lower()
+        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+            raise ValueError(f"Unsupported Deepgram Flux streaming STT format: {fmt!r}")
         session = self._sessions.get(call_id)
-        if session:
-            logger.debug(
-                "Deepgram Flux stream already active",
-                call_id=call_id,
-                session_id=session.session_id,
+        if not session:
+            raise RuntimeError(f"Deepgram Flux STT session not found for call {call_id}")
+        declared_rate = int(session.options.get("sample_rate", 0) or 0)
+        declared_encoding = str(session.options.get("encoding", "")).strip().lower()
+        if declared_rate != int(sample_rate_hz) or declared_encoding != "linear16":
+            raise RuntimeError(
+                "Deepgram Flux session audio format does not match the engine pipeline bus "
+                f"(declared={declared_encoding}@{declared_rate}, "
+                f"engine=linear16@{sample_rate_hz})"
             )
+        logger.debug(
+            "Deepgram Flux stream already active",
+            call_id=call_id,
+            session_id=session.session_id,
+            encoding=declared_encoding,
+            sample_rate_hz=declared_rate,
+        )
     
     async def send_audio(
         self,

--- a/src/pipelines/local.py
+++ b/src/pipelines/local.py
@@ -784,7 +784,7 @@ class LocalSTTAdapter(_LocalAdapterBase, STTComponent):
         if not audio:
             return audio
         fmt = fmt.lower()
-        if fmt in {"pcm16", "pcm16_16k", "pcm16-16k"}:
+        if fmt in STREAMING_STT_FORMAT_ALIASES:
             return audio
         if fmt in {"pcm16_8k", "pcm16-8k"}:
             state = self._resample_states.get(call_id)

--- a/src/pipelines/local.py
+++ b/src/pipelines/local.py
@@ -520,6 +520,8 @@ class _LocalAdapterBase:
 class LocalSTTAdapter(_LocalAdapterBase, STTComponent):
     """# Milestone7: STT adapter backed by the local AI server."""
 
+    supports_streaming = True
+
     def __init__(
         self,
         component_key: str,
@@ -540,7 +542,18 @@ class LocalSTTAdapter(_LocalAdapterBase, STTComponent):
         self,
         call_id: str,
         options: Optional[Dict[str, Any]] = None,
+        *,
+        sample_rate_hz: int,
+        fmt: str,
     ) -> None:
+        normalized_fmt = str(fmt or "").strip().lower()
+        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+            raise ValueError(f"Unsupported Local streaming STT format: {fmt!r}")
+        if int(sample_rate_hz) != 16000:
+            raise ValueError(
+                "Local streaming STT requires the canonical 16000 Hz pipeline bus "
+                f"(received {sample_rate_hz})"
+            )
         runtime_options = options or {}
         session = await self._ensure_session(call_id, runtime_options)
         if session.send_lock is None:
@@ -557,6 +570,8 @@ class LocalSTTAdapter(_LocalAdapterBase, STTComponent):
             "Local STT streaming started",
             component=self.component_key,
             call_id=call_id,
+            stream_format=normalized_fmt,
+            sample_rate_hz=sample_rate_hz,
         )
 
     async def send_audio(

--- a/src/pipelines/local.py
+++ b/src/pipelines/local.py
@@ -27,7 +27,13 @@ from ..config import AppConfig, LocalProviderConfig
 _MAX_RECONNECT_ATTEMPTS = 3
 _RECONNECT_DELAY_BASE_SEC = 0.5
 from ..logging_config import get_logger
-from .base import LLMComponent, LLMResponse, STTComponent, TTSComponent
+from .base import (
+    LLMComponent,
+    LLMResponse,
+    STREAMING_STT_FORMAT_ALIASES,
+    STTComponent,
+    TTSComponent,
+)
 
 logger = get_logger(__name__)
 
@@ -547,7 +553,7 @@ class LocalSTTAdapter(_LocalAdapterBase, STTComponent):
         fmt: str,
     ) -> None:
         normalized_fmt = str(fmt or "").strip().lower()
-        if normalized_fmt not in {"pcm16", "pcm16_16k", "pcm16-16k", "linear16"}:
+        if normalized_fmt not in STREAMING_STT_FORMAT_ALIASES:
             raise ValueError(f"Unsupported Local streaming STT format: {fmt!r}")
         if int(sample_rate_hz) != 16000:
             raise ValueError(

--- a/tests/test_pipeline_azure_streaming.py
+++ b/tests/test_pipeline_azure_streaming.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import ClassVar
 
 import pytest
 
@@ -30,7 +31,7 @@ class _SpeechConfig:
 
 
 class _AudioStreamFormat:
-    created = []
+    created: ClassVar[list] = []
 
     def __init__(self, *, samples_per_second, bits_per_sample, channels):
         self.samples_per_second = samples_per_second

--- a/tests/test_pipeline_azure_streaming.py
+++ b/tests/test_pipeline_azure_streaming.py
@@ -1,0 +1,148 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.config import AppConfig, AzureSTTProviderConfig
+from src.pipelines import azure as azure_module
+from src.pipelines.azure import AzureSTTRealtimeAdapter
+
+
+class _Signal:
+    def connect(self, callback):
+        self.callback = callback
+
+
+class _CompletedOperation:
+    def get(self):
+        return None
+
+
+class _SpeechConfig:
+    def __init__(self, subscription, region):
+        self.subscription = subscription
+        self.region = region
+        self.properties = {}
+        self.speech_recognition_language = None
+        self.output_format = None
+
+    def set_property(self, key, value):
+        self.properties[key] = value
+
+
+class _AudioStreamFormat:
+    created = []
+
+    def __init__(self, *, samples_per_second, bits_per_sample, channels):
+        self.samples_per_second = samples_per_second
+        self.bits_per_sample = bits_per_sample
+        self.channels = channels
+        self.__class__.created.append(self)
+
+
+class _PushAudioInputStream:
+    def __init__(self, *, stream_format):
+        self.stream_format = stream_format
+        self.writes = []
+        self.closed = False
+
+    def write(self, data):
+        self.writes.append(bytes(data))
+
+    def close(self):
+        self.closed = True
+
+
+class _AudioConfig:
+    def __init__(self, *, stream):
+        self.stream = stream
+
+
+class _SpeechRecognizer:
+    def __init__(self, *, speech_config, audio_config):
+        self.speech_config = speech_config
+        self.audio_config = audio_config
+        self.recognized = _Signal()
+        self.canceled = _Signal()
+        self.session_stopped = _Signal()
+
+    def start_continuous_recognition_async(self):
+        return _CompletedOperation()
+
+    def stop_continuous_recognition(self):
+        return None
+
+
+def _fake_speechsdk():
+    return SimpleNamespace(
+        SpeechConfig=_SpeechConfig,
+        SpeechRecognizer=_SpeechRecognizer,
+        OutputFormat=SimpleNamespace(Detailed="detailed"),
+        PropertyId=SimpleNamespace(
+            SpeechServiceConnection_EndSilenceTimeoutMs="end",
+            Speech_SegmentationSilenceTimeoutMs="segmentation",
+            SpeechServiceConnection_InitialSilenceTimeoutMs="initial",
+        ),
+        ResultReason=SimpleNamespace(RecognizedSpeech="recognized"),
+        CancellationReason=SimpleNamespace(Error="error"),
+        audio=SimpleNamespace(
+            AudioStreamFormat=_AudioStreamFormat,
+            PushAudioInputStream=_PushAudioInputStream,
+            AudioConfig=_AudioConfig,
+        ),
+    )
+
+
+def _app_config():
+    return AppConfig(
+        default_provider="local",
+        providers={"local": {"enabled": True}},
+        asterisk={"host": "127.0.0.1", "username": "u", "password": "p"},
+        llm={"initial_greeting": "", "prompt": "prompt", "model": "gpt-4o"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_azure_realtime_declares_the_engine_stream_format(monkeypatch):
+    _AudioStreamFormat.created.clear()
+    monkeypatch.setattr(azure_module, "speechsdk", _fake_speechsdk())
+    adapter = AzureSTTRealtimeAdapter(
+        "azure_stt_realtime",
+        _app_config(),
+        AzureSTTProviderConfig(api_key="test-key", region="eastus", language="zh-TW"),
+        {"stream_format": "pcm16_8k", "sample_rate": 8000},
+    )
+
+    await adapter.open_call("call-1", {"stream_format": "pcm16_16k", "sample_rate": 16000})
+    await adapter.start_stream(
+        "call-1",
+        {"stream_format": "pcm16_16k", "sample_rate": 16000},
+        sample_rate_hz=16000,
+        fmt="pcm16_16k",
+    )
+
+    created = _AudioStreamFormat.created[-1]
+    assert created.samples_per_second == 16000
+    assert created.bits_per_sample == 16
+    assert created.channels == 1
+    assert adapter._active_sessions["call-1"]["sample_rate"] == 16000
+
+    await adapter.send_audio("call-1", b"\x00\x00" * 160)
+    assert adapter._active_sessions["call-1"]["push_stream"].writes
+    await adapter.close_call("call-1")
+
+
+@pytest.mark.asyncio
+async def test_azure_realtime_rejects_unknown_stream_format(monkeypatch):
+    monkeypatch.setattr(azure_module, "speechsdk", _fake_speechsdk())
+    adapter = AzureSTTRealtimeAdapter(
+        "azure_stt_realtime",
+        _app_config(),
+        AzureSTTProviderConfig(api_key="test-key"),
+    )
+    with pytest.raises(ValueError, match="Unsupported Azure streaming STT format"):
+        await adapter.start_stream(
+            "call-2",
+            {},
+            sample_rate_hz=16000,
+            fmt="mulaw8k",
+        )

--- a/tests/test_pipeline_deepgram_adapters.py
+++ b/tests/test_pipeline_deepgram_adapters.py
@@ -5,6 +5,7 @@ import pytest
 
 from src.audio.resampler import convert_pcm16le_to_target_format
 from src.config import AppConfig, DeepgramProviderConfig
+from src.pipelines import deepgram as deepgram_module
 from src.pipelines.deepgram import DeepgramSTTAdapter, DeepgramTTSAdapter
 from src.pipelines.orchestrator import PipelineOrchestrator
 
@@ -60,6 +61,15 @@ class _MockWebSocket:
     async def close(self):
         self.closed = True
 
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self._queue.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item
+
 
 class _FakeJsonResponse:
     def __init__(self, payload: dict, status: int = 200):
@@ -92,6 +102,38 @@ class _FakeHttpSession:
 
     async def close(self):
         self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_streaming_url_uses_authoritative_engine_audio_format(monkeypatch):
+    config = _build_app_config()
+    provider_config = DeepgramProviderConfig(**config.providers["deepgram"])
+    adapter = DeepgramSTTAdapter(
+        "deepgram_stt",
+        config,
+        provider_config,
+        {"sample_rate": 8000, "encoding": "mulaw"},
+        session_factory=lambda: _FakeHttpSession({}),
+    )
+    await adapter.open_call("call-stream", {"sample_rate": 16000, "encoding": "linear16"})
+
+    captured = {}
+
+    async def fake_connect(url, **kwargs):
+        captured["url"] = url
+        return _MockWebSocket()
+
+    monkeypatch.setattr(deepgram_module.websockets, "connect", fake_connect)
+    await adapter.start_stream(
+        "call-stream",
+        {"sample_rate": 8000, "encoding": "mulaw"},
+        sample_rate_hz=16000,
+        fmt="pcm16_16k",
+    )
+
+    assert "encoding=linear16" in captured["url"]
+    assert "sample_rate=16000" in captured["url"]
+    await adapter.close_call("call-stream")
 
 
 class _FakeResponse:

--- a/tests/test_pipeline_deepgram_flux_streaming.py
+++ b/tests/test_pipeline_deepgram_flux_streaming.py
@@ -1,0 +1,81 @@
+import asyncio
+
+import pytest
+
+from src.config import AppConfig, DeepgramProviderConfig
+from src.pipelines import deepgram_flux as flux_module
+from src.pipelines.deepgram_flux import DeepgramFluxSTTAdapter
+
+
+class _MockFluxWebSocket:
+    def __init__(self):
+        self.closed = False
+        self._queue = asyncio.Queue()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        value = await self._queue.get()
+        if value is None:
+            raise StopAsyncIteration
+        return value
+
+    async def send(self, data):
+        return None
+
+    async def close(self):
+        self.closed = True
+        await self._queue.put(None)
+
+
+def _app_config():
+    return AppConfig(
+        default_provider="deepgram",
+        providers={
+            "deepgram": {
+                "api_key": "test-key",
+                "base_url": "https://api.deepgram.com",
+                "input_encoding": "linear16",
+                "input_sample_rate_hz": 8000,
+            }
+        },
+        asterisk={"host": "127.0.0.1", "username": "u", "password": "p"},
+        llm={"initial_greeting": "", "prompt": "prompt", "model": "gpt-4o"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_flux_connection_and_start_use_the_same_engine_audio_format(monkeypatch):
+    config = _app_config()
+    provider = DeepgramProviderConfig(**config.providers["deepgram"])
+    adapter = DeepgramFluxSTTAdapter(
+        "deepgram_flux_stt",
+        config,
+        provider,
+        {"sample_rate": 8000, "encoding": "mulaw"},
+    )
+    captured = {}
+
+    async def fake_connect(url, **kwargs):
+        captured["url"] = url
+        return _MockFluxWebSocket()
+
+    monkeypatch.setattr(flux_module.websockets, "connect", fake_connect)
+    runtime_options = {
+        "sample_rate": 16000,
+        "encoding": "linear16",
+        "stream_format": "pcm16_16k",
+    }
+    await adapter.open_call("call-flux", runtime_options)
+    await adapter.start_stream(
+        "call-flux",
+        runtime_options,
+        sample_rate_hz=16000,
+        fmt="pcm16_16k",
+    )
+
+    assert "/v2/listen" in captured["url"]
+    assert "encoding=linear16" in captured["url"]
+    assert "sample_rate=16000" in captured["url"]
+    await adapter.close_call("call-flux")

--- a/tests/test_pipeline_local_adapters.py
+++ b/tests/test_pipeline_local_adapters.py
@@ -137,17 +137,18 @@ async def test_local_stt_stream_accepts_linear16_alias(monkeypatch):
         sample_rate_hz=16000,
         fmt="linear16",
     )
-    audio_buffer = b"\x01\x02" * 160
-    await adapter.send_audio("call-linear16", audio_buffer, fmt="linear16")
+    try:
+        audio_buffer = b"\x01\x02" * 160
+        await adapter.send_audio("call-linear16", audio_buffer, fmt="linear16")
 
-    audio_message = json.loads(mock_ws.sent[-1])
-    assert audio_message["type"] == "audio"
-    assert audio_message["mode"] == "stt"
-    assert audio_message["rate"] == 16000
-    assert audio_message["format"] == "pcm16le"
-    assert base64.b64decode(audio_message["data"]) == audio_buffer
-
-    await adapter.close_call("call-linear16")
+        audio_message = json.loads(mock_ws.sent[-1])
+        assert audio_message["type"] == "audio"
+        assert audio_message["mode"] == "stt"
+        assert audio_message["rate"] == 16000
+        assert audio_message["format"] == "pcm16le"
+        assert base64.b64decode(audio_message["data"]) == audio_buffer
+    finally:
+        await adapter.close_call("call-linear16")
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_local_adapters.py
+++ b/tests/test_pipeline_local_adapters.py
@@ -119,6 +119,38 @@ async def test_local_stt_adapter_transcribes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_local_stt_stream_accepts_linear16_alias(monkeypatch):
+    app_config = _build_app_config()
+    provider_config = LocalProviderConfig(**app_config.providers["local"])
+    adapter = LocalSTTAdapter("local_stt", app_config, provider_config, {"mode": "stt"})
+
+    mock_ws = _MockWebSocket()
+
+    async def fake_connect(*_args, **_kwargs):
+        return mock_ws
+
+    monkeypatch.setattr("src.pipelines.local.websockets.connect", fake_connect)
+
+    await adapter.start_stream(
+        "call-linear16",
+        {"mode": "stt"},
+        sample_rate_hz=16000,
+        fmt="linear16",
+    )
+    audio_buffer = b"\x01\x02" * 160
+    await adapter.send_audio("call-linear16", audio_buffer, fmt="linear16")
+
+    audio_message = json.loads(mock_ws.sent[-1])
+    assert audio_message["type"] == "audio"
+    assert audio_message["mode"] == "stt"
+    assert audio_message["rate"] == 16000
+    assert audio_message["format"] == "pcm16le"
+    assert base64.b64decode(audio_message["data"]) == audio_buffer
+
+    await adapter.close_call("call-linear16")
+
+
+@pytest.mark.asyncio
 async def test_local_llm_adapter_generate(monkeypatch):
     app_config = _build_app_config()
     provider_config = LocalProviderConfig(**app_config.providers["local"])

--- a/tests/test_pipeline_runner_lifecycle.py
+++ b/tests/test_pipeline_runner_lifecycle.py
@@ -11,6 +11,42 @@ class _StubSTT(STTComponent):
         return "hi"
 
 
+class _StreamingStubSTT(STTComponent):
+    supports_streaming = True
+
+    def __init__(self):
+        self.open_options = None
+        self.start_options = None
+        self.start_format = None
+        self.sent = []
+        self.started = asyncio.Event()
+        self.audio_sent = asyncio.Event()
+        self._keep_receiving = asyncio.Event()
+
+    async def open_call(self, call_id, options):
+        self.open_options = dict(options)
+
+    async def transcribe(self, call_id, audio_pcm16, sample_rate_hz, options):
+        raise AssertionError("streaming adapter should not use buffered transcription")
+
+    async def start_stream(self, call_id, options, *, sample_rate_hz, fmt):
+        self.start_options = dict(options)
+        self.start_format = (sample_rate_hz, fmt)
+        self.started.set()
+
+    async def send_audio(self, call_id, audio, *, fmt="pcm16_16k"):
+        self.sent.append((bytes(audio), fmt))
+        self.audio_sent.set()
+
+    async def iter_results(self, call_id):
+        await self._keep_receiving.wait()
+        if False:
+            yield ""
+
+    async def stop_stream(self, call_id):
+        self._keep_receiving.set()
+
+
 class _StubLLM(LLMComponent):
     async def generate(self, call_id, transcript, context, options):
         return "hello"
@@ -22,12 +58,13 @@ class _StubTTS(TTSComponent):
 
 
 class _StubResolution:
-    def __init__(self):
+    def __init__(self, stt_adapter=None, stt_options=None):
         self.pipeline_name = "stub"
-        self.stt_adapter = _StubSTT()
+        self.stt_key = "stub_stt"
+        self.stt_adapter = stt_adapter or _StubSTT()
         self.llm_adapter = _StubLLM()
         self.tts_adapter = _StubTTS()
-        self.stt_options = {}
+        self.stt_options = stt_options or {}
         self.llm_options = {}
         self.tts_options = {}
         self.prepared = True
@@ -82,3 +119,50 @@ async def test_pipeline_runner_lifecycle(monkeypatch):
     assert call_id not in engine._pipeline_tasks
     assert call_id not in engine._pipeline_queues
     assert call_id not in engine._pipeline_forced
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runner_uses_canonical_streaming_stt_audio_contract(monkeypatch):
+    config_data = {
+        "default_provider": "local",
+        "providers": {"local": {"enabled": True}},
+        "asterisk": {"host": "127.0.0.1", "port": 8088, "username": "u", "password": "p", "app_name": "ai-voice-agent"},
+        "llm": {"initial_greeting": "", "prompt": "You are helpful", "model": "gpt-4o"},
+        "pipelines": {"streaming": {}},
+        "active_pipeline": "streaming",
+        "audio_transport": "externalmedia",
+    }
+    engine = Engine(AppConfig(**config_data))
+    engine.pipeline_orchestrator._started = True
+    stt = _StreamingStubSTT()
+    configured_options = {
+        "streaming": True,
+        "chunk_ms": 80,
+        "stream_format": "pcm16_8k",
+        "sample_rate": 8000,
+        "encoding": "mulaw",
+    }
+    resolution = _StubResolution(stt_adapter=stt, stt_options=configured_options)
+    monkeypatch.setattr(engine.pipeline_orchestrator, "get_pipeline", lambda *args, **kwargs: resolution)
+
+    from src.core.models import CallSession
+    call_id = "call-streaming-format"
+    session = CallSession(call_id=call_id, caller_channel_id=call_id)
+    session.pipeline_name = "streaming"
+    await engine.session_store.upsert_call(session)
+    await engine._ensure_pipeline_runner(session, forced=True)
+
+    await asyncio.wait_for(stt.started.wait(), timeout=2)
+    assert stt.open_options["stream_format"] == "pcm16_16k"
+    assert stt.open_options["sample_rate"] == 16000
+    assert stt.open_options["encoding"] == "linear16"
+    assert stt.start_options == stt.open_options
+    assert stt.start_format == (16000, "pcm16_16k")
+    assert configured_options["stream_format"] == "pcm16_8k"  # Stored config was not mutated.
+
+    await engine._pipeline_queues[call_id].put(b"\x00\x00" * 1280)  # 80 ms at 16 kHz PCM16.
+    await asyncio.wait_for(stt.audio_sent.wait(), timeout=2)
+    assert stt.sent[0][1] == "pcm16_16k"
+    assert len(stt.sent[0][0]) == 2560
+
+    await engine._cleanup_call(call_id)


### PR DESCRIPTION
## Summary

Fixes #458.

This aligns the modular streaming STT audio contract across backend, frontend, and docs so the metadata sent to streaming STT providers matches the bytes produced by the engine. The modular STT bus is now treated as canonical raw PCM16-LE, mono, 16 kHz.

## Root cause

The engine normalizes inbound pipeline audio to 16 kHz PCM before placing it on the modular STT queue, but the streaming STT lifecycle did not pass authoritative sample-rate/format metadata into provider start calls. Azure Realtime could therefore declare/default an 8 kHz stream while receiving 16 kHz audio, which caused non-English speech such as zh-TW to be decoded incorrectly.

## Scope note

Although #458 was reported through Azure Realtime, the failing boundary is the shared modular streaming STT contract: the engine queue carries PCM16-LE mono 16 kHz while provider adapters and UI settings could still declare conflicting stream metadata. This PR intentionally updates the affected streaming STT providers, Admin UI normalization, and docs together so Azure, Deepgram streaming, Deepgram Flux, and Local streaming STT all negotiate the same contract and do not regress independently. Buffered STT and full-agent Audio Profile negotiation remain separate.

## What changed

- Added canonical modular STT runtime constants in the engine.
- Normalized per-call streaming STT options before adapter open/start.
- Passed explicit sample_rate_hz=16000 and fmt=pcm16_16k into streaming STT start calls.
- Updated Azure Realtime, Deepgram streaming, Deepgram Flux, and Local streaming STT adapters to advertise/validate the canonical stream contract.
- Added supports_streaming metadata to STT adapters.
- Updated Admin UI pipeline handling so streaming STT displays and saves the canonical PCM16-LE mono 16 kHz contract instead of exposing a conflicting editable stream_format.
- Updated Azure/Deepgram/config docs to explain that Audio Profiles control wire/full-agent negotiation, while modular streaming STT uses the engine-normalized 16 kHz bus.

## Reporter validation

The reporter tested the branch on Azure zh-TW and confirmed the original bug is resolved:

- Chinese no longer transcribes as English phonetic approximations.
- Azure startup logs show stream_format=pcm16_16k and sample_rate_hz=16000.
- English smoke test did not show a broad regression.

They also observed slight first-syllable clipping, which appears to be a separate first-chunk / stream-start / barge-in timing issue. I asked for clarification on whether the phrases were spoken after greeting completion or during barge-in so we can track that separately.

## Validation

Backend:

- Targeted backend suite: 129 passed, 3 warnings.
- Full backend suite: 1268 passed, 6 skipped, 31 warnings. Two unrelated RTP socket tests failed in the local sandbox with PermissionError: [Errno 1] Operation not permitted on local socket binding.

Frontend:

- Frontend tests: 71 passed.
- Frontend build passed.
- Scoped ESLint on touched files passed. Full repository lint still has pre-existing unrelated warnings/failures.

Live provider validation:

- Azure zh-TW validation completed by reporter on this branch.
- Deepgram/Flux live validation was not run locally because credentials are not configured.

## Regression risk

Low-to-moderate. The change is intentionally scoped to modular streaming STT metadata and UI normalization. It should reduce risk for Azure, Deepgram, Deepgram Flux, and Local streaming STT by making the provider declaration match the actual engine audio. Buffered STT and full-agent Audio Profile negotiation are left separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canonical modular STT streaming contract (mono, 16 kHz PCM16) and standardized engine-managed streaming end-to-end.
  * Admin UI now dynamically changes STT streaming controls (buffered info vs optional/required toggle) based on adapter capabilities.

* **Bug Fixes**
  * Improved STT option normalization to resolve/ignore legacy or conflicting audio metadata.
  * Strengthened streaming adapter validation and made streaming requests consistently use authoritative audio parameters.

* **Documentation**
  * Clarified streaming bus format and updated Azure/Deepgram setup guidance.

* **Tests**
  * Added coverage for streaming mode mapping, option normalization, and streaming URL/audio-format correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
