### PR TITLE
fix: server-reconcile the "restart required" banner (engine config-state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Restart required" banner is now server-driven and only shows when changes are actually pending** (`admin_ui/frontend/src/hooks/useRestartRequired.ts`, the nine engine-config pages): the AI-Engine restart banner on Providers, Contexts, Tools, Pipelines, and the Advanced LLM/VAD/Streaming/Transport/Barge-In pages was previously driven by stale client state (localStorage for some pages, a local `useState` for others) and was always rendered (only its color changed). This caused two bugs — false positives that persisted after an out-of-band engine restart/deploy, and a banner that never disappeared when nothing was pending. The pages now consume a new `useRestartRequired` hook that polls `GET /api/system/config-state` (authoritative on-disk-vs-loaded config-hash comparison; safe-defaults to `false` when the engine is unreachable or the disk config won't parse). The banner is gated on `restart_required` so it renders only when a restart is genuinely needed, refetches immediately after a config save and after a successful restart/hot-reload, and clears itself once the engine's running hash matches disk. The `.env`-domain banner on the Environment page is intentionally left unchanged. New hook is unit-tested (Vitest).
+
 ## [7.2.0] - 2026-06-27
 
 ### Added

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -4919,3 +4919,46 @@ async def asterisk_status():
     await _probe_asterisk_ari(settings, live)
     live.pop("_app_registration_checked", None)  # internal signal — keep out of the response
     return {"mode": mode, "manifest": manifest, "live": live}
+
+
+_CONFIG_STATE_SAFE_FALLBACK = {
+    "running_config_hash": None,
+    "disk_config_hash": None,
+    "restart_required": False,
+    "disk_config_valid": True,
+    "engine_reachable": False,
+}
+
+
+@router.get("/config-state")
+async def get_config_state():
+    """
+    Proxy GET /config/state from the AI Engine health server.
+
+    Returns the engine's config reconciliation state so the Admin UI frontend
+    can show a "restart required" banner without reaching the engine directly.
+
+    On any failure (engine down, timeout, non-200, bad JSON) returns a safe
+    fallback with restart_required=false so the banner never false-alarms when
+    the engine is simply unreachable.
+    """
+    import httpx
+
+    engine_url = os.getenv("AI_ENGINE_HEALTH_URL", "http://localhost:15000")
+    url = engine_url.rstrip("/") + "/config/state"
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(url)
+        if resp.status_code != 200:
+            logger.warning(
+                "Engine /config/state returned HTTP %s; using safe fallback",
+                resp.status_code,
+            )
+            return _CONFIG_STATE_SAFE_FALLBACK
+        data = resp.json()
+        data["engine_reachable"] = True
+        return data
+    except Exception as exc:
+        logger.debug("Engine /config/state unreachable (%s: %s); using safe fallback", type(exc).__name__, exc)
+        return _CONFIG_STATE_SAFE_FALLBACK

--- a/admin_ui/backend/tests/test_config_state_proxy.py
+++ b/admin_ui/backend/tests/test_config_state_proxy.py
@@ -1,0 +1,128 @@
+"""Tests for the /api/system/config-state proxy route.
+
+The route proxies GET /config/state from the AI Engine health server so the
+Admin UI frontend can poll restart-reconciliation state without reaching the
+engine directly.
+
+Auth is covered by the router-level Depends(auth.get_current_user); these tests
+exercise the async handler function directly, mirroring the pattern used by
+test_reload_proxy_auth.py and test_restart_recreate_routing.py.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from api import system  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_config_state_proxies_engine() -> None:
+    """On a 200 response the route returns the engine's JSON plus engine_reachable=True."""
+    engine_payload = {
+        "running_config_hash": "abc123",
+        "disk_config_hash": "abc123",
+        "restart_required": False,
+        "disk_config_valid": True,
+    }
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = dict(engine_payload)
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=fake_client):
+        result = await system.get_config_state()
+
+    assert result["running_config_hash"] == "abc123"
+    assert result["disk_config_hash"] == "abc123"
+    assert result["restart_required"] is False
+    assert result["disk_config_valid"] is True
+    assert result["engine_reachable"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_state_engine_unreachable_safe() -> None:
+    """When the engine raises (unreachable/timeout), the route returns the safe fallback with HTTP 200.
+
+    Specifically: restart_required must be False and engine_reachable must be False so
+    the frontend banner never false-alarms when the engine is simply down.
+    """
+    import httpx
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=fake_client):
+        result = await system.get_config_state()
+
+    assert result["restart_required"] is False, (
+        "Must not report restart_required=True just because the engine is unreachable"
+    )
+    assert result["engine_reachable"] is False
+    assert result["running_config_hash"] is None
+    assert result["disk_config_hash"] is None
+    assert result["disk_config_valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_config_state_non_200_returns_safe_fallback() -> None:
+    """A non-200 HTTP response from the engine also yields the safe fallback."""
+    fake_resp = MagicMock()
+    fake_resp.status_code = 503
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=fake_resp)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=fake_client):
+        result = await system.get_config_state()
+
+    assert result["restart_required"] is False
+    assert result["engine_reachable"] is False
+
+
+@pytest.mark.asyncio
+async def test_config_state_uses_ai_engine_health_url_env(monkeypatch) -> None:
+    """The proxy constructs the engine URL from AI_ENGINE_HEALTH_URL env var."""
+    monkeypatch.setenv("AI_ENGINE_HEALTH_URL", "http://ai_engine:15000")
+
+    captured = {}
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {
+        "running_config_hash": "xyz",
+        "disk_config_hash": "xyz",
+        "restart_required": False,
+        "disk_config_valid": True,
+    }
+
+    async def fake_get(url, **kwargs):
+        captured["url"] = url
+        return fake_resp
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=fake_client):
+        await system.get_config_state()
+
+    assert captured["url"] == "http://ai_engine:15000/config/state"

--- a/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import axios from 'axios';
+import { useRestartRequired } from './useRestartRequired';
+
+vi.mock('axios');
+
+const mockedGet = vi.mocked(axios.get);
+
+const configState = (restart_required: boolean) => ({
+    data: {
+        running_config_hash: 'a',
+        disk_config_hash: restart_required ? 'b' : 'a',
+        restart_required,
+        disk_config_valid: true,
+        engine_reachable: true,
+    },
+});
+
+describe('useRestartRequired', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('fetches config-state on mount and reflects restart_required', async () => {
+        mockedGet.mockResolvedValue(configState(true));
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.restartRequired).toBe(true));
+        expect(mockedGet).toHaveBeenCalledWith('/api/system/config-state');
+
+        unmount();
+    });
+
+    it('reports false when restart_required is false', async () => {
+        mockedGet.mockResolvedValue(configState(false));
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.restartRequired).toBe(false);
+
+        unmount();
+    });
+
+    it('refetch re-fetches the config-state', async () => {
+        mockedGet.mockResolvedValueOnce(configState(false));
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.restartRequired).toBe(false));
+
+        mockedGet.mockResolvedValueOnce(configState(true));
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(result.current.restartRequired).toBe(true);
+
+        unmount();
+    });
+
+    it('treats request errors as no restart required', async () => {
+        mockedGet.mockRejectedValue(new Error('network down'));
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.restartRequired).toBe(false);
+
+        unmount();
+    });
+});

--- a/admin_ui/frontend/src/hooks/useRestartRequired.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.ts
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 
 interface ConfigState {
-    running_config_hash: string;
-    disk_config_hash: string;
+    running_config_hash: string | null;
+    disk_config_hash: string | null;
     restart_required: boolean;
     disk_config_valid: boolean;
     engine_reachable: boolean;
@@ -19,16 +19,26 @@ export function useRestartRequired(): {
 } {
     const [restartRequired, setRestartRequired] = useState(false);
     const [loading, setLoading] = useState(true);
+    // Latest-response-wins: a slower older request (e.g. the 15s poll) must not
+    // overwrite a newer one (e.g. a post-save/restart refetch) with stale data.
+    const requestSeq = useRef(0);
 
     const refetch = useCallback(async () => {
+        const seq = ++requestSeq.current;
         try {
             const res = await axios.get<ConfigState>(CONFIG_STATE_URL);
-            setRestartRequired(res.data?.restart_required === true);
+            if (seq === requestSeq.current) {
+                setRestartRequired(res.data?.restart_required === true);
+            }
         } catch {
             // Never false-alarm: treat any error as "no restart required".
-            setRestartRequired(false);
+            if (seq === requestSeq.current) {
+                setRestartRequired(false);
+            }
         } finally {
-            setLoading(false);
+            if (seq === requestSeq.current) {
+                setLoading(false);
+            }
         }
     }, []);
 

--- a/admin_ui/frontend/src/hooks/useRestartRequired.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface ConfigState {
+    running_config_hash: string;
+    disk_config_hash: string;
+    restart_required: boolean;
+    disk_config_valid: boolean;
+    engine_reachable: boolean;
+}
+
+const CONFIG_STATE_URL = '/api/system/config-state';
+const POLL_INTERVAL_MS = 15000;
+
+export function useRestartRequired(): {
+    restartRequired: boolean;
+    refetch: () => Promise<void>;
+    loading: boolean;
+} {
+    const [restartRequired, setRestartRequired] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    const refetch = useCallback(async () => {
+        try {
+            const res = await axios.get<ConfigState>(CONFIG_STATE_URL);
+            setRestartRequired(res.data?.restart_required === true);
+        } catch {
+            // Never false-alarm: treat any error as "no restart required".
+            setRestartRequired(false);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        const tick = async () => {
+            await refetch();
+        };
+        tick();
+        const interval = setInterval(() => {
+            if (!cancelled) tick();
+        }, POLL_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, [refetch]);
+
+    return { restartRequired, refetch, loading };
+}

--- a/admin_ui/frontend/src/pages/Advanced/BargeInPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/BargeInPage.tsx
@@ -9,13 +9,14 @@ import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput, FormSwitch } from '../../components/ui/FormComponents';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
 import { getCachedConfig, loadConfigYaml } from '../../utils/configCache';
+import { useRestartRequired } from '../../hooks/useRestartRequired';
 
 const BargeInPage = () => {
     const [config, setConfig] = useState<any>(() => getCachedConfig()?.config ?? {});
     const [loading, setLoading] = useState(() => getCachedConfig() == null);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
-    const [pendingRestart, setPendingRestart] = useState(false);
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [applyMethod, setApplyMethod] = useState<string>('restart');
 
@@ -46,7 +47,7 @@ const BargeInPage = () => {
             const response = await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             const method = response.data?.recommended_apply_method || 'restart';
             setApplyMethod(method);
-            setPendingRestart(true);
+            await refetch();
             if (method === 'hot_reload') {
                 toast.success('Barge-in configuration saved. Changes can be applied via hot-reload.');
             } else {
@@ -69,13 +70,13 @@ const BargeInPage = () => {
 
                 if (response.data?.restart_required) {
                     setApplyMethod('restart');
-                    setPendingRestart(true);
+                    await refetch();
                     toast.warning('Hot reload applied partially', { description: response.data.message || 'Restart AI Engine to fully apply changes' });
                     return;
                 }
 
                 if (response.data?.status === 'success') {
-                    setPendingRestart(false);
+                    await refetch();
                     toast.success('AI Engine hot reloaded! Changes are now active.');
                     return;
                 }
@@ -106,7 +107,7 @@ const BargeInPage = () => {
             }
 
             if (response.data.status === 'success') {
-                setPendingRestart(false);
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -147,30 +148,28 @@ const BargeInPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    {bannerMessage}
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        {bannerMessage}
+                    </div>
+                    <button
+                        onClick={() => handleApplyAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine
+                            ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
+                            : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleApplyAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${
-                        pendingRestart 
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium' 
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                    } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine
-                        ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
-                        : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
-                </button>
-            </div>
+            )}
 
             <div className="flex justify-between items-center">
                 <div>

--- a/admin_ui/frontend/src/pages/Advanced/LLMPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/LLMPage.tsx
@@ -10,6 +10,7 @@ import { FormInput } from '../../components/ui/FormComponents';
 import HelpTooltip from '../../components/ui/HelpTooltip';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
 import { localAIStatusFromLiveSnapshot } from '../../utils/liveStatus';
+import { useRestartRequired } from '../../hooks/useRestartRequired';
 
 const CHAT_FORMAT_OPTIONS = [
     { value: '', label: '(Legacy Phi-style — no chat template)' },
@@ -26,7 +27,7 @@ const LLMPage = () => {
     const [loading, setLoading] = useState(true);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(null);
     const [saving, setSaving] = useState(false);
-    const [pendingRestart, setPendingRestart] = useState(false);
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localCapability, setLocalCapability] = useState<any>(null);
     const [localConnected, setLocalConnected] = useState(false);
@@ -107,7 +108,7 @@ const LLMPage = () => {
             const yamlOk = yamlSave.status === 'fulfilled';
             const envOk = envSave.status === 'fulfilled';
             if (yamlOk || envOk) {
-                setPendingRestart(true);
+                await refetch();
             }
             if (!yamlOk || !envOk) {
                 const yamlState = yamlOk ? 'ok' : 'failed';
@@ -152,7 +153,7 @@ const LLMPage = () => {
             }
 
             if (response.data.status === 'success') {
-                setPendingRestart(false);
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -210,28 +211,26 @@ const LLMPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    LLM configuration changes require an AI Engine restart to take effect.
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        LLM configuration changes require an AI Engine restart to take effect.
+                    </div>
+                    <button
+                        onClick={() => handleReloadAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleReloadAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${
-                        pendingRestart 
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium' 
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                    } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
-                </button>
-            </div>
+            )}
 
             <div className="flex justify-between items-center">
                 <div>

--- a/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/StreamingPage.tsx
@@ -9,13 +9,14 @@ import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput, FormSelect, FormSwitch } from '../../components/ui/FormComponents';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
 import { getCachedConfig, loadConfigYaml } from '../../utils/configCache';
+import { useRestartRequired } from '../../hooks/useRestartRequired';
 
 const StreamingPage = () => {
     const [config, setConfig] = useState<any>(() => getCachedConfig()?.config ?? {});
     const [loading, setLoading] = useState(() => getCachedConfig() == null);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
-    const [pendingRestart, setPendingRestart] = useState(false);
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [applyMethod, setApplyMethod] = useState<string>('restart');
 
@@ -46,7 +47,7 @@ const StreamingPage = () => {
             const response = await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             const method = response.data?.recommended_apply_method || 'restart';
             setApplyMethod(method);
-            setPendingRestart(true);
+            await refetch();
             if (method === 'hot_reload') {
                 toast.success('Streaming configuration saved. Changes can be applied via hot-reload.');
             } else {
@@ -69,13 +70,13 @@ const StreamingPage = () => {
 
                 if (response.data?.restart_required) {
                     setApplyMethod('restart');
-                    setPendingRestart(true);
+                    await refetch();
                     toast.warning('Hot reload applied partially', { description: response.data.message || 'Restart AI Engine to fully apply changes' });
                     return;
                 }
 
                 if (response.data?.status === 'success') {
-                    setPendingRestart(false);
+                    await refetch();
                     toast.success('AI Engine hot reloaded! Changes are now active.');
                     return;
                 }
@@ -106,7 +107,7 @@ const StreamingPage = () => {
             }
 
             if (response.data.status === 'success') {
-                setPendingRestart(false);
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -197,30 +198,28 @@ const StreamingPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    {bannerMessage}
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        {bannerMessage}
+                    </div>
+                    <button
+                        onClick={() => handleApplyAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine
+                            ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
+                            : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleApplyAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${
-                        pendingRestart 
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium' 
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                    } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine
-                        ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
-                        : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
-                </button>
-            </div>
+            )}
 
             <div className="flex justify-between items-center">
                 <div>

--- a/admin_ui/frontend/src/pages/Advanced/TransportPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/TransportPage.tsx
@@ -10,6 +10,7 @@ import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput, FormSelect, FormSwitch } from '../../components/ui/FormComponents';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
 import { getCachedConfig, loadConfigYaml } from '../../utils/configCache';
+import { useRestartRequired } from '../../hooks/useRestartRequired';
 
 const TransportPage = () => {
     const { confirm } = useConfirmDialog();
@@ -17,7 +18,7 @@ const TransportPage = () => {
     const [loading, setLoading] = useState(() => getCachedConfig() == null);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
-    const [pendingRestart, setPendingRestart] = useState(false);
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [applyMethod, setApplyMethod] = useState<string>('restart');
     const [showExternalMediaExpert, setShowExternalMediaExpert] = useState(false);
@@ -49,8 +50,8 @@ const TransportPage = () => {
             const response = await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             const method = response.data?.recommended_apply_method || 'restart';
             setApplyMethod(method);
-            setPendingRestart(true);
-            
+            await refetch();
+
             // Show appropriate message based on recommended apply method
             if (method === 'hot_reload') {
                 toast.success('Configuration saved. Changes can be applied via hot-reload.');
@@ -73,13 +74,13 @@ const TransportPage = () => {
 
                 if (response.data?.restart_required) {
                     setApplyMethod('restart');
-                    setPendingRestart(true);
+                    await refetch();
                     toast.warning('Hot reload applied partially', { description: response.data.message || 'Restart AI Engine to fully apply changes' });
                     return;
                 }
 
                 if (response.data?.status === 'success') {
-                    setPendingRestart(false);
+                    await refetch();
                     toast.success('AI Engine hot reloaded! Changes are now active.');
                     return;
                 }
@@ -110,7 +111,7 @@ const TransportPage = () => {
             }
 
             if (response.data.status === 'success') {
-                setPendingRestart(false);
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
                 return;
             }
@@ -163,28 +164,26 @@ const TransportPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    {bannerMessage}
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        {bannerMessage}
+                    </div>
+                    <button
+                        onClick={() => handleApplyAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine ? 'Applying...' : buttonLabel}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleApplyAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${
-                        pendingRestart 
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium' 
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                    } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine ? 'Applying...' : buttonLabel}
-                </button>
-            </div>
+            )}
 
             <div className="flex justify-between items-center">
                 <div>

--- a/admin_ui/frontend/src/pages/Advanced/VADPage.tsx
+++ b/admin_ui/frontend/src/pages/Advanced/VADPage.tsx
@@ -10,6 +10,7 @@ import { ConfigCard } from '../../components/ui/ConfigCard';
 import { FormInput, FormSwitch } from '../../components/ui/FormComponents';
 import { sanitizeConfigForSave } from '../../utils/configSanitizers';
 import { getCachedConfig, loadConfigYaml } from '../../utils/configCache';
+import { useRestartRequired } from '../../hooks/useRestartRequired';
 
 const VAD_UTTERANCE_EXPERT_STORAGE_KEY = 'aava.ui.vad.utteranceExpert';
 
@@ -19,7 +20,7 @@ const VADPage = () => {
     const [loading, setLoading] = useState(() => getCachedConfig() == null);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
-    const [pendingRestart, setPendingRestart] = useState(false);
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [applyMethod, setApplyMethod] = useState<string>('restart');
     const [showUtteranceExpert, setShowUtteranceExpert] = useState<boolean>(() => {
@@ -68,7 +69,7 @@ const VADPage = () => {
             const response = await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             const method = response.data?.recommended_apply_method || 'restart';
             setApplyMethod(method);
-            setPendingRestart(true);
+            await refetch();
             if (method === 'hot_reload') {
                 toast.success('VAD configuration saved. Changes can be applied via hot-reload.');
             } else {
@@ -91,13 +92,13 @@ const VADPage = () => {
 
                 if (response.data?.restart_required) {
                     setApplyMethod('restart');
-                    setPendingRestart(true);
+                    await refetch();
                     toast.warning('Hot reload applied partially', { description: response.data.message || 'Restart AI Engine to fully apply changes' });
                     return;
                 }
 
                 if (response.data?.status === 'success') {
-                    setPendingRestart(false);
+                    await refetch();
                     toast.success('AI Engine hot reloaded! Changes are now active.');
                     return;
                 }
@@ -128,7 +129,7 @@ const VADPage = () => {
             }
 
             if (response.data.status === 'success') {
-                setPendingRestart(false);
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -180,30 +181,28 @@ const VADPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    {bannerMessage}
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        {bannerMessage}
+                    </div>
+                    <button
+                        onClick={() => handleApplyAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine
+                            ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
+                            : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleApplyAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${
-                        pendingRestart 
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium' 
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                    } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine
-                        ? (applyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
-                        : (applyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
-                </button>
-            </div>
+            )}
 
             <div className="flex justify-between items-center">
                 <div>

--- a/admin_ui/frontend/src/pages/ContextsPage.tsx
+++ b/admin_ui/frontend/src/pages/ContextsPage.tsx
@@ -13,6 +13,7 @@ import { ConfigCard } from '../components/ui/ConfigCard';
 import { Modal } from '../components/ui/Modal';
 import ContextForm from '../components/config/ContextForm';
 import { usePendingChanges } from '../hooks/usePendingChanges';
+import { useRestartRequired } from '../hooks/useRestartRequired';
 
 const READ_ONLY = true;
 
@@ -35,7 +36,11 @@ const ContextsPage = () => {
     const [editingContext, setEditingContext] = useState<string | null>(null);
     const [contextForm, setContextForm] = useState<any>({});
     const [isNewContext, setIsNewContext] = useState(false);
-    const { pendingRestart: pendingApply, applyMethod, setPendingChanges, clearPendingChanges } = usePendingChanges();
+    // applyMethod (hot_reload vs restart) still drives the Apply button label,
+    // confirm dialog, and apply endpoint selection. Banner VISIBILITY is now
+    // server-driven via useRestartRequired so it can't go stale.
+    const { applyMethod, setPendingChanges, clearPendingChanges } = usePendingChanges();
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
 
     useEffect(() => {
@@ -175,6 +180,7 @@ const ContextsPage = () => {
             setConfig(sanitized);
             const method = (res.data?.recommended_apply_method || 'restart') as 'hot_reload' | 'restart';
             setPendingChanges(method);
+            await refetch();
         } catch (err) {
             console.error('Failed to save config', err);
             toast.error('Failed to save configuration');
@@ -206,6 +212,7 @@ const ContextsPage = () => {
 
             if (status === 'degraded') {
                 clearPendingChanges();
+                await refetch();
                 toast.warning('AI Engine restarted but may not be fully healthy', { description: response.data.output || 'Please verify manually' });
                 fetchConfig(true);
                 return;
@@ -215,12 +222,14 @@ const ContextsPage = () => {
                 // Hot reload succeeded but indicated some changes require a restart (e.g. providers added/removed,
                 // MCP reload deferred due to active calls).
                 setPendingChanges('restart');
+                await refetch();
                 toast.warning(response.data.message || 'Hot reload applied partially; restart AI Engine to fully apply changes.');
                 return;
             }
 
             if (status === 'success') {
                 clearPendingChanges();
+                await refetch();
                 toast.success(applyMethod === 'hot_reload'
                     ? 'AI Engine hot reloaded! Changes apply to new calls.'
                     : 'AI Engine restarted! Changes are now active.');
@@ -233,6 +242,7 @@ const ContextsPage = () => {
             // completed so the UI doesn't get stuck showing "Apply Changes" forever.
             if (response.status === 200) {
                 clearPendingChanges();
+                await refetch();
                 toast.success('AI Engine updated. Please verify with a test call and logs.');
                 fetchConfig(true);
                 return;
@@ -397,7 +407,7 @@ const ContextsPage = () => {
                 </span>
             </div>
 
-            {pendingApply && (
+            {restartRequired && (
                 <div className="bg-orange-500/15 border border-orange-500/30 text-yellow-700 dark:text-yellow-400 p-4 rounded-md flex items-center justify-between">
                     <div className="flex items-center">
                         <AlertCircle className="w-5 h-5 mr-2" />

--- a/admin_ui/frontend/src/pages/PipelinesPage.tsx
+++ b/admin_ui/frontend/src/pages/PipelinesPage.tsx
@@ -13,7 +13,7 @@ import { Modal } from '../components/ui/Modal';
 import PipelineForm from '../components/config/PipelineForm';
 import { ensureModularKey, isFullAgentProvider } from '../utils/providerNaming';
 import { normalizeSttOptions } from '../utils/sttAudioContract';
-import { usePendingChanges } from '../hooks/usePendingChanges';
+import { useRestartRequired } from '../hooks/useRestartRequired';
 
 const PipelinesPage = () => {
     const { confirm } = useConfirmDialog();
@@ -24,7 +24,7 @@ const PipelinesPage = () => {
     const [editingPipeline, setEditingPipeline] = useState<string | null>(null);
     const [pipelineForm, setPipelineForm] = useState<any>({});
     const [isNewPipeline, setIsNewPipeline] = useState(false);
-    const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const providers = config?.providers || {};
 
@@ -113,7 +113,7 @@ const PipelinesPage = () => {
             const sanitized = sanitizeConfigForSave(newConfig);
             await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             setConfig(sanitized);
-            setPendingChanges('restart');
+            await refetch();
         } catch (err) {
             console.error('Failed to save config', err);
             toast.error('Failed to save configuration');
@@ -146,7 +146,7 @@ const PipelinesPage = () => {
             }
 
             if (response.data.status === 'success') {
-                clearPendingChanges();
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -401,27 +401,26 @@ const PipelinesPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    Changes to pipeline configurations require an AI Engine restart to take effect.
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        Changes to pipeline configurations require an AI Engine restart to take effect.
+                    </div>
+                    <button
+                        onClick={() => handleReloadAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine ? 'Restarting...' : 'Reload AI Engine'}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleReloadAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${pendingRestart
-                        ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium'
-                        : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                        } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine ? 'Restarting...' : 'Reload AI Engine'}
-                </button>
-            </div>
+            )}
 
             {error && (
                 <div className="bg-red-500/15 border border-red-500/30 text-red-700 dark:text-red-400 p-4 rounded-md flex items-center justify-between">

--- a/admin_ui/frontend/src/pages/ProvidersPage.tsx
+++ b/admin_ui/frontend/src/pages/ProvidersPage.tsx
@@ -11,7 +11,7 @@ import { ConfigSection } from '../components/ui/ConfigSection';
 import { ConfigCard } from '../components/ui/ConfigCard';
 import { Modal } from '../components/ui/Modal';
 import HelpTooltip from '../components/ui/HelpTooltip';
-import { usePendingChanges } from '../hooks/usePendingChanges';
+import { useRestartRequired } from '../hooks/useRestartRequired';
 import { localAIStatusFromLiveSnapshot } from '../utils/liveStatus';
 
 // Provider Forms
@@ -46,7 +46,7 @@ const ProvidersPage: React.FC = () => {
     const [testResults, setTestResults] = useState<{ [key: string]: { success: boolean; message: string } | undefined }>({});
     const [showAddProvidersModal, setShowAddProvidersModal] = useState(false);
     const [selectedTemplates, setSelectedTemplates] = useState<string[]>([]);
-    const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [localAIStatus, setLocalAIStatus] = useState<any>(null);
     const [providerHealth, setProviderHealth] = useState<Record<string, { status: string; total: number; failures: number; summary: string }>>({});
@@ -158,7 +158,7 @@ const ProvidersPage: React.FC = () => {
             const sanitized = sanitizeConfigForSave(normalized);
             await axios.post('/api/config/yaml', { content: yaml.dump(sanitized) });
             setConfig(sanitized);
-            setPendingChanges('restart');
+            await refetch();
         } catch (err) {
             console.error('Failed to save config', err);
             toast.error('Failed to save configuration');
@@ -431,7 +431,7 @@ const ProvidersPage: React.FC = () => {
             }
 
             if (response.data.status === 'success') {
-                clearPendingChanges();
+                await refetch();
                 toast.success('AI Engine restarted! Changes are now active.');
             }
         } catch (error: any) {
@@ -809,27 +809,26 @@ const ProvidersPage: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    Provider configuration changes require an AI Engine restart to take effect.
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        Provider configuration changes require an AI Engine restart to take effect.
+                    </div>
+                    <button
+                        onClick={() => handleReloadAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleReloadAIEngine(false)}
-                    disabled={restartingEngine}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${pendingRestart
-                        ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium'
-                        : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                        } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
-                </button>
-            </div>
+            )}
 
             {error && (
                 <div className="bg-red-500/15 border border-red-500/30 text-red-700 dark:text-red-400 p-4 rounded-md flex items-center justify-between">

--- a/admin_ui/frontend/src/pages/ToolsPage.tsx
+++ b/admin_ui/frontend/src/pages/ToolsPage.tsx
@@ -12,7 +12,7 @@ import HTTPToolForm from '../components/config/HTTPToolForm';
 import { useAuth } from '../auth/AuthContext';
 import { sanitizeConfigForSave } from '../utils/configSanitizers';
 import { getCachedConfig, loadConfigYaml } from '../utils/configCache';
-import { usePendingChanges } from '../hooks/usePendingChanges';
+import { useRestartRequired } from '../hooks/useRestartRequired';
 
 type ToolPhase = 'in_call' | 'pre_call' | 'post_call' | 'catalog';
 
@@ -41,7 +41,7 @@ const ToolsPage = () => {
     const [loading, setLoading] = useState(() => getCachedConfig() == null);
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
-    const { pendingRestart, setPendingChanges, clearPendingChanges } = usePendingChanges();
+    const { restartRequired, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [activePhase, setActivePhase] = useState<ToolPhase>('in_call');
     const [toolCatalog, setToolCatalog] = useState<ToolDef[]>([]);
@@ -133,7 +133,7 @@ const ToolsPage = () => {
                 headers: { Authorization: `Bearer ${token}` },
                 timeout: 30000  // 30 second timeout
             });
-            setPendingChanges('restart');
+            await refetch();
             if (successToast) toast.success(successToast);
         } catch (err: any) {
             console.error('Failed to save config', err);
@@ -175,7 +175,7 @@ const ToolsPage = () => {
                 return;
             }
 
-            clearPendingChanges();
+            await refetch();
             toast.success('AI Engine restarted! Changes are now active.');
         } catch (error: any) {
             toast.error('Failed to restart AI Engine', { description: error.response?.data?.detail || error.message });
@@ -258,27 +258,26 @@ const ToolsPage = () => {
 
     return (
         <div className="space-y-6">
-            <div className={`${pendingRestart ? 'bg-orange-500/15 border-orange-500/30' : 'bg-yellow-500/10 border-yellow-500/20'} border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between`}>
-                <div className="flex items-center">
-                    <AlertCircle className="w-5 h-5 mr-2" />
-                    Tool configuration changes require an AI Engine restart to take effect.
+            {restartRequired && (
+                <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
+                    <div className="flex items-center">
+                        <AlertCircle className="w-5 h-5 mr-2" />
+                        Tool configuration changes require an AI Engine restart to take effect.
+                    </div>
+                    <button
+                        onClick={() => handleRestartAIEngine(false)}
+                        disabled={restartingEngine}
+                        className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
+                    >
+                        {restartingEngine ? (
+                            <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="w-3 h-3 mr-1.5" />
+                        )}
+                        {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
+                    </button>
                 </div>
-                <button
-                    onClick={() => handleRestartAIEngine(false)}
-                    disabled={restartingEngine || !pendingRestart}
-                    className={`flex items-center text-xs px-3 py-1.5 rounded transition-colors ${pendingRestart
-                            ? 'bg-orange-500 text-white hover:bg-orange-600 font-medium'
-                            : 'bg-yellow-500/20 hover:bg-yellow-500/30'
-                        } disabled:opacity-50`}
-                >
-                    {restartingEngine ? (
-                        <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
-                    ) : (
-                        <RefreshCw className="w-3 h-3 mr-1.5" />
-                    )}
-                    {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
-                </button>
-            </div>
+            )}
             <div className="flex justify-between items-center">
                 <div>
                     <h1 className="text-3xl font-bold tracking-tight">Tools & Capabilities</h1>

--- a/src/engine.py
+++ b/src/engine.py
@@ -15163,7 +15163,11 @@ class Engine:
 
     async def _config_state_handler(self, request):
         """Report whether the on-disk config differs from the running config."""
-        return web.json_response(self._compute_config_state())
+        # _compute_config_state() calls load_config() (file I/O + YAML parse +
+        # Pydantic validation); offload it so the health-server event loop is
+        # never blocked.
+        state = await asyncio.to_thread(self._compute_config_state)
+        return web.json_response(state)
 
     async def _metrics_handler(self, request):
         """Expose Prometheus metrics."""

--- a/src/engine.py
+++ b/src/engine.py
@@ -12663,25 +12663,58 @@ class Engine:
         
         session.music_snoop_channel_id = None
     
-    def _compute_config_hash(self) -> str:
-        """Compute a hash of the current config for pending-changes detection."""
+    def _compute_config_hash(self, config=None) -> str:
+        """Compute a hash of a config for pending-changes detection.
+
+        Defaults to ``self.config`` when ``config`` is None so existing callers
+        keep working; pass a freshly loaded config to compare disk vs running.
+        """
         import hashlib
         import json
+        if config is None:
+            config = self.config
         try:
             # Convert config to dict and hash it
-            if hasattr(self.config, 'model_dump'):
-                config_dict = self.config.model_dump()
-            elif hasattr(self.config, 'dict'):
-                config_dict = self.config.dict()
+            if hasattr(config, 'model_dump'):
+                config_dict = config.model_dump()
+            elif hasattr(config, 'dict'):
+                config_dict = config.dict()
             else:
                 config_dict = {}
-            
+
             # Create a stable JSON representation (sorted keys)
             config_json = json.dumps(config_dict, sort_keys=True, default=str)
             return hashlib.sha256(config_json.encode()).hexdigest()[:16]
         except Exception as e:
             logger.debug(f"Failed to compute config hash: {e}")
             return "unknown"
+
+    def _compute_config_state(self) -> dict:
+        """Compare the running (loaded) config against what's on disk.
+
+        Lets the Admin UI drive a "restart required" banner from engine truth
+        instead of stale client-side state. Never raises: if the on-disk config
+        can't be parsed/validated we report it invalid rather than claiming a
+        restart is needed.
+        """
+        running_hash = self._config_hash
+        try:
+            disk_config = load_config()
+        except Exception as e:
+            logger.warning("Failed to load disk config for state check", error=str(e))
+            return {
+                "running_config_hash": running_hash,
+                "disk_config_hash": None,
+                "restart_required": False,
+                "disk_config_valid": False,
+            }
+        disk_hash = self._compute_config_hash(disk_config)
+        return {
+            "running_config_hash": running_hash,
+            "disk_config_hash": disk_hash,
+            "restart_required": running_hash != disk_hash,
+            "disk_config_valid": True,
+        }
     
     @staticmethod
     def _canonicalize_encoding(value: Optional[str]) -> str:
@@ -14007,6 +14040,7 @@ class Engine:
             # (similar to /mcp/status) and should not include secrets or PII.
             app.router.add_get('/tools/definitions', self._tools_definitions_handler)
             app.router.add_get('/sessions/stats', self._sessions_stats_handler)
+            app.router.add_get('/config/state', self._config_state_handler)
             runner = web.AppRunner(app)
             await runner.setup()
             # Host/port configurable via YAML health block with environment overrides (AAVA-30)
@@ -15126,6 +15160,10 @@ class Engine:
         except Exception as exc:
             logger.debug("Ready handler failed", error=str(exc), exc_info=True)
             return web.json_response({"ready": False, "error": "internal_error"}, status=500)
+
+    async def _config_state_handler(self, request):
+        """Report whether the on-disk config differs from the running config."""
+        return web.json_response(self._compute_config_state())
 
     async def _metrics_handler(self, request):
         """Expose Prometheus metrics."""

--- a/tests/test_engine_config_state.py
+++ b/tests/test_engine_config_state.py
@@ -1,0 +1,110 @@
+"""Tests for the engine /config/state restart-required reconciliation endpoint.
+
+The engine reports whether the on-disk config differs from the running (loaded)
+config so the Admin UI can stop relying on stale client-side localStorage to drive
+the "restart required" banner.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+import src.engine as engine_mod
+from src.config import load_config
+from src.engine import Engine
+
+# A valid, self-contained on-disk config so the unchanged-config invariant
+# exercises a real load_config() round-trip. Credentials come from env vars
+# set by the autouse fixture below.
+_CONFIG_PATH = "config/ai-agent.example.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _required_env(monkeypatch):
+    """ai-agent.example.yaml resolves Asterisk creds + API keys from env."""
+    monkeypatch.setenv("ASTERISK_ARI_USERNAME", "test_user")
+    monkeypatch.setenv("ASTERISK_ARI_PASSWORD", "test_pass")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    monkeypatch.setenv("TELNYX_API_KEY", "tk-test-key")
+
+
+def _make_engine_from_disk():
+    """Build a minimal Engine whose running config is a real on-disk load.
+
+    Mirrors the test_engine_live_status_publish.py construction pattern: bypass
+    __init__ via __new__ and set only the attributes the methods under test use.
+    The running hash is snapshotted from the SAME load_config() path the engine
+    uses at startup, so an untouched disk must hash-match the running config.
+    """
+    config = load_config(_CONFIG_PATH)
+    engine = Engine.__new__(Engine)
+    engine.config = config
+    engine._config_hash = engine._compute_config_hash()
+    return engine
+
+
+def test_unchanged_config_reports_no_restart(monkeypatch):
+    """CRITICAL INVARIANT: with nothing changed on disk since the engine loaded,
+    running and disk hashes must match and restart_required must be False."""
+    engine = _make_engine_from_disk()
+    # Engine re-reads disk via load_config(); point it at the same untouched file.
+    monkeypatch.setattr(
+        engine_mod, "load_config", lambda *a, **k: load_config(_CONFIG_PATH)
+    )
+
+    state = engine._compute_config_state()
+
+    assert state["disk_config_valid"] is True
+    assert state["running_config_hash"] == state["disk_config_hash"], (
+        f"running={state['running_config_hash']} disk={state['disk_config_hash']}"
+    )
+    assert state["restart_required"] is False
+
+
+def test_changed_disk_config_requires_restart(monkeypatch):
+    """When the on-disk config differs from what the engine loaded, the engine
+    reports restart_required and the hashes differ."""
+    engine = _make_engine_from_disk()
+
+    # Simulate an out-of-band edit to disk: a fresh load now yields a different config.
+    mutated = load_config(_CONFIG_PATH)
+    mutated.default_provider = mutated.default_provider + "_changed"
+    monkeypatch.setattr(engine_mod, "load_config", lambda *a, **k: mutated)
+
+    state = engine._compute_config_state()
+
+    assert state["disk_config_valid"] is True
+    assert state["running_config_hash"] != state["disk_config_hash"]
+    assert state["restart_required"] is True
+
+
+def test_invalid_disk_config_is_safe(monkeypatch):
+    """If the on-disk config can't be parsed/validated, the engine must not claim
+    a restart is needed and must not raise."""
+    engine = _make_engine_from_disk()
+
+    def _raise(*a, **k):
+        raise ValueError("invalid YAML")
+
+    monkeypatch.setattr(engine_mod, "load_config", _raise)
+
+    state = engine._compute_config_state()
+
+    assert state["disk_config_valid"] is False
+    assert state["disk_config_hash"] is None
+    assert state["restart_required"] is False
+
+
+def test_compute_config_hash_accepts_arg():
+    """_compute_config_hash(other) hashes the passed config; no-arg hashes
+    self.config (back-compat for existing callers)."""
+    engine = Engine.__new__(Engine)
+    engine.config = SimpleNamespace(model_dump=lambda: {"a": 1})
+
+    other = SimpleNamespace(model_dump=lambda: {"a": 2})
+
+    self_hash = engine._compute_config_hash()
+    other_hash = engine._compute_config_hash(other)
+
+    assert self_hash == engine._compute_config_hash(engine.config)
+    assert other_hash != self_hash
+    assert other_hash == engine._compute_config_hash(other)


### PR DESCRIPTION
## Summary

The Admin UI "Provider configuration changes require an AI Engine restart" banner was driven by **client-side state** (localStorage on 4 pages, local `useState` on 5 others) and was **always rendered** (only its color changed). This caused two bugs: (1) **false positives that persisted after an out-of-band engine restart/deploy** (the flag was only cleared by clicking the UI restart button), and (2) a banner that **never disappeared** even when nothing was pending. The two mechanisms were also inconsistent across pages.

This replaces both with a single **server-reconciled** signal: the engine compares the config it has loaded against the config on disk and reports whether a restart is genuinely needed.

## Related Issues

- Surfaced during v7.2.0 voiprnd validation (false-positive banner after the v7.2.0 deploy). No GitHub issue filed yet.

## Implementation Notes

**Engine** (`src/engine.py`) — new `GET /config/state` on the health server returns `{ running_config_hash, disk_config_hash, restart_required, disk_config_valid }`. `running` is the loaded `config_hash`; `disk` is a fresh `load_config()` hashed via the same function (refactored `_compute_config_hash` to accept a config arg). `load_config()` is wrapped so an unparseable mid-edit file returns `disk_config_valid:false, restart_required:false` (never crashes, never false-alarms).

**Admin-UI backend** (`admin_ui/backend/api/system.py`) — `GET /api/system/config-state` proxies the engine endpoint; on engine-unreachable it returns a safe `restart_required:false, engine_reachable:false` (HTTP 200) so the banner never false-alarms when the engine is down.

**Frontend** — new `useRestartRequired` hook polls `/api/system/config-state` (on mount, after save, after restart, + ~15s interval). The 9 engine-config pages (Providers, Contexts, Tools, Pipelines, and Advanced LLM/VAD/Streaming/Transport/Barge-In) now **gate the banner render** on `restart_required` — so it shows only when a restart is genuinely needed and clears itself once running == disk. The `.env`-domain banner on the Environment page is intentionally left unchanged (different domain the config hash doesn't cover).

## Testing

- **Engine** (`tests/test_engine_config_state.py`, 4 tests): the gating invariant — *unchanged config ⇒ running == disk ⇒ restart_required:false* — passes (confirms the engine doesn't mutate `self.config` post-load); plus changed-disk ⇒ true, invalid-disk ⇒ safe, and the hash-arg refactor.
- **Backend** (`test_config_state_proxy.py`, 4 tests): proxy success + engine-unreachable safe fallback. Full admin_ui suite 361/361.
- **Frontend**: new `useRestartRequired.test.ts` + suite green (138 tests), `npm run build` clean.
- **Verified end-to-end on the voiprnd dev box**: baseline `restart_required:false` after a fresh deploy; editing an unshadowed config field flips it to `true`; reverting clears it back to `false` — all without an engine restart.

## Documentation

- `CHANGELOG.md` `[Unreleased]` entry added (Fixed).
- No version/tag in this PR — merges to `main`, release decision deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-driven “Restart required” banner behavior, shown only when an engine restart is truly needed.
  * Enabled automatic restart-status refresh across Advanced pages (e.g., after saves, hot-reloads, and restarts).

* **Bug Fixes**
  * Prevented stale restart warnings from lingering after changes are applied.
  * Improved accuracy of restart notifications when the engine is unreachable, avoiding false alerts.

* **Tests**
  * Added backend and frontend test coverage for restart-state proxying and banner decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->