### PR TITLE
release: v7.2.0 docs + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.0] - 2026-06-27
+
+### Added
+
+- **Push-based live-status hub for the dashboard and system pages (#476)** (`admin_ui/backend/api/live_status.py`, `admin_ui/backend/services/status_hub.py`, `admin_ui/frontend/src/hooks/useLiveStatus.ts`, `src/live_status_publisher.py`, `local_ai_server/live_status_publisher.py`): the Admin UI gains a live-status hub — an authenticated publish endpoint (`POST /api/live-status/publish`), a snapshot endpoint, and a Server-Sent Events stream — and `ai_engine` and `local_ai_server` now **push** their readiness to it. The Dashboard, System Topology, Models, Providers, LLM, and Environment views consume this pushed status as the primary source, with the existing `/api/system/*` probes kept as fallback and enrichment, so the UI converges faster after a (re)start and no longer reports "unreachable"/stale while services are actually starting or already healthy (e.g. the Models page no longer shows Local AI as unreachable when a pushed degraded status exists). Push auth uses `LIVE_STATUS_PUSH_TOKEN` (falling back to `HEALTH_API_TOKEN`); probe cadence and cold-start timeout are configurable via `LIVE_STATUS_POLL_INTERVAL_SECONDS` / `LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS`, read live from `.env` so Env-UI edits apply without a manual recreate. New keys are documented in `.env.example` and `docs/ENVIRONMENT_VARIABLES.md`. Covered by backend, engine, Local AI, hook, topology, and Models-page tests.
+
 ## [7.1.2] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img alt="Asterisk AI Voice Agent" src="assets/banner_light_mode.png?v=9" width="100%">
 </picture>
 
-![Version](https://img.shields.io/badge/version-7.1.1-blue.svg)
+![Version](https://img.shields.io/badge/version-7.2.0-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![Docker](https://img.shields.io/badge/docker-compose-blue.svg)
@@ -167,6 +167,19 @@ docker compose -p asterisk-ai-voice-agent logs -f ai_engine
 ## 🎉 What's New
 
 <details open>
+<summary><b>v7.2.0 — Live-status dashboard 📡</b></summary>
+
+Real-time system status for the Admin UI — pushed, not polled.
+
+- **Live-status hub** — a single `/api/live-status` snapshot endpoint plus an SSE stream (`/api/live-status/stream`) aggregates AI Engine health, Local AI connectivity, active sessions, audio directories, platform checks, and Asterisk ARI into one normalized status feed.
+- **Push-first** — `ai_engine` and `local_ai_server` push their own readiness to the Admin UI (`POST /api/live-status/publish`, authenticated with `LIVE_STATUS_PUSH_TOKEN`), so the dashboard converges in sub-second time after a restart instead of waiting on staggered polls. Legacy `/api/system/*` probes remain as fallback/enrichment.
+- **Configurable** — `LIVE_STATUS_POLL_INTERVAL_SECONDS` (default 30 s, min 2 s) and `LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS` (default 2 s), read live from `.env`.
+
+Full notes in [CHANGELOG.md](CHANGELOG.md).
+
+</details>
+
+<details>
 <summary><b>v7.1.1 — Dashboard reliability & Admin UI polish 🛠️</b></summary>
 
 A focused quality release across the Admin UI — no call-path changes.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 </details>
 
-<details open>
+<details>
 <summary><b>v7.0.0 — the Agents release 🎯</b></summary>
 
 The biggest release yet: **manage your AI agents from the Admin UI, not a config file.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ We actively support the following versions with security updates:
 
 | Version | Supported          | End of Support |
 | ------- | ------------------ | -------------- |
+| 7.2.x   | :white_check_mark: | TBD            |
 | 7.1.x   | :white_check_mark: | TBD            |
 | 7.0.x   | :white_check_mark: | TBD            |
 | 6.5.x   | :white_check_mark: | TBD            |

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@ The operator-facing reference is [`docs/CLI_TOOLS_GUIDE.md`](../docs/CLI_TOOLS_G
 
 ## Commands
 
-Visible commands in v7.1.1:
+Visible commands in v7.2.0:
 
 - `agent setup` — interactive configuration and dynamic provider/pipeline discovery
 - `agent check` — standard health report and Local AI Server round-trip tests

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -75,7 +75,7 @@ contexts:
       configuration.
 
 
-      ABOUT ASTERISK AI VOICE AGENT v6.5.4:
+      ABOUT ASTERISK AI VOICE AGENT v7.2.0:
 
       - Open-source (MIT), production-ready AI voice agent framework for Asterisk and FreePBX
 
@@ -274,7 +274,7 @@ contexts:
       - Google Gemini Live supports over 70 live translation pairs for real-time multilingual conversations
 
 
-      ABOUT ASTERISK AI VOICE AGENT v6.5.4:
+      ABOUT ASTERISK AI VOICE AGENT v7.2.0:
 
       - Open-source (MIT), production-ready AI voice agent framework for Asterisk and FreePBX
 
@@ -560,7 +560,7 @@ contexts:
       - Zero cloud dependency for inference - all AI processing happens on-premises
 
 
-      ABOUT ASTERISK AI VOICE AGENT v6.5.4:
+      ABOUT ASTERISK AI VOICE AGENT v7.2.0:
 
       - Open-source (MIT), production-ready AI voice agent framework for Asterisk and FreePBX
 
@@ -805,7 +805,7 @@ contexts:
       configuration.
 
 
-      ABOUT ASTERISK AI VOICE AGENT v6.5.4:
+      ABOUT ASTERISK AI VOICE AGENT v7.2.0:
 
       - Open-source (MIT), production-ready AI voice agent framework for Asterisk and FreePBX
 
@@ -996,7 +996,7 @@ contexts:
       premium voice quality.
 
 
-      ABOUT ASTERISK AI VOICE AGENT v6.5.4:
+      ABOUT ASTERISK AI VOICE AGENT v7.2.0:
 
       - Open-source (MIT), production-ready AI voice agent framework for Asterisk and FreePBX
 
@@ -1314,7 +1314,7 @@ contexts:
 
       ABOUT THIS PROJECT:
 
-      - This is the Asterisk AI Voice Agent v6.5.4, an open-source framework for adding AI voice to your phone system
+      - This is the Asterisk AI Voice Agent v7.2.0, an open-source framework for adding AI voice to your phone system
 
       - MCP tools can be extended to do customer lookups, calendar scheduling, database queries, and more
 

--- a/config/contexts/demo-project-expert.yaml
+++ b/config/contexts/demo-project-expert.yaml
@@ -9,7 +9,7 @@ system_prompt: |
   You are a knowledgeable assistant helping people understand the Asterisk AI Voice Agent project.
   
   PROJECT OVERVIEW:
-  Asterisk AI Voice Agent v6.5.4 is an open-source framework that adds AI voice capabilities to Asterisk and FreePBX phone systems. A PBX is a private phone system used by businesses to manage calls. It's MIT-licensed, modular, and production-ready.
+  Asterisk AI Voice Agent v7.2.0 is an open-source framework that adds AI voice capabilities to Asterisk and FreePBX phone systems. A PBX is a private phone system used by businesses to manage calls. It's MIT-licensed, modular, and production-ready.
   
   KEY FEATURES:
   - Works natively with existing Asterisk/FreePBX installations (no external telephony providers needed)

--- a/docs/CLI_TOOLS_GUIDE.md
+++ b/docs/CLI_TOOLS_GUIDE.md
@@ -1,6 +1,6 @@
 # Agent CLI Tools Guide
 
-Operator reference for the `agent` command shipped with Asterisk AI Voice Agent v7.1.1.
+Operator reference for the `agent` command shipped with Asterisk AI Voice Agent v7.2.0.
 
 Run commands from the repository root on the Docker Compose host. Global flags are `--verbose` and `--no-color`.
 
@@ -151,7 +151,7 @@ Apply an update:
 
 ```bash
 agent update
-agent update --ref v7.1.1
+agent update --ref v7.2.0
 agent update --checkout --ref main
 agent update --rebuild auto
 agent update --rebuild none

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -77,6 +77,15 @@ If you’re not sure, start without these; use `agent check` and `docs/Transport
 - `HEALTH_CHECK_AI_ENGINE_URL`: optional override used by Admin UI for Tier-3 / non-host-network deployments.
 - `HEALTH_CHECK_LOCAL_AI_URL`: optional override used by Admin UI for Local AI Server probes.
 
+### Live-status dashboard
+
+- `LIVE_STATUS_PUSH_TOKEN`: bearer token `ai_engine` / `local_ai_server` supply when pushing component updates to `POST /api/live-status/publish`. Falls back to `HEALTH_API_TOKEN` if unset; if neither is set the publish endpoint returns `503`.
+- `LIVE_STATUS_POLL_INTERVAL_SECONDS`: how often the Admin UI's background loop re-probes all components (default `30`, minimum `2`).
+- `LIVE_STATUS_INITIAL_PROBE_TIMEOUT_SECONDS`: deadline for the eager cold-start probe on the first `/api/live-status` request before any data exists (default `2`).
+- `LIVE_STATUS_ADMIN_URL`: URL the push client on `ai_engine`/`local_ai_server` uses to reach the Admin UI API (default `http://127.0.0.1:3003`).
+- `LIVE_STATUS_PUSH_INTERVAL_SECONDS`: how often the push client fires (default `10`).
+- `LIVE_STATUS_PUSH_TIMEOUT_SECONDS`: HTTP timeout per push request (default `10`).
+
 ### Admin UI / Docker socket
 
 - `DOCKER_SOCK`: rootless docker socket path (if not `/var/run/docker.sock`).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,12 +1,12 @@
-# Asterisk AI Voice Agent - Installation Guide (v7.1.1)
+# Asterisk AI Voice Agent - Installation Guide (v7.2.0)
 
-This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v7.1.1 on your server.
+This guide provides detailed instructions for setting up the Asterisk AI Voice Agent v7.2.0 on your server.
 
 ## Three Setup Paths
 
 Choose the path that best fits your experience level:
 
-## Upgrade to v7.1.1 (Existing Checkout)
+## Upgrade to v7.2.0 (Existing Checkout)
 
 This section is for operators upgrading an existing repo checkout (not a fresh install).
 
@@ -36,11 +36,11 @@ This section is for operators upgrading an existing repo checkout (not a fresh i
 
 ### 1) Pull the new release
 
-To upgrade to the tagged `v7.1.1` release (once the tag is published):
+To upgrade to the tagged `v7.2.0` release (once the tag is published):
 
 ```bash
 git fetch --tags
-git checkout v7.1.1
+git checkout v7.2.0
 ```
 
 If the tag is not published yet, track `main` temporarily:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -2,6 +2,22 @@
 
 This guide covers upgrading between major versions of Asterisk AI Voice Agent.
 
+## v7.x to v7.2.0
+
+**Fully back-compatible.** v7.2.0 is additive — no config, schema, or behavioral changes for existing deployments.
+
+### What's new (opt-in)
+
+- **Live-status hub** — the Admin UI dashboard now aggregates system component status via `/api/live-status` and `/api/live-status/stream` (SSE). No operator action required; the background probe loop starts automatically. Optionally set `LIVE_STATUS_PUSH_TOKEN` in `.env` to enable push updates from `ai_engine` and `local_ai_server` (see [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md#live-status-dashboard)).
+
+### Upgrade
+
+```bash
+git fetch --tags
+git checkout v7.2.0
+docker compose -p asterisk-ai-voice-agent up -d --build --force-recreate admin_ui
+```
+
 ## v6.4.2 to v6.5.x
 
 **Fully back-compatible.** v6.5.0, v6.5.1, v6.5.2, v6.5.3, and v6.5.4 are additive — no required config changes, no breaking schema changes, no behavioral changes for existing single-instance deployments. v6.5.2 does introduce one **breaking change for multi-instance deployments**: short provider aliases (`AI_PROVIDER=openai`, `AI_PROVIDER=google`, `provider: deepgram_agent`) are now rejected at config load — use exact provider instance keys instead. v6.5.3 is a **mandatory hotfix** for OpenAI Realtime users (OpenAI sunset the Beta API on 2026-05-12, so any deployment running v6.5.2 or earlier with OpenAI Realtime will fail until upgraded). v6.5.4 follows up by bringing all remaining code paths (Pydantic defaults, Admin UI templates, wizard backend, etc.) in line with the post-2026-05 GA reality — see "New in v6.5.4" below.

--- a/docs/MILESTONE_HISTORY.md
+++ b/docs/MILESTONE_HISTORY.md
@@ -33,6 +33,7 @@ Archive of completed development milestones for the Asterisk AI Voice Agent. For
 | 23 | [NAT/Advertise Host](contributing/milestones/milestone-23-nat-advertise-host.md) | Feb 2026 | Separate bind vs advertise host for NAT/VPN/hybrid cloud deployments |
 | 24 | [Phase Tools & Tool Enhancements](contributing/milestones/milestone-24-tools-enhancements.md) | Feb 2026 | Pre-call HTTP lookups, in-call HTTP tools, post-call webhooks, extension status checking |
 | 25 | Multi-Instance Full-Agent Providers + xAI Grok | May 2026 | Multiple instances of the same full-agent provider type with isolated credentials (`acme_grok`, `globex_google_live`, etc.); per-instance secret files under `/app/project/secrets/providers/<key>/`. Fifth full-agent realtime provider: xAI Grok Voice Agent (μ-law @ 8 kHz, 5 voices, 30-min cap). Uniform credential UX, dashboard System Topology overhaul, ~260 admin UI tooltips, `.ulaw` recording playback. Breaking for multi-tenant: short provider aliases (`AI_PROVIDER=openai/google`, `provider: deepgram_agent`) removed. |
+| 26 | Live-status Dashboard Hub | Jun 2026 | Normalized `/api/live-status` snapshot + SSE stream aggregating AI Engine, Local AI, sessions, directories, platform, and Asterisk ARI; optional push via `LIVE_STATUS_PUSH_TOKEN`; configurable probe interval and cold-start timeout. |
 
 ---
 
@@ -40,6 +41,7 @@ Archive of completed development milestones for the Asterisk AI Voice Agent. For
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v7.2.0 | Jun 2026 | Live-status dashboard hub (SSE stream, push support, configurable probe interval). |
 | v6.5.4 | May 2026 | Follow-up to v6.5.3: bring every code path in line with the post-2026-05 GA reality. Pydantic defaults, Admin UI "Add Provider" template, model dropdown (removes 5 sunset preview options, adds `gpt-realtime-1.5` / `gpt-realtime-2` / `gpt-realtime-mini`), wizard backend, golden config, and example YAML all flipped to GA. Diagnostic legacy-value rendering (yellow banner + "Custom (legacy)" optgroup) for operators with pinned sunset values. One-shot beta-deprecation warning in the provider. Full rewrite of `docs/Provider-OpenAI-Setup.md` model section. |
 | v6.5.3 | May 2026 | Hotfix: flip shipped OpenAI Realtime config from `api_version: beta` + `gpt-4o-realtime-preview-2024-12-17` to `api_version: ga` + `gpt-realtime`. OpenAI sunset the Beta API on 2026-05-12 and removed the preview model on 2026-05-07. Two-line config change; provider's GA wire-protocol path has shipped since v6.0.0. |
 | v6.5.2 | May 2026 | xAI Grok Voice Agent realtime provider (5th full-agent), multi-instance full-agent providers (`acme_grok`, `globex_google_live`, …), uniform per-instance credentials UX, dashboard System Topology overhaul, ~260 admin UI tooltips, `.ulaw` call recording playback. Breaking for multi-tenant: short provider aliases removed. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -174,4 +174,4 @@ Longer-term goals that will shape the project's direction:
 
 ---
 
-**Last Updated**: June 2026 | **Current Version**: v7.1.1
+**Last Updated**: June 2026 | **Current Version**: v7.2.0

--- a/docs/TROUBLESHOOTING_GUIDE.md
+++ b/docs/TROUBLESHOOTING_GUIDE.md
@@ -1528,4 +1528,4 @@ See [docs/Transport-Mode-Compatibility.md](Transport-Mode-Compatibility.md) for 
 ---
 
 **Last Updated:** June 2026
-**Version:** v7.1.1
+**Version:** v7.2.0

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -124,7 +124,7 @@ For end-user and operator documentation, see the parent [/docs](../) directory:
 
 ## 📅 Project Status
 
-- **Current Version:** 7.1.1
+- **Current Version:** 7.2.0
 - **Active Branch:** `develop`
 - **Roadmap:** See [/docs/ROADMAP.md](../ROADMAP.md)
 - **Community Features:** GitHub Issues + Linear integration


### PR DESCRIPTION
## Summary

Prepares the **v7.2.0** release docs. Rolls `CHANGELOG.md` `[Unreleased]` → `[7.2.0]` (the live-status dashboard, #476), bumps every doc/version reference `7.1.1 → 7.2.0` (the 7.1.2 doc bump was deferred, so this jumps straight to 7.2.0), documents the new `LIVE_STATUS_*` env vars, and refreshes the README "What's New". Docs/config only — no code change.

## Related Issues

- Documents the live-status dashboard feature merged in #476 (this PR is its release-notes + version bump).

## Implementation Notes

- **CHANGELOG.md** — new `## [7.2.0] - 2026-06-27` Added entry for the push-based live-status hub; fresh empty `[Unreleased]` retained on top.
- **README.md** — version badge `7.1.1 → 7.2.0`; new `v7.2.0` "What's New" block (older blocks collapsed so only v7.2.0 is expanded).
- **docs/ENVIRONMENT_VARIABLES.md** — new `### Live-status dashboard` section documenting the 6 `LIVE_STATUS_*` vars.
- **Version-string bumps** — `docs/INSTALLATION.md`, `docs/ROADMAP.md`, `docs/contributing/README.md`, `docs/CLI_TOOLS_GUIDE.md`, `docs/TROUBLESHOOTING_GUIDE.md`, `cli/README.md`.
- **docs/MIGRATION.md** — new back-compatible `v7.x → v7.2.0` section.
- **SECURITY.md** — added a `7.2.x` supported row (no EOL changes to existing rows).
- **config/ai-agent.yaml** + **config/contexts/demo-project-expert.yaml** — agent self-introduction version `v6.5.4 → v7.2.0` (was stale across four releases; user-audible on every call).
- **docs/MILESTONE_HISTORY.md** — logged the live-status milestone.

## Testing

- Docs/config-only change; no application code touched. CI green (CodeQL, build, dev-artifacts, CodeRabbit).
- `config/ai-agent.yaml` and `config/contexts/demo-project-expert.yaml` re-validated as parseable YAML after the in-prompt version edits.
- Verified no stray `v7.1.1` doc-version strings and zero remaining `v6.5.4` refs in the config files.

## Documentation

- This PR *is* the documentation update. The new CHANGELOG `[7.2.0]` section is the release-notes body for the `v7.2.0` tag/GitHub release.
- Tagging `v7.2.0` follows after the golden-baseline gate (manual real-call validation per `docs/RELEASE_CHECKLIST.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)