### PR TITLE
[codex] Add pushed live status dashboard updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -552,6 +552,14 @@ SMTP_HOST=
 # SECURITY: Required for remote access to sensitive endpoints (/reload, /mcp/test/*)
 # Generate with: openssl rand -hex 32
 # HEALTH_API_TOKEN=
+#
+# OPTIONAL: Admin UI live-status push from ai_engine/local_ai_server.
+# Uses LIVE_STATUS_PUSH_TOKEN when set, otherwise falls back to HEALTH_API_TOKEN.
+# In the default host-network compose setup, the Admin UI API is reachable on 127.0.0.1:3003.
+# LIVE_STATUS_ADMIN_URL=http://127.0.0.1:3003
+# LIVE_STATUS_PUSH_TOKEN=
+# LIVE_STATUS_PUSH_INTERVAL_SECONDS=10
+# LIVE_STATUS_PUSH_TIMEOUT_SECONDS=10
 
 # ═══════════════════════════════════════════════════════════════════════════
 # DIAGNOSTIC: Audio Debugging (Troubleshooting Only)

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -106,7 +106,7 @@ def _ai_engine_env_key(key: str) -> bool:
 def _local_ai_env_key(key: str) -> bool:
     return (
         _is_prefix(key, ("LOCAL_", "KROKO_", "FASTER_WHISPER_", "WHISPER_CPP_", "MELOTTS_", "KOKORO_"))
-        or key in ("SHERPA_MODEL_PATH",)
+        or key in ("SHERPA_MODEL_PATH", "HEALTH_API_TOKEN")
         or key in _LIVE_STATUS_PUBLISHER_KEYS
     )
 

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -91,6 +91,7 @@ def _ai_engine_env_key(key: str) -> bool:
         or _is_prefix(key, ("SMTP_",))
         # Local provider runtime uses these env vars via ${LOCAL_WS_*} placeholders in ai-agent.yaml
         or _is_prefix(key, ("LOCAL_WS_",))
+        or _is_prefix(key, ("LIVE_STATUS_",))
     )
 
 
@@ -98,6 +99,7 @@ def _local_ai_env_key(key: str) -> bool:
     return (
         _is_prefix(key, ("LOCAL_", "KROKO_", "FASTER_WHISPER_", "WHISPER_CPP_", "MELOTTS_", "KOKORO_"))
         or key in ("SHERPA_MODEL_PATH",)
+        or _is_prefix(key, ("LIVE_STATUS_",))
     )
 
 
@@ -109,8 +111,9 @@ def _admin_ui_env_key(key: str) -> bool:
     # admin_ui-impacting keys, which is honest signaling: changes affect this
     # service's runtime behavior. Refs #370.
     return (
-        key in ("JWT_SECRET", "DOCKER_SOCK", "DOCKER_GID", "TZ")
+        key in ("JWT_SECRET", "DOCKER_SOCK", "DOCKER_GID", "TZ", "HEALTH_API_TOKEN", "LIVE_STATUS_PUSH_TOKEN")
         or _is_prefix(key, ("UVICORN_", "ADMIN_UI_", "AAVA_HTTP_TOOL_TEST_"))
+        or key == "LIVE_STATUS_POLL_INTERVAL_SECONDS"
     )
 
 
@@ -694,6 +697,12 @@ def persist_config_content(content: str) -> dict:
         "message": f"Configuration saved. {'Hot reload' if recommended_method == 'hot_reload' else 'Restart'} AI Engine to apply changes.",
         "warnings": warnings,
     }
+
+
+@router.get("")
+@router.get("/")
+async def get_config():
+    return _read_merged_config_dict()
 
 
 @router.post("/yaml")

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -29,6 +29,14 @@ def _is_prefix(key: str, prefixes: tuple[str, ...]) -> bool:
     return any(key.startswith(p) for p in prefixes)
 
 
+_LIVE_STATUS_PUBLISHER_KEYS = {
+    "LIVE_STATUS_ADMIN_URL",
+    "LIVE_STATUS_PUSH_TOKEN",
+    "LIVE_STATUS_PUSH_INTERVAL_SECONDS",
+    "LIVE_STATUS_PUSH_TIMEOUT_SECONDS",
+}
+
+
 def _running_container_names() -> set:
     """Return a set of container names that are currently running."""
     try:
@@ -91,7 +99,7 @@ def _ai_engine_env_key(key: str) -> bool:
         or _is_prefix(key, ("SMTP_",))
         # Local provider runtime uses these env vars via ${LOCAL_WS_*} placeholders in ai-agent.yaml
         or _is_prefix(key, ("LOCAL_WS_",))
-        or _is_prefix(key, ("LIVE_STATUS_",))
+        or key in _LIVE_STATUS_PUBLISHER_KEYS
     )
 
 
@@ -99,7 +107,7 @@ def _local_ai_env_key(key: str) -> bool:
     return (
         _is_prefix(key, ("LOCAL_", "KROKO_", "FASTER_WHISPER_", "WHISPER_CPP_", "MELOTTS_", "KOKORO_"))
         or key in ("SHERPA_MODEL_PATH",)
-        or _is_prefix(key, ("LIVE_STATUS_",))
+        or key in _LIVE_STATUS_PUBLISHER_KEYS
     )
 
 
@@ -113,7 +121,7 @@ def _admin_ui_env_key(key: str) -> bool:
     return (
         key in ("JWT_SECRET", "DOCKER_SOCK", "DOCKER_GID", "TZ", "HEALTH_API_TOKEN", "LIVE_STATUS_PUSH_TOKEN")
         or _is_prefix(key, ("UVICORN_", "ADMIN_UI_", "AAVA_HTTP_TOOL_TEST_"))
-        or key == "LIVE_STATUS_POLL_INTERVAL_SECONDS"
+        or key in ("LIVE_STATUS_POLL_INTERVAL_SECONDS", "LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS")
     )
 
 

--- a/admin_ui/backend/api/live_status.py
+++ b/admin_ui/backend/api/live_status.py
@@ -305,7 +305,11 @@ async def refresh_live_status() -> dict:
 
 
 def _poll_interval_seconds() -> float:
-    raw = (os.getenv("LIVE_STATUS_POLL_INTERVAL_SECONDS") or "30").strip()
+    raw = (
+        system_api._dotenv_value("LIVE_STATUS_POLL_INTERVAL_SECONDS")
+        or os.getenv("LIVE_STATUS_POLL_INTERVAL_SECONDS")
+        or "30"
+    ).strip()
     try:
         return max(2.0, float(raw))
     except ValueError:
@@ -313,7 +317,11 @@ def _poll_interval_seconds() -> float:
 
 
 def _initial_probe_timeout_seconds() -> float:
-    raw = (os.getenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS") or "2").strip()
+    raw = (
+        system_api._dotenv_value("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS")
+        or os.getenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS")
+        or "2"
+    ).strip()
     try:
         return max(0.1, float(raw))
     except ValueError:
@@ -328,7 +336,6 @@ def _ensure_probe_loop() -> None:
 
 
 async def _probe_loop() -> None:
-    interval = _poll_interval_seconds()
     while True:
         try:
             await refresh_live_status()
@@ -336,6 +343,7 @@ async def _probe_loop() -> None:
             raise
         except Exception as exc:
             logger.debug("live-status probe refresh failed: %s", exc)
+        interval = _poll_interval_seconds()
         await asyncio.sleep(interval)
 
 

--- a/admin_ui/backend/api/live_status.py
+++ b/admin_ui/backend/api/live_status.py
@@ -115,7 +115,7 @@ def normalize_probe_results(results: Dict[str, Any]) -> Dict[str, dict]:
         ai = health.get("ai_engine") or {}
         ai_details = ai.get("details") or {}
         ai_connected = ai.get("status") == "connected"
-        ai_healthy = ai_details.get("status") in {None, "healthy", "ok"} and ai_connected
+        ai_health_status = str(ai_details.get("status") or "healthy").lower()
         providers = ai_details.get("providers") or {}
         provider_warnings = [
             f"{name}: {info.get('reason') or 'not ready'}"
@@ -126,9 +126,22 @@ def normalize_probe_results(results: Dict[str, Any]) -> Dict[str, dict]:
         if ai.get("warning"):
             ai_warnings.append(ai["warning"])
         ai_warnings.extend(provider_warnings)
+        if ai_connected and ai_health_status not in {"healthy", "ok"}:
+            ai_warnings.append(f"health status: {ai_health_status}")
+        if ai_connected and ai_details.get("ari_connected") is False:
+            ai_warnings.append("ARI disconnected")
+        ai_degraded = ai_connected and (
+            bool(provider_warnings)
+            or ai_health_status not in {"healthy", "ok"}
+            or ai_details.get("ari_connected") is False
+        )
         components["ai_engine"] = component(
-            state=_state_from_bool(ai_connected, degraded=bool(provider_warnings) and ai_healthy),
-            summary="AI Engine connected" if ai_connected else "AI Engine unreachable",
+            state=_state_from_bool(ai_connected, degraded=ai_degraded),
+            summary=(
+                "AI Engine degraded"
+                if ai_degraded
+                else "AI Engine connected" if ai_connected else "AI Engine unreachable"
+            ),
             details={
                 "ari_connected": ai_details.get("ari_connected"),
                 "audio_transport": ai_details.get("audio_transport"),

--- a/admin_ui/backend/api/live_status.py
+++ b/admin_ui/backend/api/live_status.py
@@ -26,6 +26,7 @@ publish_router = APIRouter()
 status_hub = StatusHub()
 _probe_task: asyncio.Task | None = None
 _PUSH_COMPONENTS = {"ai_engine", "local_ai_server", "sessions"}
+_PROBE_COMPONENTS = {"directories", "platform", "asterisk", "metrics"}
 
 
 def _state_from_bool(ok: bool | None, *, degraded: bool = False) -> str:
@@ -45,7 +46,18 @@ def _exception_component(name: str, exc: BaseException) -> dict:
 
 
 def _push_token() -> str:
-    return (os.getenv("LIVE_STATUS_PUSH_TOKEN") or os.getenv("HEALTH_API_TOKEN") or "").strip()
+    return (
+        system_api._dotenv_value("LIVE_STATUS_PUSH_TOKEN")
+        or system_api._dotenv_value("HEALTH_API_TOKEN")
+        or os.getenv("LIVE_STATUS_PUSH_TOKEN")
+        or os.getenv("HEALTH_API_TOKEN")
+        or ""
+    ).strip()
+
+
+def _has_probe_components(snapshot: dict) -> bool:
+    components = snapshot.get("components") or {}
+    return _PROBE_COMPONENTS.issubset(components.keys())
 
 
 def _require_push_auth(authorization: str | None) -> None:
@@ -134,11 +146,16 @@ def normalize_probe_results(results: Dict[str, Any]) -> Dict[str, dict]:
         local = health.get("local_ai_server") or {}
         local_details = local.get("details") or {}
         local_connected = local.get("status") == "connected"
-        startup_errors = (local_details.get("config") or {}).get("startup_errors") or {}
+        local_config = local_details.get("config") or {}
+        startup_errors = local_config.get("startup_errors") or {}
         models = local_details.get("models") or {}
         model_count = sum(1 for value in models.values() if isinstance(value, dict))
         loaded_count = sum(1 for value in models.values() if isinstance(value, dict) and value.get("loaded") is True)
-        local_degraded = bool(startup_errors) or (model_count > 0 and loaded_count < model_count)
+        local_degraded = (
+            bool(local_config.get("degraded"))
+            or bool(startup_errors)
+            or (model_count > 0 and loaded_count < model_count)
+        )
         local_warnings = []
         if local.get("warning"):
             local_warnings.append(local["warning"])
@@ -152,8 +169,8 @@ def normalize_probe_results(results: Dict[str, Any]) -> Dict[str, dict]:
             ),
             details={
                 "models": models,
-                "runtime_mode": (local_details.get("config") or {}).get("runtime_mode"),
-                "degraded": (local_details.get("config") or {}).get("degraded"),
+                "runtime_mode": local_config.get("runtime_mode"),
+                "degraded": local_config.get("degraded"),
                 "gpu": local_details.get("gpu") or {},
                 "probe": local.get("probe") or {},
             },
@@ -327,8 +344,9 @@ def encode_sse(event: str, data: dict, event_id: int | None = None) -> str:
 
 @router.get("/live-status")
 async def get_live_status():
+    _ensure_probe_loop()
     snapshot = await status_hub.snapshot()
-    if snapshot.get("components"):
+    if snapshot.get("components") and _has_probe_components(snapshot):
         return snapshot
     try:
         return await asyncio.wait_for(refresh_live_status(), timeout=_initial_probe_timeout_seconds())

--- a/admin_ui/backend/api/live_status.py
+++ b/admin_ui/backend/api/live_status.py
@@ -286,21 +286,17 @@ async def probe_live_status() -> Dict[str, Any]:
     return dict(zip(names, values))
 
 
-def _run_probe_live_status_sync() -> Dict[str, Any]:
-    return asyncio.run(probe_live_status())
-
-
 async def refresh_live_status() -> dict:
-    results = await asyncio.to_thread(_run_probe_live_status_sync)
+    results = await probe_live_status()
     return await status_hub.upsert_components(normalize_probe_results(results))
 
 
 def _poll_interval_seconds() -> float:
-    raw = (os.getenv("LIVE_STATUS_POLL_INTERVAL_SECONDS") or "60").strip()
+    raw = (os.getenv("LIVE_STATUS_POLL_INTERVAL_SECONDS") or "30").strip()
     try:
         return max(2.0, float(raw))
     except ValueError:
-        return 60.0
+        return 30.0
 
 
 def _initial_probe_timeout_seconds() -> float:

--- a/admin_ui/backend/api/live_status.py
+++ b/admin_ui/backend/api/live_status.py
@@ -1,0 +1,373 @@
+"""Normalized live status endpoints for the dashboard.
+
+Phase 0 intentionally uses existing Admin UI probes as the source of truth.
+AI Engine and Local AI push publishers can feed the same hub later without
+changing the browser contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from api import system as system_api
+from services.status_hub import StatusHub, component
+
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+publish_router = APIRouter()
+status_hub = StatusHub()
+_probe_task: asyncio.Task | None = None
+_PUSH_COMPONENTS = {"ai_engine", "local_ai_server", "sessions"}
+
+
+def _state_from_bool(ok: bool | None, *, degraded: bool = False) -> str:
+    if ok is True:
+        return "degraded" if degraded else "ready"
+    if ok is False:
+        return "unreachable"
+    return "unknown"
+
+
+def _exception_component(name: str, exc: BaseException) -> dict:
+    return component(
+        state="error",
+        summary=f"{name} probe failed",
+        errors=[f"{type(exc).__name__}: {exc}"],
+    )
+
+
+def _push_token() -> str:
+    return (os.getenv("LIVE_STATUS_PUSH_TOKEN") or os.getenv("HEALTH_API_TOKEN") or "").strip()
+
+
+def _require_push_auth(authorization: str | None) -> None:
+    token = _push_token()
+    if not token:
+        raise HTTPException(status_code=503, detail="live-status push is not configured")
+    expected = f"Bearer {token}"
+    if authorization != expected:
+        raise HTTPException(status_code=403, detail="invalid live-status push token")
+
+
+def normalize_push_payload(payload: Dict[str, Any]) -> Dict[str, dict]:
+    """Normalize service-pushed component updates into the hub contract."""
+    raw_components = payload.get("components")
+    if raw_components is None and payload.get("component"):
+        raw_components = {payload["component"]: payload}
+    if not isinstance(raw_components, dict) or not raw_components:
+        raise HTTPException(status_code=400, detail="components is required")
+
+    source = str(payload.get("source") or "push")
+    updates: Dict[str, dict] = {}
+    for name, raw in raw_components.items():
+        if name not in _PUSH_COMPONENTS:
+            raise HTTPException(status_code=400, detail=f"unsupported component: {name}")
+        if not isinstance(raw, dict):
+            raise HTTPException(status_code=400, detail=f"component {name} must be an object")
+        state = str(raw.get("state") or "").strip()
+        summary = str(raw.get("summary") or "").strip()
+        if not state or not summary:
+            raise HTTPException(status_code=400, detail=f"component {name} requires state and summary")
+        updates[name] = component(
+            state=state,
+            summary=summary,
+            source="push",
+            details=raw.get("details") if isinstance(raw.get("details"), dict) else {},
+            metrics=raw.get("metrics") if isinstance(raw.get("metrics"), dict) else {},
+            warnings=raw.get("warnings") if isinstance(raw.get("warnings"), list) else [],
+            errors=raw.get("errors") if isinstance(raw.get("errors"), list) else [],
+            updated_at=raw.get("updated_at") if isinstance(raw.get("updated_at"), str) else None,
+        )
+        updates[name]["publisher"] = source
+    return updates
+
+
+def normalize_probe_results(results: Dict[str, Any]) -> Dict[str, dict]:
+    """Convert existing dashboard probe responses into one stable status model."""
+    components: Dict[str, dict] = {}
+
+    health = results.get("health")
+    if isinstance(health, BaseException):
+        components["ai_engine"] = _exception_component("AI Engine", health)
+        components["local_ai_server"] = _exception_component("Local AI Server", health)
+    else:
+        health = health or {}
+        ai = health.get("ai_engine") or {}
+        ai_details = ai.get("details") or {}
+        ai_connected = ai.get("status") == "connected"
+        ai_healthy = ai_details.get("status") in {None, "healthy", "ok"} and ai_connected
+        providers = ai_details.get("providers") or {}
+        provider_warnings = [
+            f"{name}: {info.get('reason') or 'not ready'}"
+            for name, info in providers.items()
+            if isinstance(info, dict) and info.get("ready") is False
+        ]
+        ai_warnings = []
+        if ai.get("warning"):
+            ai_warnings.append(ai["warning"])
+        ai_warnings.extend(provider_warnings)
+        components["ai_engine"] = component(
+            state=_state_from_bool(ai_connected, degraded=bool(provider_warnings) and ai_healthy),
+            summary="AI Engine connected" if ai_connected else "AI Engine unreachable",
+            details={
+                "ari_connected": ai_details.get("ari_connected"),
+                "audio_transport": ai_details.get("audio_transport"),
+                "active_calls": ai_details.get("active_calls", 0),
+                "active_sessions": ai_details.get("active_sessions", 0),
+                "asterisk_channels": ai_details.get("asterisk_channels", 0),
+                "providers": providers,
+                "pipelines": ai_details.get("pipelines") or {},
+                "probe": ai.get("probe") or {},
+            },
+            warnings=ai_warnings,
+            errors=[] if ai_connected else [ai_details.get("error") or "AI Engine health endpoint unreachable"],
+        )
+
+        local = health.get("local_ai_server") or {}
+        local_details = local.get("details") or {}
+        local_connected = local.get("status") == "connected"
+        startup_errors = (local_details.get("config") or {}).get("startup_errors") or {}
+        models = local_details.get("models") or {}
+        model_count = sum(1 for value in models.values() if isinstance(value, dict))
+        loaded_count = sum(1 for value in models.values() if isinstance(value, dict) and value.get("loaded") is True)
+        local_degraded = bool(startup_errors) or (model_count > 0 and loaded_count < model_count)
+        local_warnings = []
+        if local.get("warning"):
+            local_warnings.append(local["warning"])
+        local_warnings.extend([f"{key}: {value}" for key, value in startup_errors.items()])
+        components["local_ai_server"] = component(
+            state=_state_from_bool(local_connected, degraded=local_degraded),
+            summary=(
+                f"Local AI connected, {loaded_count}/{model_count} models loaded"
+                if local_connected
+                else "Local AI unreachable"
+            ),
+            details={
+                "models": models,
+                "runtime_mode": (local_details.get("config") or {}).get("runtime_mode"),
+                "degraded": (local_details.get("config") or {}).get("degraded"),
+                "gpu": local_details.get("gpu") or {},
+                "probe": local.get("probe") or {},
+            },
+            warnings=local_warnings,
+            errors=[] if local_connected else [local_details.get("error") or "Local AI status WebSocket unreachable"],
+        )
+
+    sessions = results.get("sessions")
+    if isinstance(sessions, BaseException):
+        components["sessions"] = _exception_component("Sessions", sessions)
+    else:
+        sessions = sessions or {}
+        reachable = sessions.get("reachable")
+        components["sessions"] = component(
+            state=_state_from_bool(reachable),
+            summary=f"{sessions.get('active_calls', 0)} active calls",
+            details={
+                "active_calls": sessions.get("active_calls", 0),
+                "sessions": sessions.get("sessions") or [],
+                "reachable": reachable,
+            },
+        )
+
+    directories = results.get("directories")
+    if isinstance(directories, BaseException):
+        components["directories"] = _exception_component("Audio directories", directories)
+    else:
+        directories = directories or {}
+        overall = directories.get("overall")
+        dir_state = "ready" if overall == "healthy" else "degraded" if overall == "warning" else "error"
+        errors = [
+            f"{name}: {check.get('message')}"
+            for name, check in (directories.get("checks") or {}).items()
+            if isinstance(check, dict) and check.get("status") == "error"
+        ]
+        warnings = [
+            f"{name}: {check.get('message')}"
+            for name, check in (directories.get("checks") or {}).items()
+            if isinstance(check, dict) and check.get("status") == "warning"
+        ]
+        components["directories"] = component(
+            state=dir_state,
+            summary=f"Audio directories {overall or 'unknown'}",
+            details=directories,
+            warnings=warnings,
+            errors=errors,
+        )
+
+    platform = results.get("platform")
+    if isinstance(platform, BaseException):
+        components["platform"] = _exception_component("Platform", platform)
+    else:
+        platform = platform or {}
+        summary = platform.get("summary") or {}
+        checks = platform.get("checks") or []
+        ready = summary.get("ready")
+        has_warnings = bool(summary.get("warnings"))
+        has_errors = bool(summary.get("errors"))
+        platform_state = "ready"
+        if ready is not True:
+            platform_state = "error"
+        elif has_warnings or has_errors:
+            platform_state = "degraded"
+        components["platform"] = component(
+            state=platform_state,
+            summary=f"{summary.get('passed', 0)}/{summary.get('total_checks', 0)} platform checks passed",
+            details=platform,
+            warnings=[c.get("message") for c in checks if isinstance(c, dict) and c.get("status") == "warning"],
+            errors=[c.get("message") for c in checks if isinstance(c, dict) and c.get("status") == "error"],
+        )
+
+    asterisk = results.get("asterisk")
+    if isinstance(asterisk, BaseException):
+        components["asterisk"] = _exception_component("Asterisk", asterisk)
+    else:
+        asterisk = asterisk or {}
+        live = asterisk.get("live") or {}
+        reachable = live.get("ari_reachable")
+        app_registered = live.get("app_registered")
+        degraded = reachable is True and app_registered is False
+        components["asterisk"] = component(
+            state=_state_from_bool(reachable, degraded=degraded),
+            summary="Asterisk ARI reachable" if reachable else "Asterisk ARI unreachable",
+            details=asterisk,
+            warnings=[] if app_registered or reachable is not True else ["Stasis app is not registered"],
+            errors=[] if reachable else ["Asterisk ARI is not reachable"],
+        )
+
+    metrics = results.get("metrics")
+    if isinstance(metrics, BaseException):
+        components["metrics"] = _exception_component("System metrics", metrics)
+    else:
+        components["metrics"] = component(
+            state="ready",
+            summary="System metrics available",
+            metrics=metrics or {},
+        )
+
+    return components
+
+
+async def probe_live_status() -> Dict[str, Any]:
+    names = ["health", "sessions", "directories", "platform", "asterisk", "metrics"]
+    values = await asyncio.gather(
+        system_api.get_system_health(),
+        system_api.get_active_sessions(),
+        system_api.get_directory_health(),
+        system_api.get_platform(),
+        system_api.asterisk_status(),
+        system_api.get_system_metrics(),
+        return_exceptions=True,
+    )
+    return dict(zip(names, values))
+
+
+def _run_probe_live_status_sync() -> Dict[str, Any]:
+    return asyncio.run(probe_live_status())
+
+
+async def refresh_live_status() -> dict:
+    results = await asyncio.to_thread(_run_probe_live_status_sync)
+    return await status_hub.upsert_components(normalize_probe_results(results))
+
+
+def _poll_interval_seconds() -> float:
+    raw = (os.getenv("LIVE_STATUS_POLL_INTERVAL_SECONDS") or "60").strip()
+    try:
+        return max(2.0, float(raw))
+    except ValueError:
+        return 60.0
+
+
+def _initial_probe_timeout_seconds() -> float:
+    raw = (os.getenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS") or "2").strip()
+    try:
+        return max(0.1, float(raw))
+    except ValueError:
+        return 2.0
+
+
+def _ensure_probe_loop() -> None:
+    global _probe_task
+    if _probe_task and not _probe_task.done():
+        return
+    _probe_task = asyncio.create_task(_probe_loop(), name="live-status-probe-loop")
+
+
+async def _probe_loop() -> None:
+    interval = _poll_interval_seconds()
+    while True:
+        try:
+            await refresh_live_status()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("live-status probe refresh failed: %s", exc)
+        await asyncio.sleep(interval)
+
+
+def encode_sse(event: str, data: dict, event_id: int | None = None) -> str:
+    lines = []
+    if event_id is not None:
+        lines.append(f"id: {event_id}")
+    lines.append(f"event: {event}")
+    payload = json.dumps(data, separators=(",", ":"), sort_keys=True)
+    for line in payload.splitlines() or [""]:
+        lines.append(f"data: {line}")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+@router.get("/live-status")
+async def get_live_status():
+    snapshot = await status_hub.snapshot()
+    if snapshot.get("components"):
+        return snapshot
+    try:
+        return await asyncio.wait_for(refresh_live_status(), timeout=_initial_probe_timeout_seconds())
+    except (asyncio.TimeoutError, Exception) as exc:
+        logger.debug("live-status initial probe fallback failed: %s", exc)
+        return await status_hub.snapshot()
+
+
+@publish_router.post("/live-status/publish")
+async def publish_live_status(payload: Dict[str, Any], authorization: str | None = Header(default=None)):
+    _require_push_auth(authorization)
+    snapshot = await status_hub.upsert_components(normalize_push_payload(payload))
+    return {"ok": True, "event_id": snapshot["event_id"], "summary": snapshot["summary"]}
+
+
+@router.get("/live-status/stream")
+async def stream_live_status(request: Request):
+    _ensure_probe_loop()
+    queue = await status_hub.subscribe()
+
+    async def events():
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=20.0)
+                    yield encode_sse(event["event"], event["data"], event.get("id"))
+                except asyncio.TimeoutError:
+                    yield ": ping\n\n"
+        finally:
+            await status_hub.unsubscribe(queue)
+
+    return StreamingResponse(
+        events(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/admin_ui/backend/main.py
+++ b/admin_ui/backend/main.py
@@ -115,7 +115,7 @@ if _is_remote_bind and _raw_jwt_secret in _placeholder_secrets:
         _uvicorn_host,
     )
 
-from api import config, system, wizard, logs, local_ai, ollama, mcp, calls, outbound, tools, docs, custom_models, agents, support  # noqa: E402
+from api import config, system, live_status, wizard, logs, local_ai, ollama, mcp, calls, outbound, tools, docs, custom_models, agents, support  # noqa: E402
 import auth  # noqa: E402
 from agents_store import AgentsStore  # noqa: E402
 from agents_migration import migrate_if_needed, current_drift  # noqa: E402
@@ -273,6 +273,8 @@ app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 # Protected routes
 app.include_router(config.router, prefix="/api/config", tags=["config"], dependencies=[Depends(auth.get_current_user)])
 app.include_router(system.router, prefix="/api/system", tags=["system"], dependencies=[Depends(auth.get_current_user)])
+app.include_router(live_status.publish_router, prefix="/api/system", tags=["system"])
+app.include_router(live_status.router, prefix="/api/system", tags=["system"], dependencies=[Depends(auth.get_current_user)])
 app.include_router(wizard.router, prefix="/api/wizard", tags=["wizard"], dependencies=[Depends(auth.get_current_user)])
 app.include_router(logs.router, prefix="/api/logs", tags=["logs"], dependencies=[Depends(auth.get_current_user)])
 app.include_router(local_ai.router, prefix="/api/local-ai", tags=["local-ai"], dependencies=[Depends(auth.get_current_user)])

--- a/admin_ui/backend/services/status_hub.py
+++ b/admin_ui/backend/services/status_hub.py
@@ -1,0 +1,183 @@
+"""In-memory live-status registry for the Admin UI backend.
+
+The hub stores normalized component status snapshots and fans updates out to
+SSE clients. It deliberately has no dependency on FastAPI so the state machine
+can be tested directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+
+
+Component = Dict[str, Any]
+Snapshot = Dict[str, Any]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _default_monotonic() -> float:
+    import time
+
+    return time.monotonic()
+
+
+def _overall_state(components: Dict[str, Component]) -> str:
+    states = {str(component.get("state") or "unknown") for component in components.values()}
+    if not states:
+        return "unknown"
+    if "unreachable" in states or "error" in states:
+        return "error"
+    if "degraded" in states or "stale" in states or "warning" in states:
+        return "degraded"
+    if states == {"ready"}:
+        return "ready"
+    if "unknown" in states:
+        return "unknown"
+    return "degraded"
+
+
+class StatusHub:
+    """Small async-safe status registry with bounded subscriber queues."""
+
+    def __init__(
+        self,
+        *,
+        stale_after_seconds: float = 15.0,
+        unreachable_after_seconds: float = 45.0,
+        queue_size: int = 8,
+        monotonic_clock: Callable[[], float] = _default_monotonic,
+        wall_clock: Callable[[], str] = utc_now_iso,
+    ) -> None:
+        self.stale_after_seconds = stale_after_seconds
+        self.unreachable_after_seconds = unreachable_after_seconds
+        self.queue_size = queue_size
+        self._monotonic_clock = monotonic_clock
+        self._wall_clock = wall_clock
+        self._components: Dict[str, Component] = {}
+        self._observed_at: Dict[str, float] = {}
+        self._event_id = 0
+        self._lock = asyncio.Lock()
+        self._subscribers: set[asyncio.Queue[dict]] = set()
+
+    async def upsert_components(self, components: Dict[str, Component]) -> Snapshot:
+        """Merge component updates and broadcast the resulting snapshot."""
+        now_mono = self._monotonic_clock()
+        now_wall = self._wall_clock()
+        async with self._lock:
+            for name, component in components.items():
+                normalized = copy.deepcopy(component)
+                normalized.setdefault("updated_at", now_wall)
+                normalized.setdefault("source", "probe")
+                if self._should_keep_existing_locked(name, normalized, now_mono):
+                    continue
+                self._components[name] = normalized
+                self._observed_at[name] = now_mono
+            self._event_id += 1
+            snapshot = self._build_snapshot_locked(now_mono, now_wall)
+
+        await self._broadcast({"event": "snapshot", "id": snapshot["event_id"], "data": snapshot})
+        return snapshot
+
+    def _should_keep_existing_locked(self, name: str, incoming: Component, now_mono: float) -> bool:
+        existing = self._components.get(name)
+        if not existing:
+            return False
+        incoming_source = str(incoming.get("source") or "probe")
+        existing_source = str(existing.get("source") or "probe")
+        existing_age = max(0.0, now_mono - self._observed_at.get(name, now_mono))
+        return (
+            existing_source == "push"
+            and incoming_source == "probe"
+            and existing_age < self.stale_after_seconds
+        )
+
+    async def snapshot(self) -> Snapshot:
+        now_mono = self._monotonic_clock()
+        now_wall = self._wall_clock()
+        async with self._lock:
+            return self._build_snapshot_locked(now_mono, now_wall)
+
+    async def subscribe(self) -> asyncio.Queue[dict]:
+        queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=self.queue_size)
+        async with self._lock:
+            self._subscribers.add(queue)
+            snapshot = self._build_snapshot_locked(self._monotonic_clock(), self._wall_clock())
+        await self._put_latest(queue, {"event": "snapshot", "id": snapshot["event_id"], "data": snapshot})
+        return queue
+
+    async def unsubscribe(self, queue: asyncio.Queue[dict]) -> None:
+        async with self._lock:
+            self._subscribers.discard(queue)
+
+    def _build_snapshot_locked(self, now_mono: float, now_wall: str) -> Snapshot:
+        components: Dict[str, Component] = {}
+        for name, component in self._components.items():
+            normalized = copy.deepcopy(component)
+            age = max(0.0, now_mono - self._observed_at.get(name, now_mono))
+            normalized["age_seconds"] = round(age, 3)
+            if age >= self.unreachable_after_seconds:
+                normalized["freshness"] = "expired"
+                if normalized.get("state") not in {"disabled", "unknown"}:
+                    normalized["state"] = "unreachable"
+            elif age >= self.stale_after_seconds:
+                normalized["freshness"] = "stale"
+            else:
+                normalized["freshness"] = "fresh"
+            components[name] = normalized
+
+        snapshot: Snapshot = {
+            "version": 1,
+            "event_id": self._event_id,
+            "generated_at": now_wall,
+            "summary": {
+                "state": _overall_state(components),
+                "component_count": len(components),
+            },
+            "components": components,
+        }
+        # Convenience aliases for the frontend migration. The canonical data
+        # remains under `components`.
+        snapshot.update(components)
+        return snapshot
+
+    async def _broadcast(self, event: dict) -> None:
+        subscribers = list(self._subscribers)
+        for queue in subscribers:
+            await self._put_latest(queue, event)
+
+    async def _put_latest(self, queue: asyncio.Queue[dict], event: dict) -> None:
+        while queue.full():
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        queue.put_nowait(copy.deepcopy(event))
+
+
+def component(
+    *,
+    state: str,
+    summary: str,
+    source: str = "probe",
+    details: Optional[dict] = None,
+    metrics: Optional[dict] = None,
+    warnings: Optional[list] = None,
+    errors: Optional[list] = None,
+    updated_at: Optional[str] = None,
+) -> Component:
+    return {
+        "state": state,
+        "summary": summary,
+        "source": source,
+        "updated_at": updated_at or utc_now_iso(),
+        "details": details or {},
+        "metrics": metrics or {},
+        "warnings": warnings or [],
+        "errors": errors or [],
+    }

--- a/admin_ui/backend/tests/test_config_api.py
+++ b/admin_ui/backend/tests/test_config_api.py
@@ -24,3 +24,7 @@ def test_get_config_returns_merged_structured_config(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"providers": {"local": {"type": "local"}}}
+
+
+def test_health_api_token_impacts_local_ai_when_used_as_live_status_fallback():
+    assert config._local_ai_env_key("HEALTH_API_TOKEN") is True

--- a/admin_ui/backend/tests/test_config_api.py
+++ b/admin_ui/backend/tests/test_config_api.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from api import config  # noqa: E402
+
+
+def test_get_config_returns_merged_structured_config(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        "_read_merged_config_dict",
+        lambda: {"providers": {"local": {"type": "local"}}},
+    )
+
+    app = FastAPI()
+    app.include_router(config.router, prefix="/api/config")
+
+    response = TestClient(app).get("/api/config")
+
+    assert response.status_code == 200
+    assert response.json() == {"providers": {"local": {"type": "local"}}}

--- a/admin_ui/backend/tests/test_live_status.py
+++ b/admin_ui/backend/tests/test_live_status.py
@@ -92,6 +92,23 @@ def test_normalize_probe_results_keeps_degraded_dimensions_separate():
     assert components["sessions"]["state"] == "ready"
 
 
+def test_local_ai_config_degraded_marks_component_degraded():
+    results = _sample_results()
+    local_config = results["health"]["local_ai_server"]["details"]["config"]
+    local_config["degraded"] = True
+    local_config["startup_errors"] = {}
+    results["health"]["local_ai_server"]["details"]["models"] = {
+        "stt": {"loaded": True},
+        "llm": {"loaded": True},
+        "tts": {"loaded": True},
+    }
+
+    components = live_status.normalize_probe_results(results)
+
+    assert components["local_ai_server"]["state"] == "degraded"
+    assert components["local_ai_server"]["details"]["degraded"] is True
+
+
 def test_platform_failed_checks_are_error_not_unreachable():
     results = _sample_results()
     results["platform"] = {
@@ -233,6 +250,7 @@ def test_live_status_endpoint_returns_snapshot(monkeypatch):
     hub = StatusHub()
     monkeypatch.setattr(live_status, "status_hub", hub)
     monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
+    monkeypatch.setattr(live_status, "_ensure_probe_loop", lambda: None)
 
     app = FastAPI()
     app.include_router(live_status.router, prefix="/api/system")
@@ -246,16 +264,21 @@ def test_live_status_endpoint_returns_snapshot(monkeypatch):
     ]
 
 
-def test_live_status_endpoint_returns_existing_snapshot_without_probe(monkeypatch):
+def test_live_status_endpoint_returns_fully_hydrated_snapshot_without_probe(monkeypatch):
     async def forbidden_probe():
-        raise AssertionError("probe should not run when the hub already has data")
+        raise AssertionError("probe should not run when the hub already has probe-owned data")
 
     hub = StatusHub()
     asyncio.run(hub.upsert_components({
-        "ai_engine": component(state="ready", summary="AI Engine pushed", source="push")
+        "ai_engine": component(state="ready", summary="AI Engine pushed", source="push"),
+        "directories": component(state="ready", summary="directories ok", source="probe"),
+        "platform": component(state="ready", summary="platform ok", source="probe"),
+        "asterisk": component(state="ready", summary="asterisk ok", source="probe"),
+        "metrics": component(state="ready", summary="metrics ok", source="probe"),
     }))
     monkeypatch.setattr(live_status, "status_hub", hub)
     monkeypatch.setattr(live_status, "probe_live_status", forbidden_probe)
+    monkeypatch.setattr(live_status, "_ensure_probe_loop", lambda: None)
 
     app = FastAPI()
     app.include_router(live_status.router, prefix="/api/system")
@@ -267,9 +290,33 @@ def test_live_status_endpoint_returns_existing_snapshot_without_probe(monkeypatc
     assert body["components"]["ai_engine"]["source"] == "push"
 
 
+def test_live_status_endpoint_enriches_incomplete_push_snapshot(monkeypatch):
+    async def fake_probe():
+        return _sample_results()
+
+    hub = StatusHub()
+    asyncio.run(hub.upsert_components({
+        "ai_engine": component(state="ready", summary="AI Engine pushed", source="push")
+    }))
+    monkeypatch.setattr(live_status, "status_hub", hub)
+    monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
+    monkeypatch.setattr(live_status, "_ensure_probe_loop", lambda: None)
+
+    app = FastAPI()
+    app.include_router(live_status.router, prefix="/api/system")
+    response = TestClient(app).get("/api/system/live-status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["components"]["ai_engine"]["summary"] == "AI Engine pushed"
+    assert body["components"]["directories"]["state"] == "error"
+    assert body["components"]["metrics"]["metrics"]["cpu"]["percent"] == 1.0
+
+
 def test_live_status_publish_requires_service_token(monkeypatch):
     monkeypatch.delenv("LIVE_STATUS_PUSH_TOKEN", raising=False)
     monkeypatch.delenv("HEALTH_API_TOKEN", raising=False)
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
 
     app = FastAPI()
     app.include_router(live_status.publish_router, prefix="/api/system")
@@ -280,6 +327,7 @@ def test_live_status_publish_requires_service_token(monkeypatch):
 
 def test_live_status_publish_upserts_pushed_components(monkeypatch):
     monkeypatch.setenv("LIVE_STATUS_PUSH_TOKEN", "push-secret")
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
     hub = StatusHub()
     monkeypatch.setattr(live_status, "status_hub", hub)
 
@@ -316,6 +364,7 @@ def test_live_status_publish_upserts_pushed_components(monkeypatch):
 
 def test_live_status_publish_rejects_unsupported_component(monkeypatch):
     monkeypatch.setenv("LIVE_STATUS_PUSH_TOKEN", "push-secret")
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
 
     app = FastAPI()
     app.include_router(live_status.publish_router, prefix="/api/system")
@@ -330,6 +379,25 @@ def test_live_status_publish_rejects_unsupported_component(monkeypatch):
     )
 
     assert response.status_code == 400
+
+
+def test_live_status_publish_token_prefers_dotenv_over_stale_process_env(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_PUSH_TOKEN", "old-process-secret")
+    monkeypatch.setattr(
+        live_status.system_api,
+        "_dotenv_value",
+        lambda key: "new-dotenv-secret" if key == "LIVE_STATUS_PUSH_TOKEN" else None,
+    )
+
+    app = FastAPI()
+    app.include_router(live_status.publish_router, prefix="/api/system")
+    response = TestClient(app).post(
+        "/api/system/live-status/publish",
+        headers={"Authorization": "Bearer new-dotenv-secret"},
+        json={"components": {"ai_engine": {"state": "ready", "summary": "ok"}}},
+    )
+
+    assert response.status_code == 200
 
 
 def test_encode_sse_formats_snapshot_event():

--- a/admin_ui/backend/tests/test_live_status.py
+++ b/admin_ui/backend/tests/test_live_status.py
@@ -1,0 +1,341 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from api import live_status  # noqa: E402
+from services.status_hub import StatusHub, component  # noqa: E402
+
+
+def _sample_results():
+    return {
+        "health": {
+            "ai_engine": {
+                "status": "connected",
+                "details": {
+                    "status": "healthy",
+                    "ari_connected": True,
+                    "audio_transport": "audiosocket",
+                    "active_calls": 0,
+                    "active_sessions": 0,
+                    "asterisk_channels": 0,
+                    "providers": {
+                        "openai_realtime": {"ready": True},
+                        "google_live": {"ready": False, "reason": "missing_config"},
+                    },
+                    "pipelines": {"local_hybrid": {"stt": "local_stt"}},
+                },
+            },
+            "local_ai_server": {
+                "status": "connected",
+                "details": {
+                    "models": {
+                        "stt": {"loaded": False},
+                        "llm": {"loaded": False},
+                        "tts": {"loaded": False},
+                    },
+                    "config": {
+                        "runtime_mode": "minimal",
+                        "degraded": True,
+                        "startup_errors": {
+                            "stt": "model missing",
+                            "tts": "model missing",
+                        },
+                    },
+                    "gpu": {"runtime_usable": False},
+                },
+            },
+        },
+        "sessions": {"active_calls": 0, "sessions": [], "reachable": True},
+        "directories": {
+            "overall": "error",
+            "checks": {
+                "media_dir_configured": {
+                    "status": "error",
+                    "message": "AST_MEDIA_DIR not set in environment",
+                },
+                "host_directory": {"status": "ok", "message": "Directory exists and is writable"},
+            },
+        },
+        "platform": {
+            "summary": {
+                "ready": True,
+                "passed": 5,
+                "total_checks": 5,
+                "warnings": 0,
+                "errors": 0,
+            },
+            "checks": [],
+        },
+        "asterisk": {"live": {"ari_reachable": True, "app_registered": True}},
+        "metrics": {"cpu": {"percent": 1.0}},
+    }
+
+
+def test_normalize_probe_results_keeps_degraded_dimensions_separate():
+    components = live_status.normalize_probe_results(_sample_results())
+
+    assert components["ai_engine"]["state"] == "degraded"
+    assert "google_live: missing_config" in components["ai_engine"]["warnings"]
+    assert components["local_ai_server"]["state"] == "degraded"
+    assert "stt: model missing" in components["local_ai_server"]["warnings"]
+    assert components["directories"]["state"] == "error"
+    assert components["platform"]["state"] == "ready"
+    assert components["asterisk"]["state"] == "ready"
+    assert components["sessions"]["state"] == "ready"
+
+
+def test_platform_failed_checks_are_error_not_unreachable():
+    results = _sample_results()
+    results["platform"] = {
+        "summary": {
+            "ready": False,
+            "passed": 4,
+            "total_checks": 5,
+            "warnings": 0,
+            "errors": 1,
+        },
+        "checks": [
+            {
+                "id": "architecture",
+                "status": "error",
+                "message": "Unsupported architecture",
+                "blocking": True,
+            }
+        ],
+    }
+
+    components = live_status.normalize_probe_results(results)
+
+    assert components["platform"]["state"] == "error"
+    assert components["platform"]["errors"] == ["Unsupported architecture"]
+
+
+@pytest.mark.asyncio
+async def test_status_hub_marks_stale_then_unreachable():
+    now = {"mono": 100.0, "wall": "2026-06-26T00:00:00Z"}
+    hub = StatusHub(
+        stale_after_seconds=5.0,
+        unreachable_after_seconds=10.0,
+        monotonic_clock=lambda: now["mono"],
+        wall_clock=lambda: now["wall"],
+    )
+
+    first = await hub.upsert_components({"ai_engine": component(state="ready", summary="ok")})
+    assert first["ai_engine"]["freshness"] == "fresh"
+    assert first["ai_engine"]["state"] == "ready"
+
+    now["mono"] += 6.0
+    stale = await hub.snapshot()
+    assert stale["ai_engine"]["freshness"] == "stale"
+    assert stale["ai_engine"]["state"] == "ready"
+    assert stale["summary"]["state"] == "ready"
+
+    now["mono"] += 5.0
+    expired = await hub.snapshot()
+    assert expired["ai_engine"]["freshness"] == "expired"
+    assert expired["ai_engine"]["state"] == "unreachable"
+    assert expired["summary"]["state"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_status_hub_subscriber_queue_keeps_latest_event():
+    hub = StatusHub(queue_size=1)
+    queue = await hub.subscribe()
+    await queue.get()
+
+    await hub.upsert_components({"ai_engine": component(state="ready", summary="one")})
+    await hub.upsert_components({"ai_engine": component(state="degraded", summary="two")})
+
+    event = await asyncio.wait_for(queue.get(), timeout=1.0)
+    assert event["data"]["event_id"] == 2
+    assert event["data"]["ai_engine"]["summary"] == "two"
+    await hub.unsubscribe(queue)
+
+
+@pytest.mark.asyncio
+async def test_status_hub_prefers_fresh_push_over_probe_then_allows_stale_probe():
+    now = {"mono": 100.0, "wall": "2026-06-26T00:00:00Z"}
+    hub = StatusHub(
+        stale_after_seconds=5.0,
+        unreachable_after_seconds=20.0,
+        monotonic_clock=lambda: now["mono"],
+        wall_clock=lambda: now["wall"],
+    )
+
+    await hub.upsert_components({
+        "ai_engine": component(state="ready", summary="pushed", source="push")
+    })
+    fresh_probe = await hub.upsert_components({
+        "ai_engine": component(state="error", summary="probe miss", source="probe")
+    })
+    assert fresh_probe["components"]["ai_engine"]["summary"] == "pushed"
+    assert fresh_probe["components"]["ai_engine"]["source"] == "push"
+
+    now["mono"] += 6.0
+    stale_probe = await hub.upsert_components({
+        "ai_engine": component(state="ready", summary="probe recovered", source="probe")
+    })
+    assert stale_probe["components"]["ai_engine"]["summary"] == "probe recovered"
+    assert stale_probe["components"]["ai_engine"]["source"] == "probe"
+
+
+@pytest.mark.asyncio
+async def test_refresh_live_status_uses_existing_probe_handlers(monkeypatch):
+    async def fake_probe():
+        return _sample_results()
+
+    hub = StatusHub()
+    monkeypatch.setattr(live_status, "status_hub", hub)
+    monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
+
+    snapshot = await live_status.refresh_live_status()
+
+    assert snapshot["version"] == 1
+    assert snapshot["components"]["platform"]["state"] == "ready"
+    assert snapshot["components"]["local_ai_server"]["state"] == "degraded"
+    assert snapshot["summary"]["state"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_refresh_live_status_offloads_probe_collection(monkeypatch):
+    async def fake_probe():
+        return _sample_results()
+
+    used = {"to_thread": False}
+    real_to_thread = asyncio.to_thread
+
+    async def spy_to_thread(func, *args, **kwargs):
+        used["to_thread"] = True
+        return await real_to_thread(func, *args, **kwargs)
+
+    hub = StatusHub()
+    monkeypatch.setattr(live_status, "status_hub", hub)
+    monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
+    monkeypatch.setattr(live_status.asyncio, "to_thread", spy_to_thread)
+
+    await live_status.refresh_live_status()
+
+    assert used["to_thread"] is True
+
+
+def test_live_status_endpoint_returns_snapshot(monkeypatch):
+    async def fake_probe():
+        return _sample_results()
+
+    hub = StatusHub()
+    monkeypatch.setattr(live_status, "status_hub", hub)
+    monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
+
+    app = FastAPI()
+    app.include_router(live_status.router, prefix="/api/system")
+    response = TestClient(app).get("/api/system/live-status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["components"]["ai_engine"]["details"]["ari_connected"] is True
+    assert body["components"]["directories"]["errors"] == [
+        "media_dir_configured: AST_MEDIA_DIR not set in environment"
+    ]
+
+
+def test_live_status_endpoint_returns_existing_snapshot_without_probe(monkeypatch):
+    async def forbidden_probe():
+        raise AssertionError("probe should not run when the hub already has data")
+
+    hub = StatusHub()
+    asyncio.run(hub.upsert_components({
+        "ai_engine": component(state="ready", summary="AI Engine pushed", source="push")
+    }))
+    monkeypatch.setattr(live_status, "status_hub", hub)
+    monkeypatch.setattr(live_status, "probe_live_status", forbidden_probe)
+
+    app = FastAPI()
+    app.include_router(live_status.router, prefix="/api/system")
+    response = TestClient(app).get("/api/system/live-status")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["components"]["ai_engine"]["summary"] == "AI Engine pushed"
+    assert body["components"]["ai_engine"]["source"] == "push"
+
+
+def test_live_status_publish_requires_service_token(monkeypatch):
+    monkeypatch.delenv("LIVE_STATUS_PUSH_TOKEN", raising=False)
+    monkeypatch.delenv("HEALTH_API_TOKEN", raising=False)
+
+    app = FastAPI()
+    app.include_router(live_status.publish_router, prefix="/api/system")
+    response = TestClient(app).post("/api/system/live-status/publish", json={"components": {}})
+
+    assert response.status_code == 503
+
+
+def test_live_status_publish_upserts_pushed_components(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_PUSH_TOKEN", "push-secret")
+    hub = StatusHub()
+    monkeypatch.setattr(live_status, "status_hub", hub)
+
+    app = FastAPI()
+    app.include_router(live_status.publish_router, prefix="/api/system")
+    response = TestClient(app).post(
+        "/api/system/live-status/publish",
+        headers={"Authorization": "Bearer push-secret"},
+        json={
+            "source": "ai_engine",
+            "components": {
+                "ai_engine": {
+                    "state": "ready",
+                    "summary": "AI Engine pushed status",
+                    "details": {"ari_connected": True},
+                },
+                "sessions": {
+                    "state": "ready",
+                    "summary": "0 active calls",
+                    "details": {"active_calls": 0, "sessions": []},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    snapshot = asyncio.run(hub.snapshot())
+    assert snapshot["components"]["ai_engine"]["source"] == "push"
+    assert snapshot["components"]["ai_engine"]["publisher"] == "ai_engine"
+    assert snapshot["components"]["sessions"]["details"]["active_calls"] == 0
+
+
+def test_live_status_publish_rejects_unsupported_component(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_PUSH_TOKEN", "push-secret")
+
+    app = FastAPI()
+    app.include_router(live_status.publish_router, prefix="/api/system")
+    response = TestClient(app).post(
+        "/api/system/live-status/publish",
+        headers={"Authorization": "Bearer push-secret"},
+        json={
+            "components": {
+                "platform": {"state": "ready", "summary": "not service owned"},
+            },
+        },
+    )
+
+    assert response.status_code == 400
+
+
+def test_encode_sse_formats_snapshot_event():
+    encoded = live_status.encode_sse("snapshot", {"hello": "world"}, 42)
+
+    assert encoded.startswith("id: 42\nevent: snapshot\n")
+    assert encoded.endswith("\n\n")
+    payload = encoded.split("data: ", 1)[1].strip()
+    assert json.loads(payload) == {"hello": "world"}

--- a/admin_ui/backend/tests/test_live_status.py
+++ b/admin_ui/backend/tests/test_live_status.py
@@ -222,25 +222,27 @@ async def test_refresh_live_status_uses_existing_probe_handlers(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_refresh_live_status_offloads_probe_collection(monkeypatch):
+async def test_refresh_live_status_keeps_probe_collection_on_current_loop(monkeypatch):
+    running_loop = asyncio.get_running_loop()
+    observed = {"same_loop": False}
+
     async def fake_probe():
+        observed["same_loop"] = asyncio.get_running_loop() is running_loop
         return _sample_results()
-
-    used = {"to_thread": False}
-    real_to_thread = asyncio.to_thread
-
-    async def spy_to_thread(func, *args, **kwargs):
-        used["to_thread"] = True
-        return await real_to_thread(func, *args, **kwargs)
 
     hub = StatusHub()
     monkeypatch.setattr(live_status, "status_hub", hub)
     monkeypatch.setattr(live_status, "probe_live_status", fake_probe)
-    monkeypatch.setattr(live_status.asyncio, "to_thread", spy_to_thread)
 
     await live_status.refresh_live_status()
 
-    assert used["to_thread"] is True
+    assert observed["same_loop"] is True
+
+
+def test_default_poll_interval_refreshes_before_probe_components_expire(monkeypatch):
+    monkeypatch.delenv("LIVE_STATUS_POLL_INTERVAL_SECONDS", raising=False)
+
+    assert live_status._poll_interval_seconds() < live_status.status_hub.unreachable_after_seconds
 
 
 def test_live_status_endpoint_returns_snapshot(monkeypatch):

--- a/admin_ui/backend/tests/test_live_status.py
+++ b/admin_ui/backend/tests/test_live_status.py
@@ -135,6 +135,21 @@ def test_platform_failed_checks_are_error_not_unreachable():
     assert components["platform"]["errors"] == ["Unsupported architecture"]
 
 
+def test_ai_engine_probe_preserves_degraded_health_without_provider_warnings():
+    results = _sample_results()
+    ai_details = results["health"]["ai_engine"]["details"]
+    ai_details["status"] = "degraded"
+    ai_details["ari_connected"] = False
+    ai_details["providers"] = {"openai_realtime": {"ready": True}}
+
+    components = live_status.normalize_probe_results(results)
+
+    assert components["ai_engine"]["state"] == "degraded"
+    assert components["ai_engine"]["summary"] == "AI Engine degraded"
+    assert "health status: degraded" in components["ai_engine"]["warnings"]
+    assert "ARI disconnected" in components["ai_engine"]["warnings"]
+
+
 @pytest.mark.asyncio
 async def test_status_hub_marks_stale_then_unreachable():
     now = {"mono": 100.0, "wall": "2026-06-26T00:00:00Z"}

--- a/admin_ui/backend/tests/test_live_status.py
+++ b/admin_ui/backend/tests/test_live_status.py
@@ -417,6 +417,56 @@ def test_live_status_publish_token_prefers_dotenv_over_stale_process_env(monkeyp
     assert response.status_code == 200
 
 
+def test_poll_interval_prefers_dotenv_over_process_env(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_POLL_INTERVAL_SECONDS", "10")
+    monkeypatch.setattr(
+        live_status.system_api,
+        "_dotenv_value",
+        lambda key: "45" if key == "LIVE_STATUS_POLL_INTERVAL_SECONDS" else None,
+    )
+
+    assert live_status._poll_interval_seconds() == 45.0
+
+
+def test_poll_interval_falls_back_to_process_env_when_dotenv_absent(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_POLL_INTERVAL_SECONDS", "60")
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
+
+    assert live_status._poll_interval_seconds() == 60.0
+
+
+def test_poll_interval_uses_default_when_both_absent(monkeypatch):
+    monkeypatch.delenv("LIVE_STATUS_POLL_INTERVAL_SECONDS", raising=False)
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
+
+    assert live_status._poll_interval_seconds() == 30.0
+
+
+def test_initial_probe_timeout_prefers_dotenv_over_process_env(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS", "1")
+    monkeypatch.setattr(
+        live_status.system_api,
+        "_dotenv_value",
+        lambda key: "5" if key == "LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS" else None,
+    )
+
+    assert live_status._initial_probe_timeout_seconds() == 5.0
+
+
+def test_initial_probe_timeout_falls_back_to_process_env_when_dotenv_absent(monkeypatch):
+    monkeypatch.setenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS", "3")
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
+
+    assert live_status._initial_probe_timeout_seconds() == 3.0
+
+
+def test_initial_probe_timeout_uses_default_when_both_absent(monkeypatch):
+    monkeypatch.delenv("LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setattr(live_status.system_api, "_dotenv_value", lambda key: None)
+
+    assert live_status._initial_probe_timeout_seconds() == 2.0
+
+
 def test_encode_sse_formats_snapshot_event():
     encoded = live_status.encode_sse("snapshot", {"hello": "world"}, 42)
 

--- a/admin_ui/frontend/src/components/SystemTopology.test.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.test.tsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/vitest';
 import { MemoryRouter } from 'react-router-dom';
 import axios from 'axios';
 import { SystemTopology } from './SystemTopology';
+import type { LiveStatusSnapshot } from '../hooks/useLiveStatus';
 
 vi.mock('axios');
 
@@ -120,9 +121,82 @@ const mockTopologyApis = ({
     });
 };
 
-const renderTopology = () => render(
+const liveStatusSnapshot = (overrides: Partial<LiveStatusSnapshot> = {}): LiveStatusSnapshot => ({
+    version: 1,
+    event_id: 1,
+    generated_at: '2026-06-26T12:00:00Z',
+    summary: { state: 'ready', component_count: 4 },
+    components: {
+        ai_engine: {
+            state: 'ready',
+            freshness: 'fresh',
+            summary: 'AI Engine connected',
+            source: 'probe',
+            updated_at: '2026-06-26T12:00:00Z',
+            details: {
+                ari_connected: true,
+                asterisk_channels: 1,
+                providers: { google_live: { ready: true } },
+            },
+            metrics: {},
+            warnings: [],
+            errors: [],
+        },
+        local_ai_server: {
+            state: 'unreachable',
+            freshness: 'fresh',
+            summary: 'Local AI unreachable',
+            source: 'probe',
+            updated_at: '2026-06-26T12:00:00Z',
+            details: {},
+            metrics: {},
+            warnings: [],
+            errors: ['Local AI status WebSocket unreachable'],
+        },
+        sessions: {
+            state: 'ready',
+            freshness: 'fresh',
+            summary: '1 active calls',
+            source: 'probe',
+            updated_at: '2026-06-26T12:00:00Z',
+            details: {
+                reachable: true,
+                active_calls: 1,
+                sessions: [
+                    {
+                        call_id: 'call-1',
+                        provider: 'google_live',
+                        pipeline: undefined,
+                        conversation_state: 'connected',
+                    },
+                ],
+            },
+            metrics: {},
+            warnings: [],
+            errors: [],
+        },
+        asterisk: {
+            state: 'ready',
+            freshness: 'fresh',
+            summary: 'Asterisk ARI reachable',
+            source: 'probe',
+            updated_at: '2026-06-26T12:00:00Z',
+            details: { live: { ari_reachable: true } },
+            metrics: {},
+            warnings: [],
+            errors: [],
+        },
+    },
+    ai_engine: undefined,
+    local_ai_server: undefined,
+    sessions: undefined,
+    asterisk: undefined,
+    ...overrides,
+});
+
+const renderTopology = (props?: React.ComponentProps<typeof SystemTopology>) => render(
     <MemoryRouter>
-        <SystemTopology />
+        <SystemTopology {...props} />
     </MemoryRouter>
 );
 
@@ -139,6 +213,42 @@ afterEach(() => {
 });
 
 describe('SystemTopology dashboard health', () => {
+    it('hydrates health and sessions from live status without legacy health/session polling', async () => {
+        vi.useFakeTimers();
+        vi.mocked(axios.get).mockImplementation((url) => {
+            if (url === '/api/config/yaml') {
+                return Promise.resolve({ data: { content: cloudConfigYaml } });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        renderTopology({ liveStatusSnapshot: liveStatusSnapshot() });
+        await flushAsyncEffects();
+
+        const requestedUrls = vi.mocked(axios.get).mock.calls.map(([url]) => url);
+        expect(requestedUrls).toContain('/api/config/yaml');
+        expect(requestedUrls).not.toContain('/api/system/health');
+        expect(requestedUrls).not.toContain('/api/system/sessions');
+        expect(screen.getAllByText('1 call').length).toBeGreaterThan(0);
+        expect(screen.getByText('All systems healthy')).toBeInTheDocument();
+    });
+
+    it('does not start legacy health/session polling while waiting for a live status snapshot', async () => {
+        vi.useFakeTimers();
+        vi.mocked(axios.get).mockImplementation((url) => {
+            if (url === '/api/config/yaml') {
+                return Promise.resolve({ data: { content: cloudConfigYaml } });
+            }
+            return Promise.reject(new Error(`Unexpected URL: ${url}`));
+        });
+
+        renderTopology({ liveStatusEnabled: true, liveStatusSnapshot: null });
+        await flushAsyncEffects();
+
+        const requestedUrls = vi.mocked(axios.get).mock.calls.map(([url]) => url);
+        expect(requestedUrls).toEqual(['/api/config/yaml']);
+    });
+
     it('shows healthy for cloud Google Live when Local AI is optional and stopped', async () => {
         vi.useFakeTimers();
         mockTopologyApis();

--- a/admin_ui/frontend/src/components/SystemTopology.test.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.test.tsx
@@ -246,6 +246,19 @@ describe('SystemTopology dashboard health', () => {
         expect(requestedUrls).toContain('/api/system/sessions');
     });
 
+    it('uses legacy health/session polling when live status is disabled after a snapshot error', async () => {
+        vi.useFakeTimers();
+        mockTopologyApis();
+
+        renderTopology({ liveStatusEnabled: false, liveStatusSnapshot: liveStatusSnapshot() });
+        await flushAsyncEffects();
+
+        const requestedUrls = vi.mocked(axios.get).mock.calls.map(([url]) => url);
+        expect(requestedUrls).toContain('/api/config/yaml');
+        expect(requestedUrls).toContain('/api/system/health');
+        expect(requestedUrls).toContain('/api/system/sessions');
+    });
+
     it('shows healthy for cloud Google Live when Local AI is optional and stopped', async () => {
         vi.useFakeTimers();
         mockTopologyApis();

--- a/admin_ui/frontend/src/components/SystemTopology.test.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.test.tsx
@@ -233,20 +233,17 @@ describe('SystemTopology dashboard health', () => {
         expect(screen.getByText('All systems healthy')).toBeInTheDocument();
     });
 
-    it('does not start legacy health/session polling while waiting for a live status snapshot', async () => {
+    it('uses legacy health/session polling while waiting for a live status snapshot', async () => {
         vi.useFakeTimers();
-        vi.mocked(axios.get).mockImplementation((url) => {
-            if (url === '/api/config/yaml') {
-                return Promise.resolve({ data: { content: cloudConfigYaml } });
-            }
-            return Promise.reject(new Error(`Unexpected URL: ${url}`));
-        });
+        mockTopologyApis();
 
         renderTopology({ liveStatusEnabled: true, liveStatusSnapshot: null });
         await flushAsyncEffects();
 
         const requestedUrls = vi.mocked(axios.get).mock.calls.map(([url]) => url);
-        expect(requestedUrls).toEqual(['/api/config/yaml']);
+        expect(requestedUrls).toContain('/api/config/yaml');
+        expect(requestedUrls).toContain('/api/system/health');
+        expect(requestedUrls).toContain('/api/system/sessions');
     });
 
     it('shows healthy for cloud Google Live when Local AI is optional and stopped', async () => {

--- a/admin_ui/frontend/src/components/SystemTopology.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.tsx
@@ -106,7 +106,7 @@ const POLL_BACKOFF_CAP_MS = 30000;
 const nextPollDelay = (base: number, ok: boolean, current: number): number =>
   ok ? base : Math.min(current * 2, POLL_BACKOFF_CAP_MS);
 
-export const SystemTopology = ({ liveStatusSnapshot = null }: SystemTopologyProps) => {
+export const SystemTopology = ({ liveStatusEnabled = true, liveStatusSnapshot = null }: SystemTopologyProps) => {
   const [state, setState] = useState<TopologyState>({
     aiEngineStatus: 'unknown',
     aiEngineDegraded: false,
@@ -130,7 +130,7 @@ export const SystemTopology = ({ liveStatusSnapshot = null }: SystemTopologyProp
   // Kept in a ref so updates don't trigger re-renders; the debounced
   // state lands in `state.providerReady` which IS reactive.
   const providerStreaks = useRef<Map<string, number>>(new Map());
-  const useLiveStatusSource = liveStatusSnapshot != null;
+  const useLiveStatusSource = liveStatusEnabled && liveStatusSnapshot != null;
 
   useEffect(() => {
     if (!liveStatusSnapshot) return;

--- a/admin_ui/frontend/src/components/SystemTopology.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.tsx
@@ -106,7 +106,7 @@ const POLL_BACKOFF_CAP_MS = 30000;
 const nextPollDelay = (base: number, ok: boolean, current: number): number =>
   ok ? base : Math.min(current * 2, POLL_BACKOFF_CAP_MS);
 
-export const SystemTopology = ({ liveStatusEnabled = false, liveStatusSnapshot = null }: SystemTopologyProps) => {
+export const SystemTopology = ({ liveStatusSnapshot = null }: SystemTopologyProps) => {
   const [state, setState] = useState<TopologyState>({
     aiEngineStatus: 'unknown',
     aiEngineDegraded: false,
@@ -130,7 +130,7 @@ export const SystemTopology = ({ liveStatusEnabled = false, liveStatusSnapshot =
   // Kept in a ref so updates don't trigger re-renders; the debounced
   // state lands in `state.providerReady` which IS reactive.
   const providerStreaks = useRef<Map<string, number>>(new Map());
-  const useLiveStatusSource = liveStatusEnabled || liveStatusSnapshot != null;
+  const useLiveStatusSource = liveStatusSnapshot != null;
 
   useEffect(() => {
     if (!liveStatusSnapshot) return;

--- a/admin_ui/frontend/src/components/SystemTopology.tsx
+++ b/admin_ui/frontend/src/components/SystemTopology.tsx
@@ -6,6 +6,7 @@ import yaml from 'js-yaml';
 import { FullscreenPanel } from './ui/FullscreenPanel';
 import { isFullAgentProvider } from '../utils/providerNaming';
 import { deriveTopologyHealth, type TopologyIssue, type TopologyWarning } from '../utils/topologyHealth';
+import type { LiveStatusSnapshot } from '../hooks/useLiveStatus';
 
 interface CallState {
   call_id: string;
@@ -47,6 +48,7 @@ interface LocalAIModels {
 
 interface TopologyState {
   aiEngineStatus: 'connected' | 'error' | 'unknown';
+  aiEngineDegraded: boolean;
   // `null` = haven't checked yet (initial render); `true`/`false` = the most
   // recent confirmed state from /api/system/health. Distinguishing "unknown"
   // from "false" prevents the dashboard from asserting "ARI Disconnected"
@@ -65,6 +67,11 @@ interface TopologyState {
   defaultPipeline: string | null;
   activePipeline: string | null;
   activeCalls: Map<string, CallState>;
+}
+
+interface SystemTopologyProps {
+  liveStatusEnabled?: boolean;
+  liveStatusSnapshot?: LiveStatusSnapshot | null;
 }
 
 /**
@@ -99,9 +106,10 @@ const POLL_BACKOFF_CAP_MS = 30000;
 const nextPollDelay = (base: number, ok: boolean, current: number): number =>
   ok ? base : Math.min(current * 2, POLL_BACKOFF_CAP_MS);
 
-export const SystemTopology = () => {
+export const SystemTopology = ({ liveStatusEnabled = false, liveStatusSnapshot = null }: SystemTopologyProps) => {
   const [state, setState] = useState<TopologyState>({
     aiEngineStatus: 'unknown',
+    aiEngineDegraded: false,
     ariConnected: null,
     asteriskChannels: 0,
     localAIStatus: 'unknown',
@@ -122,6 +130,74 @@ export const SystemTopology = () => {
   // Kept in a ref so updates don't trigger re-renders; the debounced
   // state lands in `state.providerReady` which IS reactive.
   const providerStreaks = useRef<Map<string, number>>(new Map());
+  const useLiveStatusSource = liveStatusEnabled || liveStatusSnapshot != null;
+
+  useEffect(() => {
+    if (!liveStatusSnapshot) return;
+
+    const aiEngine = liveStatusSnapshot.components.ai_engine;
+    const localAI = liveStatusSnapshot.components.local_ai_server;
+    const sessions = liveStatusSnapshot.components.sessions;
+    const asterisk = liveStatusSnapshot.components.asterisk;
+
+    const isConnectedComponent = (component: typeof aiEngine | undefined): boolean =>
+      component?.state === 'ready' || component?.state === 'degraded';
+
+    const toTriState = (success: boolean): 'connected' | 'error' =>
+      success ? 'connected' : 'error';
+
+    const providerHealthData = aiEngine?.details?.providers || {};
+    const sessionRows = Array.isArray(sessions?.details?.sessions)
+      ? sessions.details.sessions
+      : [];
+    const calls = new Map<string, CallState>();
+    for (const session of sessionRows) {
+      if (!session?.call_id) continue;
+      calls.set(session.call_id, {
+        call_id: session.call_id,
+        started_at: session.started_at ? new Date(session.started_at) : new Date(),
+        provider: session.provider,
+        pipeline: session.pipeline,
+        state: session.conversation_state === 'greeting' ? 'arriving' : 'connected',
+      });
+    }
+
+    setState(prev => {
+      const nextProviderReady: Record<string, ProviderReadyState> = { ...prev.providerReady };
+      for (const [name, info] of Object.entries(providerHealthData)) {
+        const isReady = Boolean((info as any)?.ready);
+        const streak = providerStreaks.current.get(name) || 0;
+        const newStreak = isReady ? 0 : streak + 1;
+        providerStreaks.current.set(name, newStreak);
+        nextProviderReady[name] = isReady
+          ? 'ready'
+          : newStreak >= 2
+            ? 'not_ready'
+            : prev.providerReady[name] === 'ready'
+              ? 'ready'
+              : 'unknown';
+      }
+
+      const ariConnected =
+        aiEngine?.details?.ari_connected ??
+        aiEngine?.details?.asterisk?.connected ??
+        asterisk?.details?.live?.ari_reachable ??
+        prev.ariConnected;
+
+      return {
+        ...prev,
+        aiEngineStatus: aiEngine ? toTriState(isConnectedComponent(aiEngine)) : prev.aiEngineStatus,
+        aiEngineDegraded: aiEngine ? aiEngine.state === 'degraded' : prev.aiEngineDegraded,
+        ariConnected: typeof ariConnected === 'boolean' ? ariConnected : prev.ariConnected,
+        asteriskChannels: aiEngine?.details?.asterisk_channels ?? prev.asteriskChannels,
+        localAIStatus: localAI ? toTriState(isConnectedComponent(localAI)) : prev.localAIStatus,
+        localAIModels: localAI?.details?.models ?? prev.localAIModels,
+        providerHealth: providerHealthData,
+        providerReady: nextProviderReady,
+        activeCalls: calls,
+      };
+    });
+  }, [liveStatusSnapshot]);
 
   // Fetch health status with three-state + two-strike debounce per indicator.
   //
@@ -141,6 +217,8 @@ export const SystemTopology = () => {
   //
   // Any positive read clears the streak counter and immediately shows green.
   useEffect(() => {
+    if (useLiveStatusSource) return;
+
     let ariFailStreak = 0;
     let aiEngineFailStreak = 0;
     let localAIFailStreak = 0;
@@ -288,7 +366,7 @@ export const SystemTopology = () => {
       mounted = false;
       clearTimeout(timer);
     };
-  }, []);
+  }, [useLiveStatusSource]);
 
   // Fetch config (providers, pipelines)
   useEffect(() => {
@@ -398,6 +476,8 @@ export const SystemTopology = () => {
 
   // Poll for active calls from sessions API (more reliable than log parsing)
   useEffect(() => {
+    if (useLiveStatusSource) return;
+
     let mounted = true;
     const fetchActiveSessions = async (): Promise<boolean> => {
       try {
@@ -451,7 +531,7 @@ export const SystemTopology = () => {
       mounted = false;
       clearTimeout(timer);
     };
-  }, []);
+  }, [useLiveStatusSource]);
 
   // Derive active providers/pipelines from calls
   const activeProviders = useMemo(() => {
@@ -874,6 +954,8 @@ export const SystemTopology = () => {
             title="Go to AI Engine Settings →"
             className={`self-stretch relative p-4 rounded-xl border backdrop-blur-sm transition-all duration-300 cursor-pointer hover:-translate-y-1 ${state.aiEngineStatus === 'error'
               ? 'border-red-500/50 bg-red-500/10 ring-1 ring-red-500/50'
+              : state.aiEngineDegraded
+                ? 'border-amber-500/50 bg-amber-500/10 ring-1 ring-amber-500/30'
               : hasActiveCalls && state.aiEngineStatus === 'connected'
                 ? 'border-green-500/50 bg-green-500/10 shadow-[0_8px_30px_rgb(34,197,94,0.15)] ring-1 ring-green-500/50'
                 : 'border-border/60 bg-card/60 hover:bg-card/80 hover:border-primary/40 shadow-sm'
@@ -882,10 +964,10 @@ export const SystemTopology = () => {
               <div className="absolute inset-0 rounded-lg border-2 border-green-500 animate-ping opacity-20" />
             )}
             <div className="flex flex-col items-center justify-center gap-2 h-full">
-              <Cpu className={`w-8 h-8 ${state.aiEngineStatus === 'error' ? 'text-red-500' : hasActiveCalls && state.aiEngineStatus === 'connected' ? 'text-green-500' : 'text-muted-foreground'
+              <Cpu className={`w-8 h-8 ${state.aiEngineStatus === 'error' ? 'text-red-500' : state.aiEngineDegraded ? 'text-amber-500' : hasActiveCalls && state.aiEngineStatus === 'connected' ? 'text-green-500' : 'text-muted-foreground'
                 }`} />
               <div className="text-center">
-                <div className={`font-semibold ${state.aiEngineStatus === 'error' ? 'text-red-500' : hasActiveCalls && state.aiEngineStatus === 'connected' ? 'text-green-500' : 'text-foreground'
+                <div className={`font-semibold ${state.aiEngineStatus === 'error' ? 'text-red-500' : state.aiEngineDegraded ? 'text-amber-500' : hasActiveCalls && state.aiEngineStatus === 'connected' ? 'text-green-500' : 'text-foreground'
                   }`}>AI Engine</div>
                 <div className="text-xs text-muted-foreground">Core</div>
               </div>
@@ -894,6 +976,10 @@ export const SystemTopology = () => {
                   {state.aiEngineStatus === 'unknown' ? (
                     <span className="flex items-center gap-1 text-muted-foreground">
                       <Loader2 className="w-3 h-3 animate-spin" /> Checking…
+                    </span>
+                  ) : state.aiEngineStatus === 'connected' && state.aiEngineDegraded ? (
+                    <span className="flex items-center gap-1 text-amber-500">
+                      <AlertTriangle className="w-3 h-3" /> Degraded
                     </span>
                   ) : state.aiEngineStatus === 'connected' ? (
                     <span className="flex items-center gap-1 text-green-500">

--- a/admin_ui/frontend/src/components/config/providers/LocalProviderForm.tsx
+++ b/admin_ui/frontend/src/components/config/providers/LocalProviderForm.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 import HelpTooltip from '../../ui/HelpTooltip';
+import { localAIStatusFromLiveSnapshot } from '../../../utils/liveStatus';
 
 interface LocalProviderFormProps {
     config: any;
@@ -55,9 +56,19 @@ const LocalProviderForm: React.FC<LocalProviderFormProps> = ({ config, onChange 
     const fetchCurrentStatus = useCallback(async () => {
         setStatusLoading(true);
         try {
-            const res = await axios.get('/api/system/health');
-            if (res.data?.local_ai_server?.status === 'connected') {
-                setCurrentStatus(res.data.local_ai_server.details);
+            const [liveStatusRes, healthRes] = await Promise.allSettled([
+                axios.get('/api/system/live-status'),
+                axios.get('/api/system/health'),
+            ]);
+            if (liveStatusRes.status === 'fulfilled') {
+                const liveLocalAI = localAIStatusFromLiveSnapshot(liveStatusRes.value.data);
+                if (liveLocalAI?.connected) {
+                    setCurrentStatus(liveLocalAI.details);
+                    return;
+                }
+            }
+            if (healthRes.status === 'fulfilled' && healthRes.value.data?.local_ai_server?.status === 'connected') {
+                setCurrentStatus(healthRes.value.data.local_ai_server.details);
             } else {
                 setCurrentStatus(null);
             }

--- a/admin_ui/frontend/src/hooks/useLiveStatus.test.ts
+++ b/admin_ui/frontend/src/hooks/useLiveStatus.test.ts
@@ -48,6 +48,7 @@ describe('parseSseMessages', () => {
 
 describe('useLiveStatus', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -111,6 +112,50 @@ describe('useLiveStatus', () => {
 
     await waitFor(() => expect(result.current.snapshot?.event_id).toBe(2));
     expect(result.current.snapshot?.summary.state).toBe('degraded');
+    expect(result.current.connected).toBe(true);
+    expect(result.current.mode).toBe('stream');
+
+    unmount();
+  });
+
+  it('retries the SSE stream after falling back to polling', async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(
+          `id: 3\nevent: snapshot\ndata: ${JSON.stringify(snapshot(3, 'ready'))}\n\n`
+        ));
+      },
+      cancel() {},
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => snapshot(1),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => snapshot(2, 'degraded'),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, unmount } = renderHook(() => useLiveStatus(10));
+
+    await waitFor(() => expect(result.current.snapshot?.event_id).toBe(3));
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/system/live-status',
+      '/api/system/live-status/stream',
+      '/api/system/live-status',
+      '/api/system/live-status/stream',
+    ]);
     expect(result.current.connected).toBe(true);
     expect(result.current.mode).toBe('stream');
 

--- a/admin_ui/frontend/src/hooks/useLiveStatus.test.ts
+++ b/admin_ui/frontend/src/hooks/useLiveStatus.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseSseMessages, useLiveStatus, type LiveStatusSnapshot } from './useLiveStatus';
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+const snapshot = (eventId: number, state = 'ready'): LiveStatusSnapshot => ({
+  version: 1,
+  event_id: eventId,
+  generated_at: '2026-06-26T00:00:00Z',
+  summary: { state, component_count: 1 },
+  components: {
+    ai_engine: {
+      state,
+      freshness: 'fresh',
+      summary: 'AI Engine connected',
+      source: 'probe',
+      updated_at: '2026-06-26T00:00:00Z',
+      details: {},
+      metrics: {},
+      warnings: [],
+      errors: [],
+    },
+  },
+});
+
+describe('parseSseMessages', () => {
+  it('parses complete messages and returns partial rest', () => {
+    const parsed = parseSseMessages(
+      'id: 7\nevent: snapshot\ndata: {"ok":true}\n\nid: 8\nevent: snapshot\n'
+    );
+
+    expect(parsed.messages).toEqual([
+      { id: '7', event: 'snapshot', data: '{"ok":true}' },
+    ]);
+    expect(parsed.rest).toBe('id: 8\nevent: snapshot\n');
+  });
+
+  it('joins multi-line data fields', () => {
+    const parsed = parseSseMessages('event: snapshot\ndata: {"a":1,\ndata: "b":2}\n\n');
+
+    expect(parsed.messages[0].data).toBe('{"a":1,\n"b":2}');
+  });
+});
+
+describe('useLiveStatus', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the initial snapshot with the bearer token', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => snapshot(1),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, unmount } = renderHook(() => useLiveStatus());
+
+    await waitFor(() => expect(result.current.snapshot?.event_id).toBe(1));
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/system/live-status',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-token' },
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/system/live-status/stream',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-token' },
+      }),
+    );
+    expect(result.current.mode).toBe('poll');
+    expect(result.current.connected).toBe(false);
+
+    unmount();
+  });
+
+  it('applies snapshots received from the SSE stream', async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(
+          `id: 2\nevent: snapshot\ndata: ${JSON.stringify(snapshot(2, 'degraded'))}\n\n`
+        ));
+      },
+      cancel() {},
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => snapshot(1),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: stream,
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result, unmount } = renderHook(() => useLiveStatus());
+
+    await waitFor(() => expect(result.current.snapshot?.event_id).toBe(2));
+    expect(result.current.snapshot?.summary.state).toBe('degraded');
+    expect(result.current.connected).toBe(true);
+    expect(result.current.mode).toBe('stream');
+
+    unmount();
+  });
+});

--- a/admin_ui/frontend/src/hooks/useLiveStatus.ts
+++ b/admin_ui/frontend/src/hooks/useLiveStatus.ts
@@ -120,18 +120,50 @@ export const useLiveStatus = (pollIntervalMs = 5000): LiveStatusState => {
             pollTimer = setTimeout(pollOnce, pollIntervalMs);
         };
 
+        const openStream = async () => {
+            const stream = await fetch(STREAM_URL, {
+                headers: authHeaders(token),
+                signal: controller.signal,
+            });
+            if (!stream.ok || !stream.body) {
+                throw new Error(`live-status stream failed: HTTP ${stream.status}`);
+            }
+
+            setMode('stream');
+            setConnected(true);
+            const reader = stream.body.getReader();
+            streamReader = reader;
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            while (!stopped) {
+                const { value, done } = await reader.read();
+                if (done) {
+                    throw new Error('live-status stream closed');
+                }
+                buffer += decoder.decode(value, { stream: true });
+                const parsed = parseSseMessages(buffer);
+                buffer = parsed.rest;
+                for (const message of parsed.messages) {
+                    if (message.event !== 'snapshot') continue;
+                    applySnapshot(JSON.parse(message.data));
+                }
+            }
+        };
+
         const pollOnce = async () => {
             if (stopped) return;
             setMode('poll');
             setConnected(false);
             try {
                 applySnapshot(await fetchSnapshot(controller.signal));
+                await openStream();
             } catch (err: any) {
+                if (controller.signal.aborted || stopped) return;
                 if (!controller.signal.aborted) {
                     setError(err?.message || 'live-status snapshot failed');
                     setLoading(false);
                 }
-            } finally {
                 schedulePoll();
             }
         };
@@ -139,34 +171,7 @@ export const useLiveStatus = (pollIntervalMs = 5000): LiveStatusState => {
         const start = async () => {
             try {
                 applySnapshot(await fetchSnapshot(controller.signal));
-                const stream = await fetch(STREAM_URL, {
-                    headers: authHeaders(token),
-                    signal: controller.signal,
-                });
-                if (!stream.ok || !stream.body) {
-                    throw new Error(`live-status stream failed: HTTP ${stream.status}`);
-                }
-
-                setMode('stream');
-                setConnected(true);
-                const reader = stream.body.getReader();
-                streamReader = reader;
-                const decoder = new TextDecoder();
-                let buffer = '';
-
-                while (!stopped) {
-                    const { value, done } = await reader.read();
-                    if (done) {
-                        throw new Error('live-status stream closed');
-                    }
-                    buffer += decoder.decode(value, { stream: true });
-                    const parsed = parseSseMessages(buffer);
-                    buffer = parsed.rest;
-                    for (const message of parsed.messages) {
-                        if (message.event !== 'snapshot') continue;
-                        applySnapshot(JSON.parse(message.data));
-                    }
-                }
+                await openStream();
             } catch (err: any) {
                 if (controller.signal.aborted || stopped) return;
                 setError(err?.message || 'live-status stream failed');

--- a/admin_ui/frontend/src/hooks/useLiveStatus.ts
+++ b/admin_ui/frontend/src/hooks/useLiveStatus.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+
+export interface LiveStatusComponent {
+    state: 'ready' | 'degraded' | 'error' | 'unreachable' | 'unknown' | string;
+    freshness: 'fresh' | 'stale' | 'expired' | string;
+    summary: string;
+    source: string;
+    updated_at: string;
+    age_seconds?: number;
+    details: Record<string, any>;
+    metrics: Record<string, any>;
+    warnings: string[];
+    errors: string[];
+}
+
+export interface LiveStatusSnapshot {
+    version: number;
+    event_id: number;
+    generated_at: string;
+    summary: {
+        state: 'ready' | 'degraded' | 'error' | 'unknown' | string;
+        component_count: number;
+    };
+    components: Record<string, LiveStatusComponent>;
+    ai_engine?: LiveStatusComponent;
+    local_ai_server?: LiveStatusComponent;
+    sessions?: LiveStatusComponent;
+    directories?: LiveStatusComponent;
+    platform?: LiveStatusComponent;
+    asterisk?: LiveStatusComponent;
+    metrics?: LiveStatusComponent;
+}
+
+export interface LiveStatusState {
+    snapshot: LiveStatusSnapshot | null;
+    loading: boolean;
+    connected: boolean;
+    mode: 'idle' | 'stream' | 'poll';
+    error: string | null;
+}
+
+interface SseMessage {
+    id?: string;
+    event: string;
+    data: string;
+}
+
+const SNAPSHOT_URL = '/api/system/live-status';
+const STREAM_URL = '/api/system/live-status/stream';
+
+const authHeaders = (token: string | null): HeadersInit =>
+    token ? { Authorization: `Bearer ${token}` } : {};
+
+export const parseSseMessages = (buffer: string): { messages: SseMessage[]; rest: string } => {
+    const frames = buffer.split(/\r?\n\r?\n/);
+    const rest = frames.pop() ?? '';
+    const messages = frames
+        .map(frame => {
+            const message: SseMessage = { event: 'message', data: '' };
+            const dataLines: string[] = [];
+            for (const rawLine of frame.split(/\r?\n/)) {
+                if (!rawLine || rawLine.startsWith(':')) continue;
+                const colon = rawLine.indexOf(':');
+                const field = colon >= 0 ? rawLine.slice(0, colon) : rawLine;
+                const rawValue = colon >= 0 ? rawLine.slice(colon + 1) : '';
+                const value = rawValue.startsWith(' ') ? rawValue.slice(1) : rawValue;
+                if (field === 'id') message.id = value;
+                if (field === 'event') message.event = value || 'message';
+                if (field === 'data') dataLines.push(value);
+            }
+            message.data = dataLines.join('\n');
+            return message.data ? message : null;
+        })
+        .filter((message): message is SseMessage => message != null);
+    return { messages, rest };
+};
+
+export const useLiveStatus = (pollIntervalMs = 5000): LiveStatusState => {
+    const { token } = useAuth();
+    const [snapshot, setSnapshot] = useState<LiveStatusSnapshot | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [connected, setConnected] = useState(false);
+    const [mode, setMode] = useState<LiveStatusState['mode']>('idle');
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchSnapshot = useCallback(async (signal: AbortSignal): Promise<LiveStatusSnapshot> => {
+        const response = await fetch(SNAPSHOT_URL, {
+            headers: authHeaders(token),
+            signal,
+        });
+        if (!response.ok) {
+            throw new Error(`live-status snapshot failed: HTTP ${response.status}`);
+        }
+        return response.json();
+    }, [token]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        let pollTimer: ReturnType<typeof setTimeout> | null = null;
+        let stopped = false;
+        let streamReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+        const applySnapshot = (next: LiveStatusSnapshot) => {
+            setSnapshot(next);
+            setError(null);
+            setLoading(false);
+        };
+
+        const clearPollTimer = () => {
+            if (pollTimer) {
+                clearTimeout(pollTimer);
+                pollTimer = null;
+            }
+        };
+
+        const schedulePoll = () => {
+            clearPollTimer();
+            if (stopped) return;
+            pollTimer = setTimeout(pollOnce, pollIntervalMs);
+        };
+
+        const pollOnce = async () => {
+            if (stopped) return;
+            setMode('poll');
+            setConnected(false);
+            try {
+                applySnapshot(await fetchSnapshot(controller.signal));
+            } catch (err: any) {
+                if (!controller.signal.aborted) {
+                    setError(err?.message || 'live-status snapshot failed');
+                    setLoading(false);
+                }
+            } finally {
+                schedulePoll();
+            }
+        };
+
+        const start = async () => {
+            try {
+                applySnapshot(await fetchSnapshot(controller.signal));
+                const stream = await fetch(STREAM_URL, {
+                    headers: authHeaders(token),
+                    signal: controller.signal,
+                });
+                if (!stream.ok || !stream.body) {
+                    throw new Error(`live-status stream failed: HTTP ${stream.status}`);
+                }
+
+                setMode('stream');
+                setConnected(true);
+                const reader = stream.body.getReader();
+                streamReader = reader;
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (!stopped) {
+                    const { value, done } = await reader.read();
+                    if (done) {
+                        throw new Error('live-status stream closed');
+                    }
+                    buffer += decoder.decode(value, { stream: true });
+                    const parsed = parseSseMessages(buffer);
+                    buffer = parsed.rest;
+                    for (const message of parsed.messages) {
+                        if (message.event !== 'snapshot') continue;
+                        applySnapshot(JSON.parse(message.data));
+                    }
+                }
+            } catch (err: any) {
+                if (controller.signal.aborted || stopped) return;
+                setError(err?.message || 'live-status stream failed');
+                setConnected(false);
+                setMode('poll');
+                schedulePoll();
+            }
+        };
+
+        start();
+
+        return () => {
+            stopped = true;
+            controller.abort();
+            streamReader?.cancel().catch(() => {});
+            clearPollTimer();
+        };
+    }, [fetchSnapshot, pollIntervalMs, token]);
+
+    return { snapshot, loading, connected, mode, error };
+};

--- a/admin_ui/frontend/src/pages/Advanced/LLMPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/LLMPage.tsx
@@ -9,6 +9,7 @@ import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput } from '../../components/ui/FormComponents';
 import HelpTooltip from '../../components/ui/HelpTooltip';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
+import { localAIStatusFromLiveSnapshot } from '../../utils/liveStatus';
 
 const CHAT_FORMAT_OPTIONS = [
     { value: '', label: '(Legacy Phi-style — no chat template)' },
@@ -29,6 +30,7 @@ const LLMPage = () => {
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localCapability, setLocalCapability] = useState<any>(null);
     const [localConnected, setLocalConnected] = useState(false);
+    const [localAIState, setLocalAIState] = useState('unknown');
 
     useEffect(() => {
         fetchConfig();
@@ -36,8 +38,9 @@ const LLMPage = () => {
 
     const fetchConfig = async () => {
         try {
-            const [yamlRes, healthRes, envRes] = await Promise.allSettled([
+            const [yamlRes, liveStatusRes, healthRes, envRes] = await Promise.allSettled([
                 axios.get('/api/config/yaml'),
+                axios.get('/api/system/live-status'),
                 axios.get('/api/system/health'),
                 axios.get('/api/config/env'),
             ]);
@@ -60,18 +63,28 @@ const LLMPage = () => {
                 setEnv(envRes.value.data || {});
             }
 
-            if (healthRes.status === 'fulfilled') {
+            const liveLocalAI = liveStatusRes.status === 'fulfilled'
+                ? localAIStatusFromLiveSnapshot(liveStatusRes.value.data)
+                : null;
+            if (liveLocalAI?.connected) {
+                setLocalConnected(true);
+                setLocalAIState(liveLocalAI.state);
+                setLocalCapability(liveLocalAI.details?.models?.llm?.tool_capability || null);
+            } else if (healthRes.status === 'fulfilled') {
                 const localDetails = healthRes.value.data?.local_ai_server?.details || {};
                 setLocalConnected(healthRes.value.data?.local_ai_server?.status === 'connected');
+                setLocalAIState(healthRes.value.data?.local_ai_server?.status || 'unknown');
                 setLocalCapability(localDetails?.models?.llm?.tool_capability || null);
             } else {
                 setLocalConnected(false);
+                setLocalAIState(liveLocalAI?.state || 'unknown');
                 setLocalCapability(null);
             }
         } catch (err) {
             console.error('Failed to load config', err);
             setYamlError(null);
             setLocalConnected(false);
+            setLocalAIState('unknown');
             setLocalCapability(null);
         } finally {
             setLoading(false);
@@ -418,8 +431,8 @@ const LLMPage = () => {
                         <div className="rounded-md border border-border bg-muted/20 p-3 text-xs space-y-1">
                             <div className="flex items-center justify-between gap-2">
                                 <span className="text-muted-foreground">Local AI Server</span>
-                                <span className={`font-mono ${localConnected ? 'text-green-600' : 'text-yellow-600'}`}>
-                                    {localConnected ? 'connected' : 'not-connected'}
+                                <span className={`font-mono ${localConnected && localAIState !== 'degraded' ? 'text-green-600' : 'text-yellow-600'}`}>
+                                    {localConnected ? (localAIState === 'degraded' ? 'degraded' : 'connected') : 'not-connected'}
                                 </span>
                             </div>
                             <div className="flex items-center justify-between gap-2">

--- a/admin_ui/frontend/src/pages/Dashboard.tsx
+++ b/admin_ui/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import { SystemTopology } from '../components/SystemTopology';
 import { ApiErrorInfo, buildDockerAccessHints, describeApiError } from '../utils/apiErrors';
 import DonationBanner from '../components/DonationBanner';
 import { useDonationReminder } from '../hooks/useDonationReminder';
+import { useLiveStatus } from '../hooks/useLiveStatus';
 import {
     INITIAL_CONNECTION_STATE,
     reduceConnection,
@@ -100,6 +101,7 @@ const Dashboard = () => {
     const [ariConnected, setAriConnected] = useState<boolean | null>(null);
     const navigate = useNavigate();
     const donation = useDonationReminder();
+    const liveStatus = useLiveStatus();
 
     // Cross-poll hysteresis/debounce streaks. Kept in refs so updating them
     // doesn't trigger renders; the resulting display values land in reactive
@@ -222,10 +224,48 @@ const Dashboard = () => {
     };
 
     useEffect(() => {
+        const snapshot = liveStatus.snapshot;
+        if (!snapshot) return;
+
+        const metricsComponent = snapshot.components.metrics;
+        if (metricsComponent?.metrics) {
+            setMetrics(metricsComponent.metrics as unknown as SystemMetrics);
+            setMetricsError(null);
+        }
+
+        const directoriesComponent = snapshot.components.directories;
+        if (directoriesComponent?.details?.overall) {
+            dirFailStreak.current = 0;
+            setDirectoryHealth(directoriesComponent.details as DirectoryHealth);
+            setDirectoriesError(null);
+        }
+
+        const platformComponent = snapshot.components.platform;
+        if (platformComponent?.details?.platform && platformComponent?.details?.summary) {
+            platformFailStreak.current = 0;
+            setPlatformData(platformComponent.details as PlatformResponse);
+            setPlatformLoadFailed(false);
+            setPlatformError(null);
+        }
+
+        const reachable = snapshot.components.asterisk?.details?.live?.ari_reachable;
+        const asteriskSample: ConnectionSample = typeof reachable === 'boolean' ? reachable : 'unknown';
+        ariState.current = reduceConnection(ariState.current, asteriskSample);
+        setAriConnected(ariState.current.display);
+        setAsteriskError(null);
+
+        setLoading(false);
+        setRefreshing(false);
+    }, [liveStatus.snapshot]);
+
+    useEffect(() => {
+        if (liveStatus.snapshot) return;
+        if (liveStatus.loading && !liveStatus.error) return;
+
         fetchData();
-        const interval = setInterval(fetchData, 5000); // Refresh every 5s
+        const interval = setInterval(fetchData, 5000); // Fallback until live-status hydrates
         return () => clearInterval(interval);
-    }, []);
+    }, [liveStatus.error, liveStatus.loading, liveStatus.snapshot]);
 
     const formatBytes = (bytes: number) => {
         if (bytes === 0) return '0 B';
@@ -484,7 +524,7 @@ const Dashboard = () => {
             </div>
 
             {/* Live System Topology */}
-            <SystemTopology />
+            <SystemTopology liveStatusEnabled liveStatusSnapshot={liveStatus.snapshot} />
         </div>
     );
 };

--- a/admin_ui/frontend/src/pages/Dashboard.tsx
+++ b/admin_ui/frontend/src/pages/Dashboard.tsx
@@ -259,7 +259,11 @@ const Dashboard = () => {
     }, [liveStatus.snapshot]);
 
     useEffect(() => {
-        if (liveStatus.snapshot) return;
+        const components = liveStatus.snapshot?.components || {};
+        const hasProbeHydration = ['metrics', 'directories', 'platform', 'asterisk'].every(
+            name => components[name]
+        );
+        if (hasProbeHydration) return;
         if (liveStatus.loading && !liveStatus.error) return;
 
         fetchData();
@@ -524,7 +528,10 @@ const Dashboard = () => {
             </div>
 
             {/* Live System Topology */}
-            <SystemTopology liveStatusEnabled liveStatusSnapshot={liveStatus.snapshot} />
+            <SystemTopology
+                liveStatusEnabled={Boolean(liveStatus.snapshot) && !liveStatus.error}
+                liveStatusSnapshot={liveStatus.snapshot}
+            />
         </div>
     );
 };

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -12,6 +12,7 @@ import { ConfigCard } from '../components/ui/ConfigCard';
 import { Modal } from '../components/ui/Modal';
 import HelpTooltip from '../components/ui/HelpTooltip';
 import { usePendingChanges } from '../hooks/usePendingChanges';
+import { localAIStatusFromLiveSnapshot } from '../utils/liveStatus';
 
 // Provider Forms
 import GenericProviderForm from '../components/config/providers/GenericProviderForm';
@@ -61,9 +62,19 @@ const ProvidersPage: React.FC = () => {
         // Fetch local AI status for live model info on cards
         const fetchLocalStatus = async () => {
             try {
-                const res = await axios.get('/api/system/health');
-                if (res.data?.local_ai_server?.status === 'connected') {
-                    setLocalAIStatus(res.data.local_ai_server.details);
+                const [liveStatusRes, healthRes] = await Promise.allSettled([
+                    axios.get('/api/system/live-status'),
+                    axios.get('/api/system/health'),
+                ]);
+                if (liveStatusRes.status === 'fulfilled') {
+                    const liveLocalAI = localAIStatusFromLiveSnapshot(liveStatusRes.value.data);
+                    if (liveLocalAI?.connected) {
+                        setLocalAIStatus(liveLocalAI.details);
+                        return;
+                    }
+                }
+                if (healthRes.status === 'fulfilled' && healthRes.value.data?.local_ai_server?.status === 'connected') {
+                    setLocalAIStatus(healthRes.value.data.local_ai_server.details);
                 }
             } catch { /* ignore */ }
         };

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -17,6 +17,7 @@ const PROVIDER_CREDENTIAL_TYPES: Record<string, string[]> = {
     elevenlabs_agent: ['api-key', 'agent-id'],
     grok: ['api-key'],
 };
+const MODULAR_PROVIDER_KEY_RE = /_(stt|llm|tts|vad)$/;
 
 interface PerInstanceCredentialRow {
     providerKey: string;
@@ -186,7 +187,8 @@ const EnvPage = () => {
             // credentials valid for that kind. Use that response — don't gate
             // on a frontend whitelist of canonical keys, which would silently
             // omit custom-keyed full-agent providers.
-            const entries = Object.entries(providers) as Array<[string, any]>;
+            const entries = (Object.entries(providers) as Array<[string, any]>)
+                .filter(([key]) => !MODULAR_PROVIDER_KEY_RE.test(key));
             const tasks = entries.map(async ([key, cfg]) => {
                 let credStatus: any = {};
                 let kind: string | null = null;

--- a/admin_ui/frontend/src/pages/System/ModelsPage.test.tsx
+++ b/admin_ui/frontend/src/pages/System/ModelsPage.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import ModelsPage from './ModelsPage';
+import type { LiveStatusSnapshot } from '../../hooks/useLiveStatus';
+
+vi.mock('axios');
+
+const liveStatusState = vi.hoisted(() => ({
+    current: {
+        snapshot: null as LiveStatusSnapshot | null,
+        loading: false,
+        connected: true,
+        mode: 'stream' as const,
+        error: null,
+    },
+}));
+
+vi.mock('../../hooks/useLiveStatus', () => ({
+    useLiveStatus: () => liveStatusState.current,
+}));
+
+vi.mock('../../hooks/useConfirmDialog', () => ({
+    useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(false) }),
+}));
+
+const localAIComponent = {
+    state: 'degraded',
+    freshness: 'fresh',
+    summary: 'Local AI degraded, 0/3 models loaded',
+    source: 'push',
+    updated_at: '2026-06-27T05:31:21Z',
+    details: {
+        config: {
+            runtime_mode: 'minimal',
+            degraded: true,
+        },
+        gpu: {
+            runtime_detected: false,
+            runtime_usable: false,
+            error: 'NVIDIA runtime not available in container.',
+        },
+        models: {
+            stt: {
+                backend: 'vosk',
+                path: '/app/models/stt/vosk-model-en-us-0.22',
+                loaded: false,
+                display: 'vosk-model-en-us-0.22',
+            },
+            llm: {
+                path: '/app/models/llm/phi-3-mini-4k-instruct.Q4_K_M.gguf',
+                loaded: false,
+                display: 'phi-3-mini-4k-instruct.Q4_K_M.gguf',
+                config: { context: 768, max_tokens: 64 },
+                prompt_fit: {},
+                auto_context: {},
+                tool_capability: { level: 'none' },
+            },
+            tts: {
+                backend: 'piper',
+                path: '/app/models/tts/en_US-lessac-medium.onnx',
+                loaded: false,
+                display: 'en_US-lessac-medium.onnx',
+            },
+        },
+    },
+    metrics: { models_loaded: 0, models_total: 3 },
+    warnings: [
+        'stt: STT model not found at /app/models/stt/vosk-model-en-us-0.22',
+        'tts: TTS model not found at /app/models/tts/en_US-lessac-medium.onnx',
+    ],
+    errors: [],
+};
+
+const liveStatusSnapshot = (): LiveStatusSnapshot => ({
+    version: 1,
+    event_id: 7,
+    generated_at: '2026-06-27T05:31:22Z',
+    summary: { state: 'degraded', component_count: 1 },
+    components: {
+        local_ai_server: localAIComponent,
+    },
+    local_ai_server: localAIComponent,
+});
+
+const installedModelsPayload = {
+    stt: {
+        vosk: [{ name: 'vosk-model-en-us-0.22', path: '/app/models/stt/vosk-model-en-us-0.22', size_mb: 0 }],
+    },
+    tts: {
+        piper: [{ name: 'en_US-lessac-medium.onnx', path: '/app/models/tts/en_US-lessac-medium.onnx', size_mb: 0 }],
+    },
+    llm: [
+        { name: 'phi-3-mini', path: '/app/models/llm/phi-3-mini-4k-instruct.Q4_K_M.gguf', size_mb: 0 },
+    ],
+};
+
+const mockModelsPageApis = () => {
+    vi.mocked(axios.get).mockImplementation((url) => {
+        if (url === '/api/wizard/local/available-models') {
+            return Promise.resolve({
+                data: {
+                    catalog: { stt: [], tts: [], llm: [] },
+                    language_names: {},
+                    region_names: {},
+                },
+            });
+        }
+        if (url === '/api/system/live-status') {
+            return Promise.resolve({ data: liveStatusSnapshot() });
+        }
+        if (url === '/api/system/health') {
+            return Promise.resolve({
+                data: {
+                    local_ai_server: {
+                        status: 'error',
+                        details: { error: 'old health path timed out' },
+                    },
+                },
+            });
+        }
+        if (url === '/api/local-ai/models') {
+            return Promise.resolve({ data: installedModelsPayload });
+        }
+        if (url === '/api/local-ai/capabilities') {
+            return Promise.resolve({ data: { stt: {}, tts: {} } });
+        }
+        if (url === '/api/config/env') {
+            return Promise.resolve({ data: {} });
+        }
+        if (url === '/api/custom-models') {
+            return Promise.resolve({ data: { enabled: false, models: [] } });
+        }
+        return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+};
+
+describe('ModelsPage Local AI status', () => {
+    afterEach(() => {
+        liveStatusState.current.snapshot = null;
+        vi.clearAllMocks();
+    });
+
+    it('shows degraded pushed Local AI status as reachable instead of unreachable', async () => {
+        liveStatusState.current.snapshot = liveStatusSnapshot();
+        mockModelsPageApis();
+
+        render(
+            <MemoryRouter>
+                <ModelsPage />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => expect(screen.getByText('Degraded')).toBeInTheDocument());
+
+        expect(screen.getByText(/Local AI Server is reachable but degraded/i)).toBeInTheDocument();
+        expect(screen.queryByText(/Local AI Server is not reachable/i)).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Start Local AI Server/i })).not.toBeInTheDocument();
+        expect(screen.getAllByText('vosk-model-en-us-0.22').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('en_US-lessac-medium.onnx').length).toBeGreaterThan(0);
+    });
+});

--- a/admin_ui/frontend/src/pages/System/ModelsPage.test.tsx
+++ b/admin_ui/frontend/src/pages/System/ModelsPage.test.tsx
@@ -111,7 +111,7 @@ const mockModelsPageApis = () => {
             });
         }
         if (url === '/api/system/live-status') {
-            return Promise.resolve({ data: liveStatusSnapshot() });
+            return Promise.resolve({ data: liveStatusState.current.snapshot || liveStatusSnapshot() });
         }
         if (url === '/api/system/health') {
             return Promise.resolve({
@@ -142,6 +142,7 @@ const mockModelsPageApis = () => {
 describe('ModelsPage Local AI status', () => {
     afterEach(() => {
         liveStatusState.current.snapshot = null;
+        liveStatusState.current.loading = false;
         vi.clearAllMocks();
     });
 
@@ -162,5 +163,31 @@ describe('ModelsPage Local AI status', () => {
         expect(screen.queryByRole('button', { name: /Start Local AI Server/i })).not.toBeInTheDocument();
         expect(screen.getAllByText('vosk-model-en-us-0.22').length).toBeGreaterThan(0);
         expect(screen.getAllByText('en_US-lessac-medium.onnx').length).toBeGreaterThan(0);
+    });
+
+    it('falls back to legacy health status when pushed Local AI state is unknown', async () => {
+        liveStatusState.current.snapshot = {
+            ...liveStatusSnapshot(),
+            components: {
+                local_ai_server: {
+                    ...localAIComponent,
+                    state: 'unknown',
+                    summary: 'Local AI status pending',
+                },
+            },
+        };
+        mockModelsPageApis();
+
+        render(
+            <MemoryRouter>
+                <ModelsPage />
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(vi.mocked(axios.get)).toHaveBeenCalledWith('/api/system/health');
+        });
+        await waitFor(() => expect(screen.getByText('Error')).toBeInTheDocument());
+        expect(screen.getByText(/Local AI Server is not reachable/i)).toBeInTheDocument();
     });
 });

--- a/admin_ui/frontend/src/pages/System/ModelsPage.tsx
+++ b/admin_ui/frontend/src/pages/System/ModelsPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { ConfigCard } from '../../components/ui/ConfigCard';
 import HelpTooltip from '../../components/ui/HelpTooltip';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
+import { useLiveStatus, type LiveStatusComponent } from '../../hooks/useLiveStatus';
 import { RebuildBackendDialog } from '../../components/models/RebuildBackendDialog';
 import { CustomModelsPanel } from '../../components/models/CustomModelsPanel';
 import axios from 'axios';
@@ -138,8 +139,11 @@ interface ApplyProgressState {
     details: string[];
 }
 
+type ServerStatus = 'connected' | 'degraded' | 'error' | 'loading';
+
 const ModelsPage = () => {
     const { confirm } = useConfirmDialog();
+    const liveStatus = useLiveStatus();
     const [catalog, setCatalog] = useState<{ stt: ModelInfo[]; tts: ModelInfo[]; llm: ModelInfo[] }>({ stt: [], tts: [], llm: [] });
     const [installedModels, setInstalledModels] = useState<InstalledModel[]>([]);
     const [languageNames, setLanguageNames] = useState<Record<string, string>>({});
@@ -155,7 +159,7 @@ const ModelsPage = () => {
     // Active models state (from Local AI Server)
     const [activeModels, setActiveModels] = useState<ActiveModels | null>(null);
     const [availableModels, setAvailableModels] = useState<AvailableModels | null>(null);
-    const [serverStatus, setServerStatus] = useState<'connected' | 'error' | 'loading'>('loading');
+    const [serverStatus, setServerStatus] = useState<ServerStatus>('loading');
     const [restarting, setRestarting] = useState(false);
     const [pendingChanges, setPendingChanges] = useState<{ stt?: string; tts?: string; llm?: string }>({});
     const [pendingSttExtra, setPendingSttExtra] = useState<{ language?: string; device?: string; compute_type?: string; sherpa_model_type?: string; sherpa_vad_model_path?: string; tone_decoder_type?: string; tone_kenlm_path?: string }>({});
@@ -196,6 +200,53 @@ const ModelsPage = () => {
             fetchModels();
             fetchActiveModels();
         }
+    };
+
+    const hydrateLocalAIStatus = (details: any, status: ServerStatus) => {
+        setServerStatus(status);
+        setRuntimeGpu((details?.gpu || null) as RuntimeGpuStatus | null);
+        setRuntimeMode((details?.config?.runtime_mode || details?.runtime_mode || null) as string | null);
+        setActiveModels({
+            stt: {
+                backend: details?.models?.stt?.backend || 'unknown',
+                path: details?.models?.stt?.path || '',
+                loaded: details?.models?.stt?.loaded || false,
+                display: details?.models?.stt?.display || '',
+                language: details?.models?.stt?.language || null,
+                device: details?.models?.stt?.device || null,
+                compute_type: details?.models?.stt?.compute_type || null,
+                sherpa_model_type: details?.models?.stt?.sherpa_model_type || null,
+                tone_decoder_type: details?.models?.stt?.tone_decoder_type || null,
+            },
+            tts: {
+                backend: details?.models?.tts?.backend || 'unknown',
+                path: details?.models?.tts?.path || '',
+                loaded: details?.models?.tts?.loaded || false,
+                display: details?.models?.tts?.display || ''
+            },
+            llm: {
+                path: details?.models?.llm?.path || '',
+                loaded: details?.models?.llm?.loaded || false,
+                display: details?.models?.llm?.display || '',
+                config: details?.models?.llm?.config || {},
+                prompt_fit: details?.models?.llm?.prompt_fit || {},
+                auto_context: details?.models?.llm?.auto_context || {},
+                tool_capability: details?.models?.llm?.tool_capability || {}
+            }
+        });
+    };
+
+    const applyLocalAILiveStatus = (component?: LiveStatusComponent | null): boolean => {
+        if (!component) return false;
+        if (component.freshness === 'expired') return false;
+        if (component.state === 'ready' || component.state === 'degraded') {
+            hydrateLocalAIStatus(component.details || {}, component.state === 'ready' ? 'connected' : 'degraded');
+            return true;
+        }
+        setServerStatus('error');
+        setRuntimeGpu(null);
+        setRuntimeMode(null);
+        return true;
     };
 
     const showToast = (message: string, type: 'success' | 'error' | 'warning') => {
@@ -281,6 +332,15 @@ const ModelsPage = () => {
         fetchActiveModels();
     }, []);
 
+    useEffect(() => {
+        const localAI = liveStatus.snapshot?.components?.local_ai_server || liveStatus.snapshot?.local_ai_server;
+        applyLocalAILiveStatus(localAI);
+    }, [
+        liveStatus.snapshot?.event_id,
+        liveStatus.snapshot?.components?.local_ai_server?.updated_at,
+        liveStatus.snapshot?.local_ai_server?.updated_at,
+    ]);
+
     // Resume download on mount if active
     useEffect(() => {
         let mounted = true;
@@ -344,53 +404,30 @@ const ModelsPage = () => {
 
     // Fetch active models from Local AI Server health
     const fetchActiveModels = async () => {
-        const [healthRes, modelsRes, capabilitiesRes, envRes] = await Promise.allSettled([
+        const [liveStatusRes, healthRes, modelsRes, capabilitiesRes, envRes] = await Promise.allSettled([
+            axios.get('/api/system/live-status'),
             axios.get('/api/system/health'),
             axios.get('/api/local-ai/models'),
             axios.get('/api/local-ai/capabilities'),
             axios.get('/api/config/env')
         ]);
 
-        if (healthRes.status === 'fulfilled') {
+        let hydratedFromStatus = false;
+        if (liveStatusRes.status === 'fulfilled') {
+            const localAI = liveStatusRes.value.data?.components?.local_ai_server || liveStatusRes.value.data?.local_ai_server;
+            hydratedFromStatus = applyLocalAILiveStatus(localAI);
+        }
+
+        if (!hydratedFromStatus && healthRes.status === 'fulfilled') {
             const localAI = healthRes.value.data?.local_ai_server;
             if (localAI?.status === 'connected') {
-                setServerStatus('connected');
-                setRuntimeGpu((localAI.details?.gpu || null) as RuntimeGpuStatus | null);
-                setRuntimeMode((localAI.details?.config?.runtime_mode || null) as string | null);
-                setActiveModels({
-                    stt: {
-                        backend: localAI.details?.models?.stt?.backend || 'unknown',
-                        path: localAI.details?.models?.stt?.path || '',
-                        loaded: localAI.details?.models?.stt?.loaded || false,
-                        display: localAI.details?.models?.stt?.display || '',
-                        language: localAI.details?.models?.stt?.language || null,
-                        device: localAI.details?.models?.stt?.device || null,
-                        compute_type: localAI.details?.models?.stt?.compute_type || null,
-                        sherpa_model_type: localAI.details?.models?.stt?.sherpa_model_type || null,
-                        tone_decoder_type: localAI.details?.models?.stt?.tone_decoder_type || null,
-                    },
-                    tts: {
-                        backend: localAI.details?.models?.tts?.backend || 'unknown',
-                        path: localAI.details?.models?.tts?.path || '',
-                        loaded: localAI.details?.models?.tts?.loaded || false,
-                        display: localAI.details?.models?.tts?.display || ''
-                    },
-                    llm: {
-                        path: localAI.details?.models?.llm?.path || '',
-                        loaded: localAI.details?.models?.llm?.loaded || false,
-                        display: localAI.details?.models?.llm?.display || '',
-                        config: localAI.details?.models?.llm?.config || {},
-                        prompt_fit: localAI.details?.models?.llm?.prompt_fit || {},
-                        auto_context: localAI.details?.models?.llm?.auto_context || {},
-                        tool_capability: localAI.details?.models?.llm?.tool_capability || {}
-                    }
-                });
+                hydrateLocalAIStatus(localAI.details || {}, 'connected');
             } else {
                 setServerStatus('error');
                 setRuntimeGpu(null);
                 setRuntimeMode(null);
             }
-        } else {
+        } else if (!hydratedFromStatus) {
             setServerStatus('error');
             setRuntimeGpu(null);
             setRuntimeMode(null);
@@ -926,10 +963,13 @@ const ModelsPage = () => {
                             <Cpu className="w-5 h-5 text-blue-500" />
                             <h3 className="font-semibold">Local AI Server</h3>
                             <span className={`px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1 ${serverStatus === 'connected' ? 'bg-green-500/10 text-green-500' :
+                                serverStatus === 'degraded' ? 'bg-yellow-500/10 text-yellow-500' :
                                 serverStatus === 'error' ? 'bg-red-500/10 text-red-500' : 'bg-yellow-500/10 text-yellow-500'
                                 }`}>
                                 {serverStatus === 'connected' ? (
                                     <><CheckCircle2 className="w-3 h-3" /> Connected</>
+                                ) : serverStatus === 'degraded' ? (
+                                    <><AlertTriangle className="w-3 h-3" /> Degraded</>
                                 ) : serverStatus === 'error' ? (
                                     <><XCircle className="w-3 h-3" /> Error</>
                                 ) : (
@@ -999,8 +1039,13 @@ const ModelsPage = () => {
                         </div>
                     </div>
 
-                    {serverStatus === 'connected' && activeModels && (
+                    {(serverStatus === 'connected' || serverStatus === 'degraded') && activeModels && (
                         <div className="p-4 space-y-4">
+                            {serverStatus === 'degraded' && (
+                                <div className="p-3 rounded-md border border-yellow-500/40 bg-yellow-500/10 text-xs text-yellow-700 dark:text-yellow-300">
+                                    Local AI Server is reachable but degraded. Model controls remain available; check unloaded models and runtime warnings before using local STT, LLM, or TTS in calls.
+                                </div>
+                            )}
                             <div className="text-xs text-muted-foreground">
                                 {runtimeGpuKnown ? (
                                     <span>

--- a/admin_ui/frontend/src/pages/System/ModelsPage.tsx
+++ b/admin_ui/frontend/src/pages/System/ModelsPage.tsx
@@ -243,6 +243,9 @@ const ModelsPage = () => {
             hydrateLocalAIStatus(component.details || {}, component.state === 'ready' ? 'connected' : 'degraded');
             return true;
         }
+        if (component.state !== 'error' && component.state !== 'unreachable') {
+            return false;
+        }
         setServerStatus('error');
         setRuntimeGpu(null);
         setRuntimeMode(null);
@@ -334,8 +337,11 @@ const ModelsPage = () => {
 
     useEffect(() => {
         const localAI = liveStatus.snapshot?.components?.local_ai_server || liveStatus.snapshot?.local_ai_server;
-        applyLocalAILiveStatus(localAI);
+        if (!applyLocalAILiveStatus(localAI) && !liveStatus.loading) {
+            fetchActiveModels();
+        }
     }, [
+        liveStatus.loading,
         liveStatus.snapshot?.event_id,
         liveStatus.snapshot?.components?.local_ai_server?.updated_at,
         liveStatus.snapshot?.local_ai_server?.updated_at,

--- a/admin_ui/frontend/src/utils/liveStatus.ts
+++ b/admin_ui/frontend/src/utils/liveStatus.ts
@@ -1,0 +1,29 @@
+export interface LiveStatusComponentLike {
+    state?: string;
+    freshness?: string;
+    details?: Record<string, any>;
+}
+
+export interface LocalAILiveStatus {
+    connected: boolean;
+    degraded: boolean;
+    state: string;
+    details: Record<string, any>;
+}
+
+export const localAIStatusFromLiveSnapshot = (snapshot: any): LocalAILiveStatus | null => {
+    const component: LiveStatusComponentLike | undefined =
+        snapshot?.components?.local_ai_server || snapshot?.local_ai_server;
+    if (!component || component.freshness === 'expired') return null;
+
+    const state = String(component.state || 'unknown');
+    const connected = state === 'ready' || state === 'degraded';
+    if (!connected && !['error', 'unreachable'].includes(state)) return null;
+
+    return {
+        connected,
+        degraded: state === 'degraded',
+        state,
+        details: component.details || {},
+    };
+};

--- a/local_ai_server/live_status_publisher.py
+++ b/local_ai_server/live_status_publisher.py
@@ -1,0 +1,187 @@
+"""Best-effort publisher for Admin UI live-status updates."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping
+
+
+ComponentMap = Mapping[str, Mapping[str, Any]]
+ComponentBuilder = Callable[[], ComponentMap | Awaitable[ComponentMap]]
+
+
+def live_status_component(
+    *,
+    state: str,
+    summary: str,
+    details: Mapping[str, Any] | None = None,
+    metrics: Mapping[str, Any] | None = None,
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "state": state,
+        "summary": summary,
+        "details": dict(details or {}),
+        "metrics": dict(metrics or {}),
+        "warnings": list(warnings or []),
+        "errors": list(errors or []),
+    }
+
+
+@dataclass(frozen=True)
+class LiveStatusPublisherConfig:
+    source: str
+    admin_url: str
+    token: str
+    interval_seconds: float = 10.0
+    timeout_seconds: float = 10.0
+
+    @classmethod
+    def from_env(cls, source: str) -> "LiveStatusPublisherConfig":
+        port = (os.getenv("UVICORN_PORT") or "3003").strip() or "3003"
+        admin_url = (
+            os.getenv("LIVE_STATUS_ADMIN_URL")
+            or os.getenv("ADMIN_UI_URL")
+            or f"http://127.0.0.1:{port}"
+        ).strip()
+        token = (os.getenv("LIVE_STATUS_PUSH_TOKEN") or os.getenv("HEALTH_API_TOKEN") or "").strip()
+        return cls(
+            source=source,
+            admin_url=admin_url.rstrip("/"),
+            token=token,
+            interval_seconds=_float_env("LIVE_STATUS_PUSH_INTERVAL_SECONDS", 10.0, minimum=2.0),
+            timeout_seconds=_float_env("LIVE_STATUS_PUSH_TIMEOUT_SECONDS", 10.0, minimum=0.2),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.admin_url and self.token and self.source)
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.admin_url}/api/system/live-status/publish"
+
+
+def _float_env(name: str, default: float, *, minimum: float) -> float:
+    try:
+        value = float((os.getenv(name) or "").strip())
+    except ValueError:
+        value = default
+    return max(minimum, value)
+
+
+class LiveStatusPublisher:
+    def __init__(
+        self,
+        config: LiveStatusPublisherConfig,
+        *,
+        logger: Any | None = None,
+        post: Callable[[str, dict[str, Any], str, float], Any] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.config = config
+        self._logger = logger
+        self._post = post or _post_json
+        self._monotonic = monotonic
+        self._closed = False
+        self._publish_lock = asyncio.Lock()
+        self._last_failure_log = 0.0
+
+    @classmethod
+    def from_env(cls, source: str, *, logger: Any | None = None) -> "LiveStatusPublisher":
+        return cls(LiveStatusPublisherConfig.from_env(source), logger=logger)
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled and not self._closed
+
+    def publish_now(self, components: ComponentMap, *, name: str | None = None) -> asyncio.Task | None:
+        if not self.enabled:
+            return None
+        task = asyncio.create_task(self.publish(components), name=name or f"live-status-publish-{self.config.source}")
+        task.add_done_callback(self._log_task_exception)
+        return task
+
+    async def publish(self, components: ComponentMap) -> bool:
+        if not self.enabled:
+            return False
+        payload = {"source": self.config.source, "components": dict(components)}
+        async with self._publish_lock:
+            try:
+                await asyncio.to_thread(
+                    self._post,
+                    self.config.endpoint,
+                    payload,
+                    self.config.token,
+                    self.config.timeout_seconds,
+                )
+                return True
+            except Exception as exc:
+                self._log_failure(exc)
+                return False
+
+    async def publish_loop(self, build_components: ComponentBuilder) -> None:
+        if not self.enabled:
+            return
+        while not self._closed:
+            try:
+                components = build_components()
+                if inspect.isawaitable(components):
+                    components = await components
+                await self.publish(components)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._log_failure(exc)
+            await asyncio.sleep(self.config.interval_seconds)
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def _log_task_exception(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            self._log_failure(exc)
+
+    def _log_failure(self, exc: BaseException) -> None:
+        if not self._logger:
+            return
+        now = self._monotonic()
+        if now - self._last_failure_log < 60.0:
+            return
+        self._last_failure_log = now
+        try:
+            self._logger.debug("Live-status publish failed: %s", exc)
+        except Exception:
+            pass
+
+
+def _post_json(endpoint: str, payload: dict[str, Any], token: str, timeout_seconds: float) -> None:
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            if response.status >= 400:
+                raise RuntimeError(f"HTTP {response.status}")
+            response.read()
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code}") from exc

--- a/local_ai_server/model_manager.py
+++ b/local_ai_server/model_manager.py
@@ -53,6 +53,9 @@ class ModelManager:
                     self._server._filler_cache.clear()
             logging.info("✅ Runtime-only configuration applied without model reload")
 
+        if not dry_run and not _requires_model_reload(changed) and hasattr(self._server, "_publish_live_status_now"):
+            self._server._publish_live_status_now()
+
         return {
             "type": "switch_response",
             "status": "success",

--- a/local_ai_server/server.py
+++ b/local_ai_server/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import audioop
 import base64
+import contextlib
 import io
 import json
 import logging
@@ -58,7 +59,9 @@ from optional_imports import VoskModel, KaldiRecognizer, Llama, PiperVoice
 
 from session import SessionContext
 from config import LocalAIConfig
+from live_status_publisher import LiveStatusPublisher, live_status_component
 from model_manager import ModelManager
+from status_builder import build_status_response
 from ws_protocol import WebSocketProtocol
 
 
@@ -812,6 +815,8 @@ class LocalAIServer:
             "validated_at": int(time() * 1000),
             "model_fingerprint": "unknown",
         }
+        self.live_status_publisher = LiveStatusPublisher.from_env("local_ai_server", logger=logging.getLogger(__name__))
+        self._live_status_task: Optional[asyncio.Task] = None
 
     def _llm_auto_ctx_cache_path(self) -> str:
         """
@@ -1196,6 +1201,57 @@ class LocalAIServer:
             )
         else:
             logging.info("✅ All models loaded successfully for MVP pipeline")
+
+    def _build_live_status_components(self) -> Dict[str, Dict[str, Any]]:
+        """Build Admin UI live-status components from the canonical status response."""
+        status = build_status_response(self)
+        models = status.get("models") or {}
+        model_count = sum(1 for value in models.values() if isinstance(value, dict))
+        loaded_count = sum(
+            1 for value in models.values()
+            if isinstance(value, dict) and value.get("loaded") is True
+        )
+        startup_errors = (status.get("config") or {}).get("startup_errors") or {}
+        degraded = bool(startup_errors) or (model_count > 0 and loaded_count < model_count)
+        runtime_mode = (status.get("config") or {}).get("runtime_mode")
+        state = "degraded" if degraded else "ready"
+        warnings = [f"{key}: {value}" for key, value in startup_errors.items()]
+
+        return {
+            "local_ai_server": live_status_component(
+                state=state,
+                summary=f"Local AI {'degraded' if degraded else 'ready'}, {loaded_count}/{model_count} models loaded",
+                details=status,
+                metrics={
+                    "models_loaded": loaded_count,
+                    "models_total": model_count,
+                    "runtime_mode": runtime_mode,
+                },
+                warnings=warnings,
+            )
+        }
+
+    def _start_live_status_publisher(self) -> None:
+        if self.live_status_publisher.enabled and not self._live_status_task:
+            self._live_status_task = asyncio.create_task(
+                self.live_status_publisher.publish_loop(self._build_live_status_components),
+                name="local-ai-live-status-publish-loop",
+            )
+            self._live_status_task.add_done_callback(self._log_live_status_task_exception)
+
+    def _publish_live_status_now(self) -> None:
+        self.live_status_publisher.publish_now(
+            self._build_live_status_components(),
+            name="local-ai-live-status-publish",
+        )
+
+    @staticmethod
+    def _log_live_status_task_exception(task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            logging.debug("Local AI live-status publisher failed: %s", exc, exc_info=True)
 
     async def _load_stt_model(self):
         """Load STT model based on configured backend."""
@@ -2276,6 +2332,12 @@ class LocalAIServer:
     async def shutdown(self) -> None:
         """Best-effort cleanup on server shutdown."""
         logging.info("🛑 Shutting down Local AI Server...")
+        if self._live_status_task:
+            self._live_status_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._live_status_task
+            self._live_status_task = None
+        await self.live_status_publisher.close()
         await self._cleanup_kroko_backend()
         if self.sherpa_backend:
             try:
@@ -2324,6 +2386,7 @@ class LocalAIServer:
                 self._tts_cache.clear()
             await self._cleanup_kroko_backend()
             await self.initialize_models(startup=False)
+            self._publish_live_status_now()
             logging.info("✅ Models reloaded successfully")
         except Exception as exc:
             logging.error("❌ Model reload failed: %s", exc)
@@ -5875,6 +5938,7 @@ async def main():
     server = LocalAIServer()
     try:
         await server.initialize_models(startup=True)
+        server._start_live_status_publisher()
 
         # SECURITY: Default to localhost. Set LOCAL_WS_HOST=0.0.0.0 for remote access.
         # If binding non-localhost, LOCAL_WS_AUTH_TOKEN should be set (enforced in handler).

--- a/local_ai_server/server.py
+++ b/local_ai_server/server.py
@@ -1237,7 +1237,7 @@ class LocalAIServer:
                 self.live_status_publisher.publish_loop(self._build_live_status_components),
                 name="local-ai-live-status-publish-loop",
             )
-            self._live_status_task.add_done_callback(self._log_live_status_task_exception)
+            self._live_status_task.add_done_callback(self._on_live_status_task_done)
 
     def _publish_live_status_now(self) -> None:
         self.live_status_publisher.publish_now(
@@ -1245,11 +1245,16 @@ class LocalAIServer:
             name="local-ai-live-status-publish",
         )
 
-    @staticmethod
-    def _log_live_status_task_exception(task: asyncio.Task) -> None:
+    def _on_live_status_task_done(self, task: asyncio.Task) -> None:
+        if self._live_status_task is task:
+            self._live_status_task = None
         if task.cancelled():
             return
-        exc = task.exception()
+        try:
+            exc = task.exception()
+        except Exception:
+            logging.debug("Local AI live-status publisher failed while finishing", exc_info=True)
+            return
         if exc:
             logging.debug("Local AI live-status publisher failed: %s", exc, exc_info=True)
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -53,6 +53,7 @@ from .config.provider_instances import (
 )
 from .pipelines import PipelineOrchestrator, PipelineOrchestratorError, PipelineResolution
 from .logging_config import get_logger, configure_logging
+from .live_status_publisher import LiveStatusPublisher, live_status_component
 from .rtp_server import RTPServer
 from .audio.audiosocket_server import AudioSocketServer
 from .audio.resampler import resample_audio
@@ -583,6 +584,9 @@ class Engine:
         self.mcp_manager = None
         # Background ARI reconnect supervisor task
         self._ari_listener_task: Optional[asyncio.Task] = None
+        # Best-effort Admin UI status publisher. Disabled unless a push token is configured.
+        self.live_status_publisher = LiveStatusPublisher.from_env("ai_engine", logger=logger)
+        self._live_status_task: Optional[asyncio.Task] = None
 
         # Event handlers
         self.ari_client.on_event("StasisStart", self._handle_stasis_start)
@@ -733,6 +737,12 @@ class Engine:
             asyncio.create_task(self._start_health_server())
         except Exception:
             logger.debug("Health server failed to start", exc_info=True)
+
+        if self.live_status_publisher.enabled and not self._live_status_task:
+            self._live_status_task = self._fire_and_forget(
+                self.live_status_publisher.publish_loop(self._build_live_status_components),
+                name="live-status-publish-loop",
+            )
 
         # 3) Log transport and downstream modes
         logger.info("Runtime modes", audio_transport=self.config.audio_transport, downstream_mode=self.config.downstream_mode)
@@ -2272,6 +2282,15 @@ class Engine:
                 await self._health_runner.cleanup()
         except Exception:
             logger.debug("Health server cleanup error", exc_info=True)
+        try:
+            if self._live_status_task:
+                self._live_status_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._live_status_task
+                self._live_status_task = None
+            await self.live_status_publisher.close()
+        except Exception:
+            logger.debug("Live-status publisher cleanup error", exc_info=True)
         # Ensure orchestrator releases component assignments before shutdown.
         try:
             await self.pipeline_orchestrator.stop()
@@ -14819,6 +14838,129 @@ class Engine:
         except Exception:
             pass  # Don't fail health endpoint if warning computation fails
         return warnings
+
+    async def _build_live_status_components(self) -> Dict[str, Dict[str, Any]]:
+        """Build Admin UI live-status components from the engine's in-memory state."""
+        providers_info: Dict[str, Dict[str, Any]] = {}
+        provider_warnings: List[str] = []
+        for name, prov in (self.providers or {}).items():
+            ready = False
+            reason = None
+            try:
+                if hasattr(prov, "is_ready"):
+                    ready = bool(prov.is_ready())
+                    if not ready:
+                        reason = "missing_config"
+                else:
+                    reason = "no_is_ready_method"
+            except Exception as exc:
+                reason = f"error: {exc}"
+            providers_info[name] = {"ready": ready, "reason": reason} if reason else {"ready": ready}
+            if not ready:
+                provider_warnings.append(f"{name}: {reason or 'not ready'}")
+
+        default_ready = False
+        default_target = getattr(self.config, "default_provider", None) if self.config else None
+        if default_target in (self.providers or {}):
+            prov = self.providers[default_target]
+            try:
+                if self._get_provider_kind(default_target) == "local" and hasattr(prov, "is_connected"):
+                    default_ready = bool(prov.is_connected())
+                else:
+                    default_ready = bool(prov.is_ready()) if hasattr(prov, "is_ready") else False
+            except Exception:
+                default_ready = False
+        elif self.config and hasattr(self.config, "pipelines") and default_target in (self.config.pipelines or {}):
+            default_ready = bool(getattr(self, "pipeline_orchestrator", None) and self.pipeline_orchestrator.started)
+
+        ari_connected = bool(self.ari_client and self.ari_client.running)
+        if getattr(self.config, "audio_transport", None) == "audiosocket":
+            transport_ok = self.audio_socket_server is not None
+        elif getattr(self.config, "audio_transport", None) == "externalmedia":
+            transport_ok = self.rtp_server is not None
+        else:
+            transport_ok = True
+
+        active_sessions = await self.session_store.get_all_sessions()
+        session_stats = await self.session_store.get_session_stats()
+        pending_timers = self.conversation_coordinator.get_pending_timer_count()
+        try:
+            conversation_summary = await self.conversation_coordinator.get_summary()
+        except Exception:
+            conversation_summary = {}
+
+        is_ready = ari_connected and transport_ok and default_ready
+        config_warnings = self._compute_nat_warnings()
+        warnings = list(config_warnings)
+        provider_warning_severity = "info" if is_ready else "degraded"
+        if provider_warnings:
+            warnings.extend(provider_warnings)
+        uptime_seconds = int(time.time() - self._start_time)
+        state = "ready" if is_ready else "degraded"
+        if not ari_connected:
+            state = "unreachable"
+
+        ai_details = {
+            "ari_connected": ari_connected,
+            "audio_transport": getattr(self.config, "audio_transport", None),
+            "transport_ok": transport_ok,
+            "default_target": default_target,
+            "default_ready": default_ready,
+            "active_calls": len(active_sessions),
+            "active_sessions": len(active_sessions),
+            "asterisk_channels": len(self._pre_stasis_channels) + len(active_sessions),
+            "pending_timers": pending_timers,
+            "uptime_seconds": uptime_seconds,
+            "providers": providers_info,
+            "provider_warning_severity": provider_warning_severity,
+            "pipelines": {
+                name: {
+                    "stt": getattr(cfg, "stt", None),
+                    "llm": getattr(cfg, "llm", None),
+                    "tts": getattr(cfg, "tts", None),
+                    "tools": getattr(cfg, "tools", None),
+                }
+                for name, cfg in (getattr(self.config, "pipelines", {}) or {}).items()
+            },
+            "config_hash": getattr(self, "_config_hash", None),
+            "config_loaded_at": getattr(self, "_config_loaded_at", None),
+            "config_warnings": config_warnings,
+            "conversation": {
+                "gating_active": conversation_summary.get("gating_active", 0),
+                "capture_disabled": conversation_summary.get("capture_disabled", 0),
+                "barge_in_total": conversation_summary.get("barge_in_total", 0),
+                "pending_timers": pending_timers,
+            },
+        }
+
+        return {
+            "ai_engine": live_status_component(
+                state=state,
+                summary="AI Engine ready" if state == "ready" else "AI Engine degraded",
+                details=ai_details,
+                metrics={
+                    "active_calls": len(active_sessions),
+                    "active_sessions": len(active_sessions),
+                    "pending_timers": pending_timers,
+                    "uptime_seconds": uptime_seconds,
+                },
+                warnings=warnings,
+                errors=[] if ari_connected else ["ARI client is not connected"],
+            ),
+            "sessions": live_status_component(
+                state="ready",
+                summary=f"{session_stats.get('active_calls', 0)} active calls",
+                details={
+                    **session_stats,
+                    "reachable": True,
+                },
+                metrics={
+                    "active_calls": session_stats.get("active_calls", 0),
+                    "active_playbacks": session_stats.get("active_playbacks", 0),
+                    "provider_sessions": session_stats.get("provider_sessions", 0),
+                },
+            ),
+        }
 
     async def _health_handler(self, request):
         """Return JSON with engine/provider status."""

--- a/src/engine.py
+++ b/src/engine.py
@@ -738,9 +738,10 @@ class Engine:
         except Exception:
             logger.debug("Health server failed to start", exc_info=True)
 
-        if self.live_status_publisher.enabled and not self._live_status_task:
+        live_status_publisher = getattr(self, "live_status_publisher", None)
+        if live_status_publisher and live_status_publisher.enabled and not getattr(self, "_live_status_task", None):
             self._live_status_task = self._fire_and_forget(
-                self.live_status_publisher.publish_loop(self._build_live_status_components),
+                live_status_publisher.publish_loop(self._build_live_status_components),
                 name="live-status-publish-loop",
             )
 
@@ -2283,12 +2284,15 @@ class Engine:
         except Exception:
             logger.debug("Health server cleanup error", exc_info=True)
         try:
-            if self._live_status_task:
-                self._live_status_task.cancel()
+            live_status_task = getattr(self, "_live_status_task", None)
+            if live_status_task:
+                live_status_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await self._live_status_task
+                    await live_status_task
                 self._live_status_task = None
-            await self.live_status_publisher.close()
+            live_status_publisher = getattr(self, "live_status_publisher", None)
+            if live_status_publisher:
+                await live_status_publisher.close()
         except Exception:
             logger.debug("Live-status publisher cleanup error", exc_info=True)
         # Ensure orchestrator releases component assignments before shutdown.

--- a/src/live_status_publisher.py
+++ b/src/live_status_publisher.py
@@ -1,0 +1,187 @@
+"""Best-effort publisher for Admin UI live-status updates."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping
+
+
+ComponentMap = Mapping[str, Mapping[str, Any]]
+ComponentBuilder = Callable[[], ComponentMap | Awaitable[ComponentMap]]
+
+
+def live_status_component(
+    *,
+    state: str,
+    summary: str,
+    details: Mapping[str, Any] | None = None,
+    metrics: Mapping[str, Any] | None = None,
+    warnings: list[str] | None = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "state": state,
+        "summary": summary,
+        "details": dict(details or {}),
+        "metrics": dict(metrics or {}),
+        "warnings": list(warnings or []),
+        "errors": list(errors or []),
+    }
+
+
+@dataclass(frozen=True)
+class LiveStatusPublisherConfig:
+    source: str
+    admin_url: str
+    token: str
+    interval_seconds: float = 10.0
+    timeout_seconds: float = 10.0
+
+    @classmethod
+    def from_env(cls, source: str) -> "LiveStatusPublisherConfig":
+        port = (os.getenv("UVICORN_PORT") or "3003").strip() or "3003"
+        admin_url = (
+            os.getenv("LIVE_STATUS_ADMIN_URL")
+            or os.getenv("ADMIN_UI_URL")
+            or f"http://127.0.0.1:{port}"
+        ).strip()
+        token = (os.getenv("LIVE_STATUS_PUSH_TOKEN") or os.getenv("HEALTH_API_TOKEN") or "").strip()
+        return cls(
+            source=source,
+            admin_url=admin_url.rstrip("/"),
+            token=token,
+            interval_seconds=_float_env("LIVE_STATUS_PUSH_INTERVAL_SECONDS", 10.0, minimum=2.0),
+            timeout_seconds=_float_env("LIVE_STATUS_PUSH_TIMEOUT_SECONDS", 10.0, minimum=0.2),
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.admin_url and self.token and self.source)
+
+    @property
+    def endpoint(self) -> str:
+        return f"{self.admin_url}/api/system/live-status/publish"
+
+
+def _float_env(name: str, default: float, *, minimum: float) -> float:
+    try:
+        value = float((os.getenv(name) or "").strip())
+    except ValueError:
+        value = default
+    return max(minimum, value)
+
+
+class LiveStatusPublisher:
+    def __init__(
+        self,
+        config: LiveStatusPublisherConfig,
+        *,
+        logger: Any | None = None,
+        post: Callable[[str, dict[str, Any], str, float], Any] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.config = config
+        self._logger = logger
+        self._post = post or _post_json
+        self._monotonic = monotonic
+        self._closed = False
+        self._publish_lock = asyncio.Lock()
+        self._last_failure_log = 0.0
+
+    @classmethod
+    def from_env(cls, source: str, *, logger: Any | None = None) -> "LiveStatusPublisher":
+        return cls(LiveStatusPublisherConfig.from_env(source), logger=logger)
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enabled and not self._closed
+
+    def publish_now(self, components: ComponentMap, *, name: str | None = None) -> asyncio.Task | None:
+        if not self.enabled:
+            return None
+        task = asyncio.create_task(self.publish(components), name=name or f"live-status-publish-{self.config.source}")
+        task.add_done_callback(self._log_task_exception)
+        return task
+
+    async def publish(self, components: ComponentMap) -> bool:
+        if not self.enabled:
+            return False
+        payload = {"source": self.config.source, "components": dict(components)}
+        async with self._publish_lock:
+            try:
+                await asyncio.to_thread(
+                    self._post,
+                    self.config.endpoint,
+                    payload,
+                    self.config.token,
+                    self.config.timeout_seconds,
+                )
+                return True
+            except Exception as exc:
+                self._log_failure(exc)
+                return False
+
+    async def publish_loop(self, build_components: ComponentBuilder) -> None:
+        if not self.enabled:
+            return
+        while not self._closed:
+            try:
+                components = build_components()
+                if inspect.isawaitable(components):
+                    components = await components
+                await self.publish(components)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._log_failure(exc)
+            await asyncio.sleep(self.config.interval_seconds)
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def _log_task_exception(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc:
+            self._log_failure(exc)
+
+    def _log_failure(self, exc: BaseException) -> None:
+        if not self._logger:
+            return
+        now = self._monotonic()
+        if now - self._last_failure_log < 60.0:
+            return
+        self._last_failure_log = now
+        try:
+            self._logger.debug("Live-status publish failed: %s", exc)
+        except Exception:
+            pass
+
+
+def _post_json(endpoint: str, payload: dict[str, Any], token: str, timeout_seconds: float) -> None:
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            if response.status >= 400:
+                raise RuntimeError(f"HTTP {response.status}")
+            response.read()
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"HTTP {exc.code}") from exc

--- a/tests/test_engine_live_status_publish.py
+++ b/tests/test_engine_live_status_publish.py
@@ -1,0 +1,101 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from src.engine import Engine
+
+
+class _Provider:
+    def __init__(self, *, ready=True, connected=True):
+        self._ready = ready
+        self._connected = connected
+
+    def is_ready(self):
+        return self._ready
+
+    def is_connected(self):
+        return self._connected
+
+
+class _SessionStore:
+    async def get_all_sessions(self):
+        return [SimpleNamespace(call_id="call-1")]
+
+    async def get_session_stats(self):
+        return {
+            "active_calls": 1,
+            "active_playbacks": 0,
+            "provider_sessions": 1,
+            "sessions": [{"call_id": "call-1", "provider": "local"}],
+        }
+
+
+class _ConversationCoordinator:
+    def get_pending_timer_count(self):
+        return 2
+
+    async def get_summary(self):
+        return {"gating_active": 1, "capture_disabled": 0, "barge_in_total": 3}
+
+
+def _make_engine(provider):
+    engine = Engine.__new__(Engine)
+    engine.config = SimpleNamespace(
+        audio_transport="audiosocket",
+        default_provider="local",
+        pipelines={},
+        audiosocket=SimpleNamespace(host="127.0.0.1"),
+        external_media=None,
+        asterisk=SimpleNamespace(host="127.0.0.1"),
+    )
+    engine.providers = {"local": provider}
+    engine.provider_kinds = {"local": "local"}
+    engine.pipeline_orchestrator = None
+    engine.ari_client = SimpleNamespace(running=True)
+    engine.audio_socket_server = object()
+    engine.rtp_server = None
+    engine.session_store = _SessionStore()
+    engine.conversation_coordinator = _ConversationCoordinator()
+    engine._pre_stasis_channels = set()
+    engine._start_time = time.time() - 42
+    engine._config_hash = "hash"
+    engine._config_loaded_at = "2026-06-26T00:00:00Z"
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_engine_live_status_components_report_ready_and_sessions():
+    engine = _make_engine(_Provider(ready=True, connected=True))
+
+    components = await engine._build_live_status_components()
+
+    assert components["ai_engine"]["state"] == "ready"
+    assert components["ai_engine"]["details"]["ari_connected"] is True
+    assert components["ai_engine"]["details"]["default_ready"] is True
+    assert components["sessions"]["summary"] == "1 active calls"
+    assert components["sessions"]["details"]["sessions"][0]["call_id"] == "call-1"
+
+
+@pytest.mark.asyncio
+async def test_engine_live_status_components_degrade_when_local_provider_disconnected():
+    engine = _make_engine(_Provider(ready=True, connected=False))
+
+    components = await engine._build_live_status_components()
+
+    assert components["ai_engine"]["state"] == "degraded"
+    assert components["ai_engine"]["details"]["default_ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_engine_live_status_keeps_default_ready_when_optional_provider_missing_config():
+    engine = _make_engine(_Provider(ready=True, connected=True))
+    engine.providers["google_live"] = _Provider(ready=False)
+    engine.provider_kinds["google_live"] = "google_live"
+
+    components = await engine._build_live_status_components()
+
+    assert components["ai_engine"]["state"] == "ready"
+    assert components["ai_engine"]["details"]["default_ready"] is True
+    assert components["ai_engine"]["details"]["provider_warning_severity"] == "info"
+    assert components["ai_engine"]["warnings"] == ["google_live: missing_config"]

--- a/tests/test_live_status_publisher.py
+++ b/tests/test_live_status_publisher.py
@@ -1,0 +1,96 @@
+import pytest
+
+from src.live_status_publisher import (
+    LiveStatusPublisher,
+    LiveStatusPublisherConfig,
+    live_status_component,
+)
+
+
+def test_live_status_component_defaults_are_stable():
+    component = live_status_component(state="ready", summary="ok")
+
+    assert component == {
+        "state": "ready",
+        "summary": "ok",
+        "details": {},
+        "metrics": {},
+        "warnings": [],
+        "errors": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_status_publisher_disabled_without_token():
+    publisher = LiveStatusPublisher(
+        LiveStatusPublisherConfig(source="ai_engine", admin_url="http://admin", token="")
+    )
+
+    assert publisher.enabled is False
+    assert publisher.publish_now({"ai_engine": live_status_component(state="ready", summary="ok")}) is None
+    assert await publisher.publish({"ai_engine": live_status_component(state="ready", summary="ok")}) is False
+
+
+@pytest.mark.asyncio
+async def test_live_status_publisher_posts_expected_contract():
+    calls = []
+
+    def fake_post(endpoint, payload, token, timeout):
+        calls.append({"endpoint": endpoint, "payload": payload, "token": token, "timeout": timeout})
+
+    publisher = LiveStatusPublisher(
+        LiveStatusPublisherConfig(
+            source="ai_engine",
+            admin_url="http://admin.local:3003",
+            token="secret",
+            timeout_seconds=1.5,
+        ),
+        post=fake_post,
+    )
+
+    ok = await publisher.publish(
+        {
+            "ai_engine": live_status_component(
+                state="ready",
+                summary="AI Engine ready",
+                details={"ari_connected": True},
+            )
+        }
+    )
+
+    assert ok is True
+    assert calls == [
+        {
+            "endpoint": "http://admin.local:3003/api/system/live-status/publish",
+            "payload": {
+                "source": "ai_engine",
+                "components": {
+                    "ai_engine": {
+                        "state": "ready",
+                        "summary": "AI Engine ready",
+                        "details": {"ari_connected": True},
+                        "metrics": {},
+                        "warnings": [],
+                        "errors": [],
+                    }
+                },
+            },
+            "token": "secret",
+            "timeout": 1.5,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_status_publisher_failure_is_best_effort():
+    def fake_post(*_args):
+        raise RuntimeError("admin down")
+
+    publisher = LiveStatusPublisher(
+        LiveStatusPublisherConfig(source="ai_engine", admin_url="http://admin", token="secret"),
+        post=fake_post,
+    )
+
+    ok = await publisher.publish({"ai_engine": live_status_component(state="ready", summary="ok")})
+
+    assert ok is False


### PR DESCRIPTION
## Summary

- Add an Admin UI live-status hub with snapshot, SSE stream, and authenticated publish endpoints.
- Add push publishers in `ai_engine` and `local_ai_server` so dashboard status is fresh without UI-driven polling as the primary mechanism.
- Update dashboard, topology, models, providers, LLM, and environment views to consume pushed live status while keeping legacy probes as fallback/enrichment.
- Add focused backend, engine, Local AI, hook, topology, and models-page test coverage.

## Why

The dashboard and related system pages previously depended heavily on UI/API polling probes. That made the UI slower to converge and could report stale or unreachable states while the services were actually starting or already healthy. This change moves service readiness toward push-first status publication while preserving probes for diagnostics, enrichment, and release-cycle fallback safety.

## Validation

Local validation:

- `python -m pytest admin_ui/backend/tests/test_config_api.py admin_ui/backend/tests/test_live_status.py tests/test_engine_live_status_publish.py tests/test_live_status_publisher.py -q`
  - 21 passed
- `npm --prefix admin_ui/frontend run test -- src/hooks/useLiveStatus.test.ts src/components/SystemTopology.test.tsx src/pages/System/ModelsPage.test.tsx`
  - 14 passed
- `npm --prefix admin_ui/frontend run build`
  - Passed; existing browser-data/chunk-size warnings only
- `python -m py_compile admin_ui/backend/api/config.py admin_ui/backend/main.py admin_ui/backend/api/live_status.py admin_ui/backend/services/status_hub.py src/live_status_publisher.py src/engine.py local_ai_server/live_status_publisher.py local_ai_server/server.py local_ai_server/model_manager.py`
  - Passed
- `git diff --check`
  - Passed

Dev server validation:

- Rebuilt/recreated `admin_ui` and `ai_engine` only; did not restart Local AI because it is slow and not needed for that environment.
- Confirmed dashboard shows AI Engine as ready from fresh push status.
- Confirmed Models page no longer reports Local AI as unreachable when a pushed degraded status exists.
- Known dev-environment observations remain: Local AI degraded due unloaded models, directories probe error due environment setup.

voiprnd validation:

- Rebuilt/recreated `admin_ui`, `ai_engine`, and `local_ai_server`.
- Set `ASTERISK_ARI_SSL_VERIFY=false` as approved to address the existing ARI TLS mismatch against `127.0.0.1`.
- Confirmed container health: `admin_ui`, `ai_engine`, and `local_ai_server` healthy.
- Confirmed live status: AI Engine ready, sessions ready with 0 active calls, Local AI ready with 3/3 models loaded.
- Full browser UI sweep completed across dashboard, models, providers, env, history, scheduling, wizard, agents, pipelines, contexts, profiles, tools, MCP, VAD, streaming, LLM defaults, transport, barge-in, Docker, Asterisk, updates, logs, terminal, raw YAML, and help.
- Post-settle logs were clean. One Admin UI connection-refused publish failure occurred during intentional container recreation and did not recur.

## Notes

The old probe mechanism is intentionally not removed in this PR. It remains as fallback and diagnostic enrichment for at least one release cycle. The follow-up retirement strategy is documented in the archived implementation plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time Admin UI system live-status reporting with SSE streaming and automatic fallback to legacy polling.
  * Introduced push-based live-status updates secured with bearer tokens and validated component publishing.
  * Added Admin UI live config endpoint for merged settings.
  * Enabled live-status-driven UI hydration across dashboard, topology, providers, and models, including a clearer “Degraded” state.
  * Added environment configuration for live-status push behavior.
* **Bug Fixes**
  * Improved resilience when live data is incomplete or delayed, ensuring graceful fallback and consistent warning/error normalization.
* **Chores**
  * Added backend and frontend test coverage for publishing, streaming, and UI state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->