### PR TITLE
release: v7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.2] - 2026-06-27
+
 ### Added
 
 - **Managed Tools REST API** (`/api/tools`): authenticated CRUD endpoints for


### PR DESCRIPTION
Rolls `CHANGELOG.md` `[Unreleased]` → `[7.1.2] - 2026-06-27` for the v7.1.2 release (donation support #471, Managed Tools API, #468, #458, #464, #437, #438). Docs-only; no code change. Tagging `v7.1.2` once merged.

Note: per-issue version-reference bumps (README badge, INSTALLATION.md, SECURITY.md, contributing/README.md) are intentionally deferred — can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release heading in the changelog for version 7.1.2, dated 2026-06-27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->