### PR TITLE
feat(admin-ui): in-product donation support (Ko-fi / GitHub Sponsors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reserved names and invalid tool shapes, and are covered by the Admin backend
   CI suite.
 - **In-product donation support (Ko-fi / GitHub Sponsors)** (`admin_ui/frontend`): a
-  persistent "Support on Ko-fi" / "Sponsor" link in the sidebar Support group, plus an
-  earned, dismissible reminder banner on the Dashboard that appears on call-count
-  milestones (10/25/50/100/200/500/1000, then every +1000) or after 30 days, with
-  "Maybe later" (30-day snooze) / "Don't show again" (permanent). Local links only — no
+  persistent "Support on Ko-fi" / "Sponsor" link in the sidebar Support group, plus a
+  gentle, dismissible reminder banner on the Dashboard. The banner first appears once the
+  install has handled a call (or after 3 days), then on a weekly cadence; its buttons are
+  "Support on Ko-fi" / "Sponsor" (snooze 1 week), "I already donated" (snooze 3 months),
+  "Maybe later" (1 week), and "Don't show again" (permanent). Local links only — no
   embedded third-party script, no analytics, and no Ko-fi/GitHub network traffic unless
-  the operator clicks. Dismissal state is per-browser (localStorage/sessionStorage).
+  the operator clicks. Dismissal/snooze state is per-browser (localStorage/sessionStorage).
   Eligibility logic, the hook's storage effects, and the banner are unit-tested (Vitest).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gentle, dismissible reminder banner on the Dashboard. The banner first appears once the
   install has handled a call (or after 3 days), then on a weekly cadence; its buttons are
   "Support on Ko-fi" / "Sponsor" (snooze 1 week), "I already donated" (snooze 3 months),
-  "Maybe later" (1 week), and "Don't show again" (permanent). Local links only — no
+  "Maybe later" (1 week), and "Don't show again" (a quick "really?" confirm → keep reminders for ~1 month, or hide permanently). Local links only — no
   embedded third-party script, no analytics, and no Ko-fi/GitHub network traffic unless
   the operator clicks. Dismissal/snooze state is per-browser (localStorage/sessionStorage).
   Eligibility logic, the hook's storage effects, and the banner are unit-tested (Vitest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same validated local-override persistence path as the raw YAML editor, reject
   reserved names and invalid tool shapes, and are covered by the Admin backend
   CI suite.
+- **In-product donation support (Ko-fi / GitHub Sponsors)** (`admin_ui/frontend`): a
+  persistent "Support on Ko-fi" / "Sponsor" link in the sidebar Support group, plus an
+  earned, dismissible reminder banner on the Dashboard that appears on call-count
+  milestones (10/25/50/100/200/500/1000, then every +1000) or after 30 days, with
+  "Maybe later" (30-day snooze) / "Don't show again" (permanent). Local links only — no
+  embedded third-party script, no analytics, and no Ko-fi/GitHub network traffic unless
+  the operator clicks. Dismissal state is per-browser (localStorage/sessionStorage).
+  Eligibility logic, the hook's storage effects, and the banner are unit-tested (Vitest).
 
 ### Fixed
 

--- a/admin_ui/frontend/src/components/DonationBanner.test.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DonationBanner from './DonationBanner';
+import { KOFI_URL, SPONSORS_URL } from '../config/donation';
+
+const handlers = () => ({ onLater: vi.fn(), onDismiss: vi.fn(), onDonate: vi.fn() });
+
+describe('DonationBanner', () => {
+  it('renders the call count when provided', () => {
+    render(<DonationBanner callCount={1234} {...handlers()} />);
+    expect(screen.getByText(/1,234 calls/)).toBeInTheDocument();
+  });
+
+  it('uses generic copy when count is absent', () => {
+    render(<DonationBanner {...handlers()} />);
+    expect(screen.getByText(/Thanks for running AVA/)).toBeInTheDocument();
+  });
+
+  it('Ko-fi link has correct href, target and rel', () => {
+    render(<DonationBanner callCount={10} {...handlers()} />);
+    const link = screen.getByRole('link', { name: 'Support AVA on Ko-fi' });
+    expect(link).toHaveAttribute('href', KOFI_URL);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('Sponsor link points at GitHub Sponsors', () => {
+    render(<DonationBanner callCount={10} {...handlers()} />);
+    expect(screen.getByRole('link', { name: 'Sponsor AVA on GitHub' })).toHaveAttribute(
+      'href',
+      SPONSORS_URL,
+    );
+  });
+
+  it('fires the callbacks', async () => {
+    const h = handlers();
+    render(<DonationBanner callCount={10} {...h} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Maybe later' }));
+    expect(h.onLater).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: "Don't show again" }));
+    expect(h.onDismiss).toHaveBeenCalled();
+    await user.click(screen.getByRole('link', { name: 'Support AVA on Ko-fi' }));
+    expect(h.onDonate).toHaveBeenCalled();
+  });
+});

--- a/admin_ui/frontend/src/components/DonationBanner.test.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.test.tsx
@@ -45,5 +45,7 @@ describe('DonationBanner', () => {
     expect(h.onDismiss).toHaveBeenCalled();
     await user.click(screen.getByRole('link', { name: 'Support AVA on Ko-fi' }));
     expect(h.onDonate).toHaveBeenCalled();
+    await user.click(screen.getByRole('link', { name: 'Sponsor AVA on GitHub' }));
+    expect(h.onDonate).toHaveBeenCalledTimes(2);
   });
 });

--- a/admin_ui/frontend/src/components/DonationBanner.test.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.test.tsx
@@ -25,6 +25,11 @@ describe('DonationBanner', () => {
     expect(screen.getByText(/Thanks for running AVA/)).toBeInTheDocument();
   });
 
+  it('uses generic copy for a zero-call install', () => {
+    render(<DonationBanner callCount={0} {...handlers()} />);
+    expect(screen.getByText(/Thanks for running AVA/)).toBeInTheDocument();
+  });
+
   it('Ko-fi link has correct href, target and rel', () => {
     render(<DonationBanner callCount={10} {...handlers()} />);
     const link = screen.getByRole('link', { name: 'Support AVA on Ko-fi' });

--- a/admin_ui/frontend/src/components/DonationBanner.test.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
-import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
 import DonationBanner from './DonationBanner';
 import { KOFI_URL, SPONSORS_URL } from '../config/donation';
 
-const handlers = () => ({ onLater: vi.fn(), onDismiss: vi.fn(), onDonate: vi.fn(), onAlreadyDonated: vi.fn() });
+const handlers = () => ({
+  onLater: vi.fn(),
+  onDismiss: vi.fn(),
+  onDonate: vi.fn(),
+  onAlreadyDonated: vi.fn(),
+  onKeepReminders: vi.fn(),
+});
 
 describe('DonationBanner', () => {
   it('renders the call count when provided', () => {
@@ -35,25 +41,51 @@ describe('DonationBanner', () => {
     );
   });
 
-  it('fires the callbacks', async () => {
+  it('both donate links call onDonate', async () => {
     const h = handlers();
     render(<DonationBanner callCount={10} {...h} />);
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: 'Maybe later' }));
-    expect(h.onLater).toHaveBeenCalled();
-    await user.click(screen.getByRole('button', { name: "Don't show again" }));
-    expect(h.onDismiss).toHaveBeenCalled();
     await user.click(screen.getByRole('link', { name: 'Support AVA on Ko-fi' }));
-    expect(h.onDonate).toHaveBeenCalled();
     await user.click(screen.getByRole('link', { name: 'Sponsor AVA on GitHub' }));
     expect(h.onDonate).toHaveBeenCalledTimes(2);
   });
 
-  it('fires onAlreadyDonated', async () => {
+  it('fires onAlreadyDonated and onLater', async () => {
     const h = handlers();
     render(<DonationBanner callCount={10} {...h} />);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: 'I already donated' }));
     expect(h.onAlreadyDonated).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Maybe later' }));
+    expect(h.onLater).toHaveBeenCalled();
+  });
+
+  it("Don't show again opens a confirm instead of dismissing immediately", async () => {
+    const h = handlers();
+    render(<DonationBanner callCount={10} {...h} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: "Don't show again" }));
+    expect(h.onDismiss).not.toHaveBeenCalled();
+    expect(screen.getByText(/Really\?/)).toBeInTheDocument();
+  });
+
+  it('confirm Yes, hide for good calls onDismiss', async () => {
+    const h = handlers();
+    render(<DonationBanner callCount={10} {...h} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: "Don't show again" }));
+    await user.click(screen.getByRole('button', { name: 'Yes, hide for good' }));
+    expect(h.onDismiss).toHaveBeenCalled();
+    expect(h.onKeepReminders).not.toHaveBeenCalled();
+  });
+
+  it('confirm Keep reminders calls onKeepReminders, not onDismiss', async () => {
+    const h = handlers();
+    render(<DonationBanner callCount={10} {...h} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: "Don't show again" }));
+    await user.click(screen.getByRole('button', { name: 'Keep reminders' }));
+    expect(h.onKeepReminders).toHaveBeenCalled();
+    expect(h.onDismiss).not.toHaveBeenCalled();
   });
 });

--- a/admin_ui/frontend/src/components/DonationBanner.test.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import DonationBanner from './DonationBanner';
 import { KOFI_URL, SPONSORS_URL } from '../config/donation';
 
-const handlers = () => ({ onLater: vi.fn(), onDismiss: vi.fn(), onDonate: vi.fn() });
+const handlers = () => ({ onLater: vi.fn(), onDismiss: vi.fn(), onDonate: vi.fn(), onAlreadyDonated: vi.fn() });
 
 describe('DonationBanner', () => {
   it('renders the call count when provided', () => {
@@ -47,5 +47,13 @@ describe('DonationBanner', () => {
     expect(h.onDonate).toHaveBeenCalled();
     await user.click(screen.getByRole('link', { name: 'Sponsor AVA on GitHub' }));
     expect(h.onDonate).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires onAlreadyDonated', async () => {
+    const h = handlers();
+    render(<DonationBanner callCount={10} {...h} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'I already donated' }));
+    expect(h.onAlreadyDonated).toHaveBeenCalled();
   });
 });

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -14,7 +14,7 @@ interface DonationBannerProps {
 const FOCUS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring';
 const PRIMARY_BTN = `inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground ${FOCUS}`;
-const OUTLINE_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 ${FOCUS}`;
+const OUTLINE_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-foreground hover:bg-accent transition-colors ${FOCUS}`;
 const SECONDARY_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors ${FOCUS}`;
 const CONTAINER =
   'mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between';

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Coffee, Heart, X } from 'lucide-react';
 import { KOFI_URL, SPONSORS_URL } from '../config/donation';
 
@@ -7,7 +8,16 @@ interface DonationBannerProps {
   onDismiss: () => void;
   onDonate: () => void;
   onAlreadyDonated: () => void;
+  onKeepReminders: () => void;
 }
+
+const FOCUS =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring';
+const PRIMARY_BTN = `inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground ${FOCUS}`;
+const OUTLINE_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 ${FOCUS}`;
+const SECONDARY_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors ${FOCUS}`;
+const CONTAINER =
+  'mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between';
 
 export default function DonationBanner({
   callCount,
@@ -15,65 +25,88 @@ export default function DonationBanner({
   onDismiss,
   onDonate,
   onAlreadyDonated,
+  onKeepReminders,
 }: DonationBannerProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (confirming) {
+    return (
+      <div data-testid="donation-banner" className={CONTAINER}>
+        <p>
+          <span aria-hidden="true">🙁</span>{' '}
+          <span className="font-medium text-foreground">Really?</span> AVA&apos;s
+          development runs on these contributions.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={SECONDARY_BTN}
+            onClick={() => {
+              setConfirming(false);
+              onKeepReminders();
+            }}
+          >
+            Keep reminders
+          </button>
+          <button type="button" className={SECONDARY_BTN} onClick={onDismiss}>
+            Yes, hide for good
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   const lead =
     callCount !== undefined
       ? `AVA has handled ${callCount.toLocaleString()} calls for you.`
       : 'Thanks for running AVA.';
 
   return (
-    <div
-      data-testid="donation-banner"
-      className="mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
-    >
+    <div data-testid="donation-banner" className={CONTAINER}>
       <p>
         <span className="font-medium text-foreground">{lead}</span>{' '}
         It&apos;s free and self-hosted — if it&apos;s saving you time, supporting
         development helps keep it going.
       </p>
-      <div className="flex flex-wrap items-center gap-2">
-        <a
-          href={KOFI_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={onDonate}
-          aria-label="Support AVA on Ko-fi"
-          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground"
-        >
-          <Coffee className="h-4 w-4" aria-hidden="true" /> Support on Ko-fi
-        </a>
-        <a
-          href={SPONSORS_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={onDonate}
-          aria-label="Sponsor AVA on GitHub"
-          className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5"
-        >
-          <Heart className="h-4 w-4" aria-hidden="true" /> Sponsor
-        </a>
-        <button
-          type="button"
-          onClick={onAlreadyDonated}
-          className="rounded-md px-3 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
-        >
-          I already donated
-        </button>
-        <button
-          type="button"
-          onClick={onLater}
-          className="rounded-md px-3 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
-        >
-          Maybe later
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Don't show again"
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
-        >
-          <X className="h-3.5 w-3.5" aria-hidden="true" /> Don&apos;t show again
-        </button>
+      <div className="flex flex-col gap-2 sm:items-end">
+        <div className="flex flex-wrap items-center gap-2">
+          <a
+            href={KOFI_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onDonate}
+            aria-label="Support AVA on Ko-fi"
+            className={PRIMARY_BTN}
+          >
+            <Coffee className="w-4 h-4" aria-hidden="true" /> Support on Ko-fi
+          </a>
+          <a
+            href={SPONSORS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={onDonate}
+            aria-label="Sponsor AVA on GitHub"
+            className={OUTLINE_BTN}
+          >
+            <Heart className="w-4 h-4" aria-hidden="true" /> Sponsor
+          </a>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button type="button" className={SECONDARY_BTN} onClick={onAlreadyDonated}>
+            I already donated
+          </button>
+          <button type="button" className={SECONDARY_BTN} onClick={onLater}>
+            Maybe later
+          </button>
+          <button
+            type="button"
+            className={SECONDARY_BTN}
+            onClick={() => setConfirming(true)}
+            aria-label="Don't show again"
+          >
+            <X className="w-3.5 h-3.5" aria-hidden="true" /> Don&apos;t show again
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -38,7 +38,7 @@ export default function DonationBanner({
           aria-label="Support AVA on Ko-fi"
           className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground"
         >
-          <Coffee className="h-4 w-4" /> Support on Ko-fi
+          <Coffee className="h-4 w-4" aria-hidden="true" /> Support on Ko-fi
         </a>
         <a
           href={SPONSORS_URL}
@@ -48,12 +48,12 @@ export default function DonationBanner({
           aria-label="Sponsor AVA on GitHub"
           className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5"
         >
-          <Heart className="h-4 w-4" /> Sponsor
+          <Heart className="h-4 w-4" aria-hidden="true" /> Sponsor
         </a>
         <button
           type="button"
           onClick={onLater}
-          className="rounded-md px-3 py-1.5 hover:text-foreground"
+          className="rounded-md px-3 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
         >
           Maybe later
         </button>
@@ -61,9 +61,9 @@ export default function DonationBanner({
           type="button"
           onClick={onDismiss}
           aria-label="Don't show again"
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 hover:text-foreground"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
         >
-          <X className="h-3.5 w-3.5" /> Don&apos;t show again
+          <X className="h-3.5 w-3.5" aria-hidden="true" /> Don&apos;t show again
         </button>
       </div>
     </div>

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -13,11 +13,13 @@ interface DonationBannerProps {
 
 const FOCUS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring';
-const PRIMARY_BTN = `inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground ${FOCUS}`;
-const OUTLINE_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-foreground hover:bg-accent transition-colors ${FOCUS}`;
-const SECONDARY_BTN = `inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors ${FOCUS}`;
+const BTN_BASE = `inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-sm ${FOCUS}`;
+const PRIMARY_BTN = `${BTN_BASE} bg-primary font-medium text-primary-foreground`;
+const OUTLINE_BTN = `${BTN_BASE} border border-border font-medium text-foreground hover:bg-accent transition-colors`;
+const SECONDARY_BTN = `${BTN_BASE} border border-border text-muted-foreground hover:bg-accent hover:text-foreground transition-colors`;
 const CONTAINER =
-  'mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between';
+  'mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground';
+const ICON = 'w-4 h-4 shrink-0';
 
 export default function DonationBanner({
   callCount,
@@ -32,7 +34,7 @@ export default function DonationBanner({
   if (confirming) {
     return (
       <div data-testid="donation-banner" className={CONTAINER}>
-        <p>
+        <p className="leading-relaxed">
           <span aria-hidden="true">🙁</span>{' '}
           <span className="font-medium text-foreground">Really?</span> AVA&apos;s
           development runs on these contributions.
@@ -63,50 +65,50 @@ export default function DonationBanner({
 
   return (
     <div data-testid="donation-banner" className={CONTAINER}>
-      <p>
+      <p className="leading-relaxed">
         <span className="font-medium text-foreground">{lead}</span>{' '}
         It&apos;s free and self-hosted — if it&apos;s saving you time, supporting
         development helps keep it going.
       </p>
-      <div className="flex flex-col gap-2 sm:items-end">
-        <div className="flex flex-wrap items-center gap-2">
-          <a
-            href={KOFI_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={onDonate}
-            aria-label="Support AVA on Ko-fi"
-            className={PRIMARY_BTN}
-          >
-            <Coffee className="w-4 h-4" aria-hidden="true" /> Support on Ko-fi
-          </a>
-          <a
-            href={SPONSORS_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={onDonate}
-            aria-label="Sponsor AVA on GitHub"
-            className={OUTLINE_BTN}
-          >
-            <Heart className="w-4 h-4" aria-hidden="true" /> Sponsor
-          </a>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <button type="button" className={SECONDARY_BTN} onClick={onAlreadyDonated}>
-            I already donated
-          </button>
-          <button type="button" className={SECONDARY_BTN} onClick={onLater}>
-            Maybe later
-          </button>
-          <button
-            type="button"
-            className={SECONDARY_BTN}
-            onClick={() => setConfirming(true)}
-            aria-label="Don't show again"
-          >
-            <X className="w-3.5 h-3.5" aria-hidden="true" /> Don&apos;t show again
-          </button>
-        </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <a
+          href={KOFI_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onDonate}
+          aria-label="Support AVA on Ko-fi"
+          className={PRIMARY_BTN}
+        >
+          <Coffee className={ICON} aria-hidden="true" /> Support on Ko-fi
+        </a>
+        <a
+          href={SPONSORS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onDonate}
+          aria-label="Sponsor AVA on GitHub"
+          className={OUTLINE_BTN}
+        >
+          <Heart className={ICON} aria-hidden="true" /> Sponsor
+        </a>
+        <span
+          aria-hidden="true"
+          className="mx-1 hidden h-5 w-px shrink-0 bg-border sm:inline-block"
+        />
+        <button type="button" className={SECONDARY_BTN} onClick={onAlreadyDonated}>
+          I already donated
+        </button>
+        <button type="button" className={SECONDARY_BTN} onClick={onLater}>
+          Maybe later
+        </button>
+        <button
+          type="button"
+          className={SECONDARY_BTN}
+          onClick={() => setConfirming(true)}
+          aria-label="Don't show again"
+        >
+          <X className="w-3.5 h-3.5 shrink-0" aria-hidden="true" /> Don&apos;t show again
+        </button>
       </div>
     </div>
   );

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -6,6 +6,7 @@ interface DonationBannerProps {
   onLater: () => void;
   onDismiss: () => void;
   onDonate: () => void;
+  onAlreadyDonated: () => void;
 }
 
 export default function DonationBanner({
@@ -13,6 +14,7 @@ export default function DonationBanner({
   onLater,
   onDismiss,
   onDonate,
+  onAlreadyDonated,
 }: DonationBannerProps) {
   const lead =
     callCount !== undefined
@@ -50,6 +52,13 @@ export default function DonationBanner({
         >
           <Heart className="h-4 w-4" aria-hidden="true" /> Sponsor
         </a>
+        <button
+          type="button"
+          onClick={onAlreadyDonated}
+          className="rounded-md px-3 py-1.5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+        >
+          I already donated
+        </button>
         <button
           type="button"
           onClick={onLater}

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -1,0 +1,71 @@
+import { Coffee, Heart, X } from 'lucide-react';
+import { KOFI_URL, SPONSORS_URL } from '../config/donation';
+
+interface DonationBannerProps {
+  callCount?: number;
+  onLater: () => void;
+  onDismiss: () => void;
+  onDonate: () => void;
+}
+
+export default function DonationBanner({
+  callCount,
+  onLater,
+  onDismiss,
+  onDonate,
+}: DonationBannerProps) {
+  const lead =
+    callCount !== undefined
+      ? `AVA has handled ${callCount.toLocaleString()} calls for you.`
+      : 'Thanks for running AVA.';
+
+  return (
+    <div
+      data-testid="donation-banner"
+      className="mb-4 flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
+    >
+      <p>
+        <span className="font-medium text-foreground">{lead}</span>{' '}
+        It&apos;s free and self-hosted — if it&apos;s saving you time, supporting
+        development helps keep it going.
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <a
+          href={KOFI_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onDonate}
+          aria-label="Support AVA on Ko-fi"
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-primary-foreground"
+        >
+          <Coffee className="h-4 w-4" /> Support on Ko-fi
+        </a>
+        <a
+          href={SPONSORS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onDonate}
+          aria-label="Sponsor AVA on GitHub"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5"
+        >
+          <Heart className="h-4 w-4" /> Sponsor
+        </a>
+        <button
+          type="button"
+          onClick={onLater}
+          className="rounded-md px-3 py-1.5 hover:text-foreground"
+        >
+          Maybe later
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Don't show again"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1.5 hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" /> Don&apos;t show again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/admin_ui/frontend/src/components/DonationBanner.tsx
+++ b/admin_ui/frontend/src/components/DonationBanner.tsx
@@ -59,7 +59,7 @@ export default function DonationBanner({
   }
 
   const lead =
-    callCount !== undefined
+    callCount !== undefined && callCount > 0
       ? `AVA has handled ${callCount.toLocaleString()} calls for you.`
       : 'Thanks for running AVA.';
 

--- a/admin_ui/frontend/src/components/layout/Sidebar.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.tsx
@@ -21,6 +21,8 @@ import {
     Code,
     HelpCircle,
     ExternalLink,
+    Coffee,
+    Heart,
     HardDrive,
     ArrowUpCircle,
     Phone,
@@ -29,6 +31,7 @@ import {
     Lock
 } from 'lucide-react';
 import { useAuth } from '../../auth/AuthContext';
+import { KOFI_URL, SPONSORS_URL } from '../../config/donation';
 import ChangePasswordModal from '../auth/ChangePasswordModal';
 import { useState } from 'react';
 
@@ -129,6 +132,24 @@ const Sidebar = () => {
                     >
                         <ExternalLink className="w-4 h-4" />
                         API Docs
+                    </a>
+                    <a
+                        href={KOFI_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Support AVA on Ko-fi"
+                        className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                    >
+                        <Coffee className="h-4 w-4" aria-hidden="true" /> Support on Ko-fi
+                    </a>
+                    <a
+                        href={SPONSORS_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Sponsor AVA on GitHub"
+                        className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                    >
+                        <Heart className="h-4 w-4" aria-hidden="true" /> Sponsor
                     </a>
                 </SidebarGroup>
             </nav>

--- a/admin_ui/frontend/src/components/layout/Sidebar.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.tsx
@@ -138,18 +138,18 @@ const Sidebar = () => {
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label="Support AVA on Ko-fi"
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                        className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
                     >
-                        <Coffee className="h-4 w-4" aria-hidden="true" /> Support on Ko-fi
+                        <Coffee className="w-4 h-4" aria-hidden="true" /> Support on Ko-fi
                     </a>
                     <a
                         href={SPONSORS_URL}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label="Sponsor AVA on GitHub"
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground"
+                        className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
                     >
-                        <Heart className="h-4 w-4" aria-hidden="true" /> Sponsor
+                        <Heart className="w-4 h-4" aria-hidden="true" /> Sponsor
                     </a>
                 </SidebarGroup>
             </nav>

--- a/admin_ui/frontend/src/config/donation.ts
+++ b/admin_ui/frontend/src/config/donation.ts
@@ -1,23 +1,19 @@
 export const KOFI_URL = 'https://ko-fi.com/asteriskaivoiceagent';
 export const SPONSORS_URL = 'https://github.com/sponsors/hkjarral';
 
-// Reminder ladder: fixed milestones, then repeat every MILESTONE_STEP.
-// Invariant: the last fixed milestone must be a multiple of MILESTONE_STEP —
-// the ladder continues from it in MILESTONE_STEP increments (the tail guard relies on this).
-export const MILESTONES = [10, 25, 50, 100, 200, 500, 1000];
-export const MILESTONE_STEP = 1000;
-
 const DAY_MS = 24 * 60 * 60 * 1000;
-export const SNOOZE_LATER_MS = 30 * DAY_MS;
-export const SNOOZE_DONATE_MS = 180 * DAY_MS;
-export const TIME_FALLBACK_MS = 30 * DAY_MS;
+// Don't nag a brand-new install before it has delivered value: first show after
+// the first handled call OR 3 days, whichever comes first.
+export const FIRST_SHOW_DELAY_MS = 3 * DAY_MS;
+// Weekly recurring cadence — "Maybe later" and donate-link clicks snooze a week.
+export const SNOOZE_LATER_MS = 7 * DAY_MS;
+// "I already donated" — a generous 3-month break for someone who gave.
+export const SNOOZE_DONATED_MS = 90 * DAY_MS;
 
 export const STORAGE_KEYS = {
   firstSeenAt: 'aava.donation.firstSeenAt',
   snoozeUntil: 'aava.donation.snoozeUntil',
   dismissedForever: 'aava.donation.dismissedForever',
-  lastMilestoneShown: 'aava.donation.lastMilestoneShown',
-  timeFallbackUsed: 'aava.donation.timeFallbackUsed',
 } as const;
 
 export const SESSION_KEY = 'aava.donation.shownThisSession';

--- a/admin_ui/frontend/src/config/donation.ts
+++ b/admin_ui/frontend/src/config/donation.ts
@@ -1,8 +1,9 @@
-// admin_ui/frontend/src/config/donation.ts
 export const KOFI_URL = 'https://ko-fi.com/asteriskaivoiceagent';
 export const SPONSORS_URL = 'https://github.com/sponsors/hkjarral';
 
 // Reminder ladder: fixed milestones, then repeat every MILESTONE_STEP.
+// Invariant: the last fixed milestone must be a multiple of MILESTONE_STEP —
+// the ladder continues from it in MILESTONE_STEP increments (the tail guard relies on this).
 export const MILESTONES = [10, 25, 50, 100, 200, 500, 1000];
 export const MILESTONE_STEP = 1000;
 

--- a/admin_ui/frontend/src/config/donation.ts
+++ b/admin_ui/frontend/src/config/donation.ts
@@ -1,0 +1,22 @@
+// admin_ui/frontend/src/config/donation.ts
+export const KOFI_URL = 'https://ko-fi.com/asteriskaivoiceagent';
+export const SPONSORS_URL = 'https://github.com/sponsors/hkjarral';
+
+// Reminder ladder: fixed milestones, then repeat every MILESTONE_STEP.
+export const MILESTONES = [10, 25, 50, 100, 200, 500, 1000];
+export const MILESTONE_STEP = 1000;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const SNOOZE_LATER_MS = 30 * DAY_MS;
+export const SNOOZE_DONATE_MS = 180 * DAY_MS;
+export const TIME_FALLBACK_MS = 30 * DAY_MS;
+
+export const STORAGE_KEYS = {
+  firstSeenAt: 'aava.donation.firstSeenAt',
+  snoozeUntil: 'aava.donation.snoozeUntil',
+  dismissedForever: 'aava.donation.dismissedForever',
+  lastMilestoneShown: 'aava.donation.lastMilestoneShown',
+  timeFallbackUsed: 'aava.donation.timeFallbackUsed',
+} as const;
+
+export const SESSION_KEY = 'aava.donation.shownThisSession';

--- a/admin_ui/frontend/src/config/donation.ts
+++ b/admin_ui/frontend/src/config/donation.ts
@@ -9,6 +9,8 @@ export const FIRST_SHOW_DELAY_MS = 3 * DAY_MS;
 export const SNOOZE_LATER_MS = 7 * DAY_MS;
 // "I already donated" — a generous 3-month break for someone who gave.
 export const SNOOZE_DONATED_MS = 90 * DAY_MS;
+// "Keep reminders" (the soft path on the dismiss confirm) — snooze ~1 month.
+export const SNOOZE_MONTH_MS = 30 * DAY_MS;
 
 export const STORAGE_KEYS = {
   firstSeenAt: 'aava.donation.firstSeenAt',

--- a/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
@@ -76,4 +76,14 @@ describe('useDonationReminder', () => {
     await waitFor(() => expect(result.current.show).toBe(true));
     expect(result.current.callCount).toBeUndefined();
   });
+
+  it('Keep reminders snoozes ~1 month', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onKeepReminders());
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
+    expect(snooze).toBeGreaterThan(Date.now() + 25 * DAY);
+    expect(snooze).toBeLessThan(Date.now() + 35 * DAY);
+  });
 });

--- a/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { useDonationReminder } from './useDonationReminder';
+import { STORAGE_KEYS, SESSION_KEY } from '../config/donation';
+
+vi.mock('axios');
+const mockGet = axios.get as unknown as ReturnType<typeof vi.fn>;
+
+describe('useDonationReminder', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('shows on milestone hit and sets shownThisSession', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 10 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe('true');
+  });
+
+  it('does not show below the first milestone', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 9 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.callCount).toBe(9));
+    expect(result.current.show).toBe(false);
+  });
+
+  it('Maybe later snoozes into the future and advances the milestone', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 25 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onLater());
+    expect(result.current.show).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEYS.lastMilestoneShown)).toBe('25');
+    expect(Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil))).toBeGreaterThan(Date.now());
+    expect(localStorage.getItem(STORAGE_KEYS.timeFallbackUsed)).toBe('true');
+  });
+
+  it("Don't show again sets the permanent flag", async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 100 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onDismiss());
+    expect(localStorage.getItem(STORAGE_KEYS.dismissedForever)).toBe('true');
+  });
+
+  it('stays eligible via time fallback when the stats fetch fails', async () => {
+    mockGet.mockRejectedValue(new Error('network'));
+    localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(Date.now() - 31 * 24 * 60 * 60 * 1000));
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    expect(result.current.callCount).toBeUndefined();
+  });
+});

--- a/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
@@ -55,4 +55,15 @@ describe('useDonationReminder', () => {
     await waitFor(() => expect(result.current.show).toBe(true));
     expect(result.current.callCount).toBeUndefined();
   });
+
+  it('Support/donate click snoozes ~180 days', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 50 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onDonate());
+    expect(result.current.show).toBe(false);
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
+    // ~180 days out (allow generous slack); must be well beyond a 30-day "later" snooze
+    expect(snooze).toBeGreaterThan(Date.now() + 100 * 24 * 60 * 60 * 1000);
+  });
 });

--- a/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
@@ -48,6 +48,8 @@ describe('useDonationReminder', () => {
     act(() => result.current.onDonate());
     const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
     expect(snooze).toBeLessThan(Date.now() + 8 * DAY);
+    expect(snooze).toBeGreaterThan(Date.now() + 6 * DAY);
+    expect(result.current.show).toBe(false);
   });
 
   it('I already donated snoozes ~3 months', async () => {

--- a/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.test.ts
@@ -7,6 +7,7 @@ import { STORAGE_KEYS, SESSION_KEY } from '../config/donation';
 
 vi.mock('axios');
 const mockGet = axios.get as unknown as ReturnType<typeof vi.fn>;
+const DAY = 24 * 60 * 60 * 1000;
 
 describe('useDonationReminder', () => {
   beforeEach(() => {
@@ -15,55 +16,62 @@ describe('useDonationReminder', () => {
     vi.clearAllMocks();
   });
 
-  it('shows on milestone hit and sets shownThisSession', async () => {
-    mockGet.mockResolvedValue({ data: { total_calls: 10 } });
+  it('shows once the install has handled a call and sets shownThisSession', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
     const { result } = renderHook(() => useDonationReminder());
     await waitFor(() => expect(result.current.show).toBe(true));
     expect(sessionStorage.getItem(SESSION_KEY)).toBe('true');
   });
 
-  it('does not show below the first milestone', async () => {
-    mockGet.mockResolvedValue({ data: { total_calls: 9 } });
+  it('does not show a brand-new zero-call install', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 0 } });
     const { result } = renderHook(() => useDonationReminder());
-    await waitFor(() => expect(result.current.callCount).toBe(9));
+    await waitFor(() => expect(result.current.callCount).toBe(0));
     expect(result.current.show).toBe(false);
   });
 
-  it('Maybe later snoozes into the future and advances the milestone', async () => {
-    mockGet.mockResolvedValue({ data: { total_calls: 25 } });
+  it('Maybe later snoozes ~1 week', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
     const { result } = renderHook(() => useDonationReminder());
     await waitFor(() => expect(result.current.show).toBe(true));
     act(() => result.current.onLater());
     expect(result.current.show).toBe(false);
-    expect(localStorage.getItem(STORAGE_KEYS.lastMilestoneShown)).toBe('25');
-    expect(Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil))).toBeGreaterThan(Date.now());
-    expect(localStorage.getItem(STORAGE_KEYS.timeFallbackUsed)).toBe('true');
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
+    expect(snooze).toBeGreaterThan(Date.now() + 6 * DAY);
+    expect(snooze).toBeLessThan(Date.now() + 8 * DAY);
+  });
+
+  it('donate-link click snoozes ~1 week (same as later)', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onDonate());
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
+    expect(snooze).toBeLessThan(Date.now() + 8 * DAY);
+  });
+
+  it('I already donated snoozes ~3 months', async () => {
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
+    const { result } = renderHook(() => useDonationReminder());
+    await waitFor(() => expect(result.current.show).toBe(true));
+    act(() => result.current.onAlreadyDonated());
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
+    expect(snooze).toBeGreaterThan(Date.now() + 80 * DAY);
   });
 
   it("Don't show again sets the permanent flag", async () => {
-    mockGet.mockResolvedValue({ data: { total_calls: 100 } });
+    mockGet.mockResolvedValue({ data: { total_calls: 5 } });
     const { result } = renderHook(() => useDonationReminder());
     await waitFor(() => expect(result.current.show).toBe(true));
     act(() => result.current.onDismiss());
     expect(localStorage.getItem(STORAGE_KEYS.dismissedForever)).toBe('true');
   });
 
-  it('stays eligible via time fallback when the stats fetch fails', async () => {
+  it('stays eligible (aged-in) when the stats fetch fails', async () => {
     mockGet.mockRejectedValue(new Error('network'));
-    localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(Date.now() - 31 * 24 * 60 * 60 * 1000));
+    localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(Date.now() - 4 * DAY));
     const { result } = renderHook(() => useDonationReminder());
     await waitFor(() => expect(result.current.show).toBe(true));
     expect(result.current.callCount).toBeUndefined();
-  });
-
-  it('Support/donate click snoozes ~180 days', async () => {
-    mockGet.mockResolvedValue({ data: { total_calls: 50 } });
-    const { result } = renderHook(() => useDonationReminder());
-    await waitFor(() => expect(result.current.show).toBe(true));
-    act(() => result.current.onDonate());
-    expect(result.current.show).toBe(false);
-    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
-    // ~180 days out (allow generous slack); must be well beyond a 30-day "later" snooze
-    expect(snooze).toBeGreaterThan(Date.now() + 100 * 24 * 60 * 60 * 1000);
   });
 });

--- a/admin_ui/frontend/src/hooks/useDonationReminder.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.ts
@@ -5,6 +5,7 @@ import {
   SESSION_KEY,
   SNOOZE_LATER_MS,
   SNOOZE_DONATED_MS,
+  SNOOZE_MONTH_MS,
 } from '../config/donation';
 import { ReminderState, isEligible } from '../utils/donationReminder';
 
@@ -15,6 +16,7 @@ export interface UseDonationReminder {
   onDismiss: () => void;
   onDonate: () => void;
   onAlreadyDonated: () => void;
+  onKeepReminders: () => void;
 }
 
 /** Reads all state; returns null if storage is unavailable (fail closed). */
@@ -96,6 +98,7 @@ export function useDonationReminder(): UseDonationReminder {
     onLater: () => snooze(SNOOZE_LATER_MS),
     onDonate: () => snooze(SNOOZE_LATER_MS),
     onAlreadyDonated: () => snooze(SNOOZE_DONATED_MS),
+    onKeepReminders: () => snooze(SNOOZE_MONTH_MS),
     onDismiss: () => {
       try {
         localStorage.setItem(STORAGE_KEYS.dismissedForever, 'true');

--- a/admin_ui/frontend/src/hooks/useDonationReminder.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.ts
@@ -4,9 +4,9 @@ import {
   STORAGE_KEYS,
   SESSION_KEY,
   SNOOZE_LATER_MS,
-  SNOOZE_DONATE_MS,
+  SNOOZE_DONATED_MS,
 } from '../config/donation';
-import { ReminderState, isEligible, highestLadderValue } from '../utils/donationReminder';
+import { ReminderState, isEligible } from '../utils/donationReminder';
 
 export interface UseDonationReminder {
   show: boolean;
@@ -14,6 +14,7 @@ export interface UseDonationReminder {
   onLater: () => void;
   onDismiss: () => void;
   onDonate: () => void;
+  onAlreadyDonated: () => void;
 }
 
 /** Reads all state; returns null if storage is unavailable (fail closed). */
@@ -25,16 +26,11 @@ function readState(): ReminderState | null {
       firstSeenAt = now;
       localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(now));
     }
-    const num = (k: string) => {
-      const v = Number(localStorage.getItem(k));
-      return Number.isNaN(v) ? 0 : v;
-    };
+    const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
     return {
       firstSeenAt,
-      snoozeUntil: num(STORAGE_KEYS.snoozeUntil),
+      snoozeUntil: Number.isNaN(snooze) ? 0 : snooze,
       dismissedForever: localStorage.getItem(STORAGE_KEYS.dismissedForever) === 'true',
-      lastMilestoneShown: num(STORAGE_KEYS.lastMilestoneShown),
-      timeFallbackUsed: localStorage.getItem(STORAGE_KEYS.timeFallbackUsed) === 'true',
       shownThisSession: sessionStorage.getItem(SESSION_KEY) === 'true',
     };
   } catch {
@@ -60,7 +56,7 @@ export function useDonationReminder(): UseDonationReminder {
         if (active) setCallCount(r.data?.total_calls);
       })
       .catch(() => {
-        /* leave undefined → time fallback still applies */
+        /* leave undefined → aged-in fallback still applies */
       })
       .finally(() => {
         if (active) setCountResolved(true);
@@ -85,14 +81,9 @@ export function useDonationReminder(): UseDonationReminder {
     }
   }, [countResolved, callCount]);
 
-  const advanceAndSnooze = (snoozeMs: number) => {
+  const snooze = (ms: number) => {
     try {
-      const now = Date.now();
-      const reached = highestLadderValue(callCount ?? 0);
-      const prev = Number(localStorage.getItem(STORAGE_KEYS.lastMilestoneShown)) || 0;
-      localStorage.setItem(STORAGE_KEYS.lastMilestoneShown, String(Math.max(prev, reached)));
-      localStorage.setItem(STORAGE_KEYS.snoozeUntil, String(now + snoozeMs));
-      localStorage.setItem(STORAGE_KEYS.timeFallbackUsed, 'true');
+      localStorage.setItem(STORAGE_KEYS.snoozeUntil, String(Date.now() + ms));
     } catch {
       /* ignore */
     }
@@ -102,8 +93,9 @@ export function useDonationReminder(): UseDonationReminder {
   return {
     show,
     callCount,
-    onLater: () => advanceAndSnooze(SNOOZE_LATER_MS),
-    onDonate: () => advanceAndSnooze(SNOOZE_DONATE_MS),
+    onLater: () => snooze(SNOOZE_LATER_MS),
+    onDonate: () => snooze(SNOOZE_LATER_MS),
+    onAlreadyDonated: () => snooze(SNOOZE_DONATED_MS),
     onDismiss: () => {
       try {
         localStorage.setItem(STORAGE_KEYS.dismissedForever, 'true');

--- a/admin_ui/frontend/src/hooks/useDonationReminder.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.ts
@@ -19,15 +19,12 @@ export interface UseDonationReminder {
   onKeepReminders: () => void;
 }
 
-/** Reads all state; returns null if storage is unavailable (fail closed). */
+/** Reads all state; returns null if storage is unavailable (fail closed). Pure — no writes. */
 function readState(): ReminderState | null {
   try {
     const now = Date.now();
-    let firstSeenAt = Number(localStorage.getItem(STORAGE_KEYS.firstSeenAt));
-    if (!firstSeenAt || Number.isNaN(firstSeenAt)) {
-      firstSeenAt = now;
-      localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(now));
-    }
+    const stored = Number(localStorage.getItem(STORAGE_KEYS.firstSeenAt));
+    const firstSeenAt = !stored || Number.isNaN(stored) ? now : stored;
     const snooze = Number(localStorage.getItem(STORAGE_KEYS.snoozeUntil));
     return {
       firstSeenAt,
@@ -48,6 +45,19 @@ export function useDonationReminder(): UseDonationReminder {
   if (stateRef.current === undefined) {
     stateRef.current = readState();
   }
+
+  // Persist firstSeenAt out of render (readState stays pure).
+  useEffect(() => {
+    const state = stateRef.current;
+    if (!state) return;
+    try {
+      if (!localStorage.getItem(STORAGE_KEYS.firstSeenAt)) {
+        localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(state.firstSeenAt));
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
 
   // One-shot call-count fetch (NOT the dashboard poll).
   useEffect(() => {

--- a/admin_ui/frontend/src/hooks/useDonationReminder.ts
+++ b/admin_ui/frontend/src/hooks/useDonationReminder.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import {
+  STORAGE_KEYS,
+  SESSION_KEY,
+  SNOOZE_LATER_MS,
+  SNOOZE_DONATE_MS,
+} from '../config/donation';
+import { ReminderState, isEligible, highestLadderValue } from '../utils/donationReminder';
+
+export interface UseDonationReminder {
+  show: boolean;
+  callCount?: number;
+  onLater: () => void;
+  onDismiss: () => void;
+  onDonate: () => void;
+}
+
+/** Reads all state; returns null if storage is unavailable (fail closed). */
+function readState(): ReminderState | null {
+  try {
+    const now = Date.now();
+    let firstSeenAt = Number(localStorage.getItem(STORAGE_KEYS.firstSeenAt));
+    if (!firstSeenAt || Number.isNaN(firstSeenAt)) {
+      firstSeenAt = now;
+      localStorage.setItem(STORAGE_KEYS.firstSeenAt, String(now));
+    }
+    const num = (k: string) => {
+      const v = Number(localStorage.getItem(k));
+      return Number.isNaN(v) ? 0 : v;
+    };
+    return {
+      firstSeenAt,
+      snoozeUntil: num(STORAGE_KEYS.snoozeUntil),
+      dismissedForever: localStorage.getItem(STORAGE_KEYS.dismissedForever) === 'true',
+      lastMilestoneShown: num(STORAGE_KEYS.lastMilestoneShown),
+      timeFallbackUsed: localStorage.getItem(STORAGE_KEYS.timeFallbackUsed) === 'true',
+      shownThisSession: sessionStorage.getItem(SESSION_KEY) === 'true',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function useDonationReminder(): UseDonationReminder {
+  const [callCount, setCallCount] = useState<number | undefined>(undefined);
+  const [countResolved, setCountResolved] = useState(false);
+  const [show, setShow] = useState(false);
+  const stateRef = useRef<ReminderState | null | undefined>(undefined);
+  if (stateRef.current === undefined) {
+    stateRef.current = readState();
+  }
+
+  // One-shot call-count fetch (NOT the dashboard poll).
+  useEffect(() => {
+    let active = true;
+    axios
+      .get('/api/calls/stats')
+      .then((r) => {
+        if (active) setCallCount(r.data?.total_calls);
+      })
+      .catch(() => {
+        /* leave undefined → time fallback still applies */
+      })
+      .finally(() => {
+        if (active) setCountResolved(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Decide once the count has resolved. Side effect lives here, not in render.
+  useEffect(() => {
+    if (!countResolved) return;
+    const state = stateRef.current;
+    if (!state) return; // storage broken → never show
+    if (isEligible(state, callCount, Date.now())) {
+      setShow(true);
+      try {
+        sessionStorage.setItem(SESSION_KEY, 'true');
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [countResolved, callCount]);
+
+  const advanceAndSnooze = (snoozeMs: number) => {
+    try {
+      const now = Date.now();
+      const reached = highestLadderValue(callCount ?? 0);
+      const prev = Number(localStorage.getItem(STORAGE_KEYS.lastMilestoneShown)) || 0;
+      localStorage.setItem(STORAGE_KEYS.lastMilestoneShown, String(Math.max(prev, reached)));
+      localStorage.setItem(STORAGE_KEYS.snoozeUntil, String(now + snoozeMs));
+      localStorage.setItem(STORAGE_KEYS.timeFallbackUsed, 'true');
+    } catch {
+      /* ignore */
+    }
+    setShow(false);
+  };
+
+  return {
+    show,
+    callCount,
+    onLater: () => advanceAndSnooze(SNOOZE_LATER_MS),
+    onDonate: () => advanceAndSnooze(SNOOZE_DONATE_MS),
+    onDismiss: () => {
+      try {
+        localStorage.setItem(STORAGE_KEYS.dismissedForever, 'true');
+      } catch {
+        /* ignore */
+      }
+      setShow(false);
+    },
+  };
+}

--- a/admin_ui/frontend/src/pages/Dashboard.tsx
+++ b/admin_ui/frontend/src/pages/Dashboard.tsx
@@ -273,6 +273,7 @@ const Dashboard = () => {
                     onLater={donation.onLater}
                     onDismiss={donation.onDismiss}
                     onDonate={donation.onDonate}
+                    onAlreadyDonated={donation.onAlreadyDonated}
                 />
             )}
 

--- a/admin_ui/frontend/src/pages/Dashboard.tsx
+++ b/admin_ui/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,8 @@ import axios from 'axios';
 import { toast } from 'sonner';
 import { SystemTopology } from '../components/SystemTopology';
 import { ApiErrorInfo, buildDockerAccessHints, describeApiError } from '../utils/apiErrors';
+import DonationBanner from '../components/DonationBanner';
+import { useDonationReminder } from '../hooks/useDonationReminder';
 import {
     INITIAL_CONNECTION_STATE,
     reduceConnection,
@@ -97,6 +99,7 @@ const Dashboard = () => {
     const [platformLoadFailed, setPlatformLoadFailed] = useState(false);
     const [ariConnected, setAriConnected] = useState<boolean | null>(null);
     const navigate = useNavigate();
+    const donation = useDonationReminder();
 
     // Cross-poll hysteresis/debounce streaks. Kept in refs so updating them
     // doesn't trigger renders; the resulting display values land in reactive
@@ -263,6 +266,15 @@ const Dashboard = () => {
                     <RefreshCw className={`w-5 h-5 ${refreshing ? 'animate-spin' : ''}`} />
                 </button>
             </div>
+
+            {donation.show && (
+                <DonationBanner
+                    callCount={donation.callCount}
+                    onLater={donation.onLater}
+                    onDismiss={donation.onDismiss}
+                    onDonate={donation.onDonate}
+                />
+            )}
 
             {dataErrors.length > 0 && (
                 <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-4">

--- a/admin_ui/frontend/src/pages/Dashboard.tsx
+++ b/admin_ui/frontend/src/pages/Dashboard.tsx
@@ -274,6 +274,7 @@ const Dashboard = () => {
                     onDismiss={donation.onDismiss}
                     onDonate={donation.onDonate}
                     onAlreadyDonated={donation.onAlreadyDonated}
+                    onKeepReminders={donation.onKeepReminders}
                 />
             )}
 

--- a/admin_ui/frontend/src/setupTests.ts
+++ b/admin_ui/frontend/src/setupTests.ts
@@ -2,9 +2,6 @@
 // Node 25+ exposes a stub global.localStorage that lacks .clear() / .setItem() etc.
 // When the test environment is jsdom, override the stubs with jsdom's full
 // Storage implementations so that localStorage.clear() works as expected.
-// Node 25+ exposes a stub global.localStorage that lacks .clear() / .setItem() etc.
-// When the test environment is jsdom, override the stubs with jsdom's full
-// Storage implementations so that localStorage.clear() works as expected.
 // jsdom requires a URL to enable localStorage; vitest's default jsdom config
 // uses 'http://localhost' but Node 25's storage stub may take precedence.
 // We build a fresh jsdom Storage and inject it as the globalThis property.

--- a/admin_ui/frontend/src/setupTests.ts
+++ b/admin_ui/frontend/src/setupTests.ts
@@ -1,0 +1,34 @@
+// setupTests.ts — runs in every vitest environment after the environment is set up.
+// Node 25+ exposes a stub global.localStorage that lacks .clear() / .setItem() etc.
+// When the test environment is jsdom, override the stubs with jsdom's full
+// Storage implementations so that localStorage.clear() works as expected.
+// Node 25+ exposes a stub global.localStorage that lacks .clear() / .setItem() etc.
+// When the test environment is jsdom, override the stubs with jsdom's full
+// Storage implementations so that localStorage.clear() works as expected.
+// jsdom requires a URL to enable localStorage; vitest's default jsdom config
+// uses 'http://localhost' but Node 25's storage stub may take precedence.
+// We build a fresh jsdom Storage and inject it as the globalThis property.
+if (typeof window !== 'undefined') {
+  // In jsdom environment vitest sets window = the jsdom window, but Node 25's
+  // built-in localStorage getter shadowing means window.localStorage is the stub.
+  // Directly override with a fresh Map-backed in-memory store.
+  function makeStorage() {
+    const store = new Map<string, string>();
+    return {
+      get length() { return store.size; },
+      key(n: number) { return [...store.keys()][n] ?? null; },
+      getItem(k: string) { return store.has(k) ? store.get(k)! : null; },
+      setItem(k: string, v: string) { store.set(k, String(v)); },
+      removeItem(k: string) { store.delete(k); },
+      clear() { store.clear(); },
+    };
+  }
+  const _ls = makeStorage();
+  const _ss = makeStorage();
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: _ls, configurable: true, writable: true,
+  });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: _ss, configurable: true, writable: true,
+  });
+}

--- a/admin_ui/frontend/src/utils/donationReminder.test.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { nextMilestone, highestLadderValue, isEligible, ReminderState } from './donationReminder';
+import { TIME_FALLBACK_MS } from '../config/donation';
+
+const base: ReminderState = {
+  firstSeenAt: 0,
+  snoozeUntil: 0,
+  dismissedForever: false,
+  lastMilestoneShown: 0,
+  timeFallbackUsed: false,
+  shownThisSession: false,
+};
+
+describe('nextMilestone', () => {
+  it('starts at 10', () => expect(nextMilestone(0)).toBe(10));
+  it('walks the fixed ladder', () => {
+    expect(nextMilestone(10)).toBe(25);
+    expect(nextMilestone(50)).toBe(100);
+    expect(nextMilestone(500)).toBe(1000);
+  });
+  it('repeats every 1000 after the last fixed milestone', () => {
+    expect(nextMilestone(1000)).toBe(2000);
+    expect(nextMilestone(2000)).toBe(3000);
+  });
+});
+
+describe('highestLadderValue', () => {
+  it('is 0 below the first milestone', () => expect(highestLadderValue(9)).toBe(0));
+  it('picks the highest fixed milestone reached', () => {
+    expect(highestLadderValue(10)).toBe(10);
+    expect(highestLadderValue(99)).toBe(50);
+    expect(highestLadderValue(700)).toBe(500);
+  });
+  it('handles the +1000 tail', () => {
+    expect(highestLadderValue(1500)).toBe(1000);
+    expect(highestLadderValue(2500)).toBe(2000);
+  });
+});
+
+describe('isEligible', () => {
+  it('false when dismissed forever', () =>
+    expect(isEligible({ ...base, dismissedForever: true }, 1000, 0)).toBe(false));
+  it('false when already shown this session', () =>
+    expect(isEligible({ ...base, shownThisSession: true }, 1000, 0)).toBe(false));
+  it('false while snoozed', () =>
+    expect(isEligible({ ...base, snoozeUntil: 100 }, 1000, 50)).toBe(false));
+  it('true on milestone hit', () => expect(isEligible(base, 10, 0)).toBe(true));
+  it('false below next milestone', () => expect(isEligible(base, 9, 0)).toBe(false));
+  it('false on milestone path when count is undefined', () =>
+    expect(isEligible(base, undefined, 0)).toBe(false));
+  it('true via time fallback after 30 days with low usage', () =>
+    expect(isEligible(base, 0, TIME_FALLBACK_MS)).toBe(true));
+  it('true via time fallback even when count undefined', () =>
+    expect(isEligible(base, undefined, TIME_FALLBACK_MS)).toBe(true));
+  it('false via time fallback once already used', () =>
+    expect(isEligible({ ...base, timeFallbackUsed: true }, 0, TIME_FALLBACK_MS)).toBe(false));
+});

--- a/admin_ui/frontend/src/utils/donationReminder.test.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.test.ts
@@ -35,6 +35,8 @@ describe('highestLadderValue', () => {
     expect(highestLadderValue(1500)).toBe(1000);
     expect(highestLadderValue(2500)).toBe(2000);
   });
+  it('returns the last fixed milestone exactly at the boundary', () =>
+    expect(highestLadderValue(1000)).toBe(1000));
 });
 
 describe('isEligible', () => {

--- a/admin_ui/frontend/src/utils/donationReminder.test.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.test.ts
@@ -1,59 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { nextMilestone, highestLadderValue, isEligible, ReminderState } from './donationReminder';
-import { TIME_FALLBACK_MS } from '../config/donation';
+import { isEligible, ReminderState } from './donationReminder';
+import { FIRST_SHOW_DELAY_MS } from '../config/donation';
 
 const base: ReminderState = {
   firstSeenAt: 0,
   snoozeUntil: 0,
   dismissedForever: false,
-  lastMilestoneShown: 0,
-  timeFallbackUsed: false,
   shownThisSession: false,
 };
 
-describe('nextMilestone', () => {
-  it('starts at 10', () => expect(nextMilestone(0)).toBe(10));
-  it('walks the fixed ladder', () => {
-    expect(nextMilestone(10)).toBe(25);
-    expect(nextMilestone(50)).toBe(100);
-    expect(nextMilestone(500)).toBe(1000);
-  });
-  it('repeats every 1000 after the last fixed milestone', () => {
-    expect(nextMilestone(1000)).toBe(2000);
-    expect(nextMilestone(2000)).toBe(3000);
-  });
-});
-
-describe('highestLadderValue', () => {
-  it('is 0 below the first milestone', () => expect(highestLadderValue(9)).toBe(0));
-  it('picks the highest fixed milestone reached', () => {
-    expect(highestLadderValue(10)).toBe(10);
-    expect(highestLadderValue(99)).toBe(50);
-    expect(highestLadderValue(700)).toBe(500);
-  });
-  it('handles the +1000 tail', () => {
-    expect(highestLadderValue(1500)).toBe(1000);
-    expect(highestLadderValue(2500)).toBe(2000);
-  });
-  it('returns the last fixed milestone exactly at the boundary', () =>
-    expect(highestLadderValue(1000)).toBe(1000));
-});
-
 describe('isEligible', () => {
   it('false when dismissed forever', () =>
-    expect(isEligible({ ...base, dismissedForever: true }, 1000, 0)).toBe(false));
+    expect(isEligible({ ...base, dismissedForever: true }, 100, FIRST_SHOW_DELAY_MS)).toBe(false));
   it('false when already shown this session', () =>
-    expect(isEligible({ ...base, shownThisSession: true }, 1000, 0)).toBe(false));
+    expect(isEligible({ ...base, shownThisSession: true }, 100, FIRST_SHOW_DELAY_MS)).toBe(false));
   it('false while snoozed', () =>
-    expect(isEligible({ ...base, snoozeUntil: 100 }, 1000, 50)).toBe(false));
-  it('true on milestone hit', () => expect(isEligible(base, 10, 0)).toBe(true));
-  it('false below next milestone', () => expect(isEligible(base, 9, 0)).toBe(false));
-  it('false on milestone path when count is undefined', () =>
-    expect(isEligible(base, undefined, 0)).toBe(false));
-  it('true via time fallback after 30 days with low usage', () =>
-    expect(isEligible(base, 0, TIME_FALLBACK_MS)).toBe(true));
-  it('true via time fallback even when count undefined', () =>
-    expect(isEligible(base, undefined, TIME_FALLBACK_MS)).toBe(true));
-  it('false via time fallback once already used', () =>
-    expect(isEligible({ ...base, timeFallbackUsed: true }, 0, TIME_FALLBACK_MS)).toBe(false));
+    expect(isEligible({ ...base, snoozeUntil: 100 }, 100, 50)).toBe(false));
+  it('shows once the install has at least one call', () =>
+    expect(isEligible(base, 1, 0)).toBe(true));
+  it('does not show a fresh zero-call install before the delay', () =>
+    expect(isEligible(base, 0, FIRST_SHOW_DELAY_MS - 1)).toBe(false));
+  it('shows a zero-call install once 3 days have passed', () =>
+    expect(isEligible(base, 0, FIRST_SHOW_DELAY_MS)).toBe(true));
+  it('shows when call count is unknown but the install has aged in', () =>
+    expect(isEligible(base, undefined, FIRST_SHOW_DELAY_MS)).toBe(true));
+  it('does not show when call count is unknown and not yet aged in', () =>
+    expect(isEligible(base, undefined, FIRST_SHOW_DELAY_MS - 1)).toBe(false));
+  it('re-shows after a snooze window elapses', () =>
+    expect(isEligible({ ...base, snoozeUntil: 1000 }, 5, 1000)).toBe(true));
 });

--- a/admin_ui/frontend/src/utils/donationReminder.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.ts
@@ -1,36 +1,17 @@
-import { MILESTONES, MILESTONE_STEP, TIME_FALLBACK_MS } from '../config/donation';
+import { FIRST_SHOW_DELAY_MS } from '../config/donation';
 
 export interface ReminderState {
   firstSeenAt: number;
   snoozeUntil: number;
   dismissedForever: boolean;
-  lastMilestoneShown: number;
-  timeFallbackUsed: boolean;
   shownThisSession: boolean;
 }
 
-/** Smallest ladder value strictly greater than `last` (fixed list, then +STEP tail). */
-export function nextMilestone(last: number): number {
-  for (const m of MILESTONES) {
-    if (m > last) return m;
-  }
-  return Math.floor(last / MILESTONE_STEP) * MILESTONE_STEP + MILESTONE_STEP;
-}
-
-/** Highest ladder value <= count (fixed list or +STEP tail); 0 if none reached. */
-export function highestLadderValue(count: number): number {
-  let highest = 0;
-  for (const m of MILESTONES) {
-    if (m <= count) highest = m;
-  }
-  const lastFixed = MILESTONES[MILESTONES.length - 1];
-  if (count > lastFixed) {
-    highest = Math.max(highest, Math.floor(count / MILESTONE_STEP) * MILESTONE_STEP);
-  }
-  return highest;
-}
-
-/** Pure eligibility decision. `now` and `callCount` injected for testability. */
+/**
+ * Pure eligibility decision. `now` and `callCount` injected for testability.
+ * Weekly cadence is governed by `snoozeUntil`; this only gates the FIRST show
+ * (don't nag a brand-new install before it has handled a call or existed 3 days).
+ */
 export function isEligible(
   state: ReminderState,
   callCount: number | undefined,
@@ -39,9 +20,7 @@ export function isEligible(
   if (state.dismissedForever) return false;
   if (state.shownThisSession) return false;
   if (now < state.snoozeUntil) return false;
-  const milestoneHit =
-    callCount !== undefined && callCount >= nextMilestone(state.lastMilestoneShown);
-  const timeFallback =
-    !state.timeFallbackUsed && now - state.firstSeenAt >= TIME_FALLBACK_MS;
-  return milestoneHit || timeFallback;
+  const hasUsage = callCount !== undefined && callCount >= 1;
+  const agedIn = now - state.firstSeenAt >= FIRST_SHOW_DELAY_MS;
+  return hasUsage || agedIn;
 }

--- a/admin_ui/frontend/src/utils/donationReminder.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.ts
@@ -1,0 +1,46 @@
+import { MILESTONES, MILESTONE_STEP, TIME_FALLBACK_MS } from '../config/donation';
+
+export interface ReminderState {
+  firstSeenAt: number;
+  snoozeUntil: number;
+  dismissedForever: boolean;
+  lastMilestoneShown: number;
+  timeFallbackUsed: boolean;
+  shownThisSession: boolean;
+}
+
+/** Smallest ladder value strictly greater than `last` (fixed list, then +STEP tail). */
+export function nextMilestone(last: number): number {
+  for (const m of MILESTONES) {
+    if (m > last) return m;
+  }
+  return Math.floor(last / MILESTONE_STEP) * MILESTONE_STEP + MILESTONE_STEP;
+}
+
+/** Highest ladder value <= count (fixed list or +STEP tail); 0 if none reached. */
+export function highestLadderValue(count: number): number {
+  let highest = 0;
+  for (const m of MILESTONES) {
+    if (m <= count) highest = m;
+  }
+  if (count >= MILESTONE_STEP) {
+    highest = Math.max(highest, Math.floor(count / MILESTONE_STEP) * MILESTONE_STEP);
+  }
+  return highest;
+}
+
+/** Pure eligibility decision. `now` and `callCount` injected for testability. */
+export function isEligible(
+  state: ReminderState,
+  callCount: number | undefined,
+  now: number,
+): boolean {
+  if (state.dismissedForever) return false;
+  if (state.shownThisSession) return false;
+  if (now < state.snoozeUntil) return false;
+  const milestoneHit =
+    callCount !== undefined && callCount >= nextMilestone(state.lastMilestoneShown);
+  const timeFallback =
+    !state.timeFallbackUsed && now - state.firstSeenAt >= TIME_FALLBACK_MS;
+  return milestoneHit || timeFallback;
+}

--- a/admin_ui/frontend/src/utils/donationReminder.ts
+++ b/admin_ui/frontend/src/utils/donationReminder.ts
@@ -23,7 +23,8 @@ export function highestLadderValue(count: number): number {
   for (const m of MILESTONES) {
     if (m <= count) highest = m;
   }
-  if (count >= MILESTONE_STEP) {
+  const lastFixed = MILESTONES[MILESTONES.length - 1];
+  if (count > lastFixed) {
     highest = Math.max(highest, Math.floor(count / MILESTONE_STEP) * MILESTONE_STEP);
   }
   return highest;

--- a/admin_ui/frontend/vite.config.ts
+++ b/admin_ui/frontend/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     // cleanup (so portal-rendered dialogs don't leak across component tests).
     test: {
         globals: true,
+        // Node 25+ stubs global.localStorage without .clear(); patch it with
+        // the real jsdom Storage in all jsdom-environment tests.
+        setupFiles: ['./src/setupTests.ts'],
     },
     css: {
         postcss: {

--- a/admin_ui/frontend/vite.config.ts
+++ b/admin_ui/frontend/vite.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
         globals: true,
         // Node 25+ stubs global.localStorage without .clear(); patch it with
         // the real jsdom Storage in all jsdom-environment tests.
+        // Global setupFiles: the shim self-guards on `typeof window`, so it only
+        // patches storage in jsdom-environment tests; node-env tests are untouched.
         setupFiles: ['./src/setupTests.ts'],
     },
     css: {


### PR DESCRIPTION
## Summary

Adds a respectful, in-product way for self-hosted operators to support the project from inside the admin UI (previously the funding links lived only in the README and the repo Sponsor button).

Two parts:
- A persistent **Support on Ko-fi** / **Sponsor** link in the sidebar's Support group.
- A gentle, dismissible reminder **banner on the Dashboard**.

## Banner behavior

- First appears once the install has handled a call (or after 3 days) — it never nags a brand-new, zero-call install.
- Recurs on a weekly cadence.
- Actions: **Support on Ko-fi** / **Sponsor** (snooze 1 week), **I already donated** (snooze 3 months), **Maybe later** (1 week), and **Don't show again** → a quick "really?" confirm → keep reminders (~1 month) or hide permanently.

## Privacy / self-hosted friendly

- Local links only — no embedded third-party script, no analytics, and no Ko-fi/GitHub network traffic unless the operator clicks.
- The only request is the same-origin `/api/calls/stats` (already used by Call History) to show the call count.
- Dismissal/snooze state is per-browser (localStorage/sessionStorage) and fails closed if storage is unavailable.

## Implementation

- Frontend-only and additive — no backend or call-path changes.
- Pure eligibility logic (`utils/donationReminder.ts`), a hook owning storage + the one-shot stats fetch (`hooks/useDonationReminder.ts`), a presentational banner (`components/DonationBanner.tsx`), and shared constants (`config/donation.ts`).
- Reuses the existing Ko-fi and GitHub Sponsors links already declared in `.github/FUNDING.yml`.
- Adds a small Node-25 jsdom `localStorage` shim to the test setup (`src/setupTests.ts` + `vite.config.ts`) so storage-using tests run on Node 25.

## Testing

- Vitest unit + component + hook-integration tests: eligibility matrix, snooze durations, the confirm flow, fail-closed storage, and link/a11y attributes. Full admin_ui frontend suite green.
- `npm run build` clean.
- Manually verified on a dev server: banner renders, every action behaves, links open in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Support” entry to the sidebar with links to Ko-fi and GitHub Sponsors.
  * Added a dismissible donation/reminder banner on the dashboard with snooze options and a “Really?” confirmation to hide permanently.

* **Bug Fixes**
  * Reminder display now correctly follows per-browser snooze timing, permanent dismissal, and “shown this session” rules, including handling unknown call counts.

* **Tests**
  * Added unit/integration coverage for the reminder eligibility logic, the reminder hook behavior, and banner rendering/interaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->