### PR TITLE
[codex] Add deferred transfer handoff routing

### DIFF
--- a/admin_ui/frontend/src/components/config/ToolForm.tsx
+++ b/admin_ui/frontend/src/components/config/ToolForm.tsx
@@ -1004,16 +1004,6 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
         });
     };
 
-    const unsetNestedConfig = (section: string, field: string) => {
-        const next = { ...config };
-        const current = next[section];
-        if (!current || typeof current !== 'object') return;
-        const copy = { ...current };
-        delete copy[field];
-        next[section] = copy;
-        onChange(next);
-    };
-
     const updateByContextMap = (section: string, key: string, contextName: string, value: string) => {
         const next = { ...config };
         const toolCfg = { ...(next[section] || {}) };
@@ -1218,7 +1208,12 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
     // Transfer Destinations Management
     const handleEditDestination = (key: string, data: any) => {
         setEditingDestination(key);
-        setDestinationForm({ key, ...data });
+        setDestinationForm({
+            key,
+            ...data,
+            dialplan_context: data?.dialplan_context ?? data?.context ?? '',
+            live_agent: showLiveAgentRoutingAdvanced ? (data?.live_agent ?? false) : false,
+        });
     };
 
     const handleAddDestination = () => {
@@ -1237,6 +1232,9 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
         }
 
         const { key, ...data } = destinationForm;
+        if (!showLiveAgentRoutingAdvanced) {
+            delete data.live_agent;
+        }
         destinations[key] = data;
 
         updateNestedConfig('transfer', 'destinations', destinations);
@@ -1297,10 +1295,10 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 	                        <div className="mt-4 space-y-4">
 		                            <FormInput
 		                                label="Channel Technology"
-		                                value={config.transfer?.technology || 'SIP'}
-		                                onChange={(e) => updateNestedConfig('transfer', 'technology', e.target.value)}
-		                                tooltip="Channel technology for extension transfers (SIP, PJSIP, IAX2, etc.). Default: SIP"
-		                                placeholder="SIP"
+		                                value={config.transfer?.technology || 'PJSIP'}
+		                                onChange={(e) => updateNestedConfig('transfer', 'technology', e.target.value.trim() || 'PJSIP')}
+		                                tooltip="Channel technology for extension transfers (PJSIP, SIP, IAX2, etc.). Default: PJSIP"
+		                                placeholder="PJSIP"
 		                            />
                                     <FormSwitch
                                         label="Defer Transfer Until Playback Completes"
@@ -1366,14 +1364,24 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
                                             : "No Live Agents configured. Enable to select which transfer destination should handle live-agent requests."
                                     }
                                     checked={showLiveAgentRoutingAdvanced}
-                                    onChange={(e) => {
-                                        const enabled = e.target.checked;
-                                        setShowLiveAgentRoutingAdvanced(enabled);
-                                        if (!enabled) {
-                                            // Disable override behavior and reduce config confusion.
-                                            unsetNestedConfig('transfer', 'live_agent_destination_key');
-                                        }
-                                    }}
+	                                    onChange={(e) => {
+	                                        const enabled = e.target.checked;
+	                                        setShowLiveAgentRoutingAdvanced(enabled);
+	                                        if (!enabled) {
+	                                            const cleanedDestinations = Object.fromEntries(
+	                                                Object.entries(config.transfer?.destinations || {}).map(([key, dest]: [string, any]) => {
+	                                                    if (!dest || typeof dest !== 'object') return [key, dest];
+	                                                    const nextDest = { ...dest };
+	                                                    delete nextDest.live_agent;
+	                                                    return [key, nextDest];
+	                                                })
+	                                            );
+	                                            const nextTransfer = { ...(config.transfer || {}), destinations: cleanedDestinations };
+	                                            delete nextTransfer.live_agent_destination_key;
+	                                            onChange({ ...config, transfer: nextTransfer });
+	                                            setDestinationForm({ ...destinationForm, live_agent: false });
+	                                        }
+	                                    }}
                                     className="mb-0 border border-border rounded-lg p-3 bg-background/50"
                                 />
                                 {showLiveAgentRoutingAdvanced && (
@@ -1382,12 +1390,13 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 	                                    value={config.transfer?.live_agent_destination_key || ''}
 	                                    onChange={(e) => updateNestedConfig('transfer', 'live_agent_destination_key', e.target.value)}
 		                                    options={[
-		                                        { value: '', label: 'Not set (auto: destinations.live_agent or key live_agent)' },
-		                                        ...Object.entries(config.transfer?.destinations || {})
-		                                            .map(([key, dest]: [string, any]) => ({
-                                                        key,
-                                                        type: dest?.type || 'extension',
-                                                        target: dest?.target || '',
+			                                        { value: '', label: 'Not set (auto: destinations.live_agent or key live_agent)' },
+			                                        ...Object.entries(config.transfer?.destinations || {})
+			                                            .filter(([, dest]) => dest && typeof dest === 'object')
+			                                            .map(([key, dest]: [string, any]) => ({
+	                                                        key,
+	                                                        type: dest?.type || 'extension',
+	                                                        target: dest?.target || '',
                                                     }))
 		                                            .sort((a, b) => a.key.localeCompare(b.key))
 		                                            .map(({ key, type, target }) => ({
@@ -1416,11 +1425,12 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 		                                    const destTarget = dest.target || '';
 		                                    const destDescription = dest.description || '';
                                             const defaultContext = destType === 'queue'
-                                                ? (config.transfer?.queue_context || 'ext-queues')
-                                                : destType === 'ringgroup'
-                                                    ? (config.transfer?.ringgroup_context || 'ext-group')
-                                                    : (config.transfer?.extension_context || 'from-internal');
-                                            const destContext = dest.dialplan_context || defaultContext;
+	                                                ? (config.transfer?.queue_context || 'ext-queues')
+	                                                : destType === 'ringgroup'
+	                                                    ? (config.transfer?.ringgroup_context || 'ext-group')
+	                                                    : (config.transfer?.extension_context || 'from-internal');
+	                                            const explicitContext = dest.dialplan_context || dest.context || '';
+	                                            const destContext = explicitContext || defaultContext;
 		                                    return (
 	                                    <div key={key} className="flex items-center justify-between p-3 bg-accent/30 rounded border border-border/50">
 	                                        <div>
@@ -3384,8 +3394,8 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 		                                ? "Marks this destination as the live-agent target fallback when no explicit live_agent_destination_key is set."
 		                                : "Disabled. Enable 'Advanced: Route Live Agent via Destination' to use destination-based live-agent routing."
 		                        }
-		                        checked={destinationForm.live_agent ?? false}
-		                        onChange={(e) => setDestinationForm({ ...destinationForm, live_agent: e.target.checked })}
+			                        checked={showLiveAgentRoutingAdvanced ? (destinationForm.live_agent ?? false) : false}
+			                        onChange={(e) => setDestinationForm({ ...destinationForm, live_agent: e.target.checked })}
 		                        disabled={!showLiveAgentRoutingAdvanced}
 		                    />
 	                    <FormInput

--- a/admin_ui/frontend/src/components/config/ToolForm.tsx
+++ b/admin_ui/frontend/src/components/config/ToolForm.tsx
@@ -1223,7 +1223,7 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 
     const handleAddDestination = () => {
         setEditingDestination('new_destination');
-        setDestinationForm({ key: '', type: 'extension', target: '', description: '', attended_allowed: false, live_agent: false });
+        setDestinationForm({ key: '', type: 'extension', target: '', description: '', dialplan_context: '', attended_allowed: false, live_agent: false });
     };
 
     const handleSaveDestination = () => {
@@ -1295,14 +1295,44 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 
 	                    {config.transfer?.enabled !== false && (
 	                        <div className="mt-4 space-y-4">
-	                            <FormInput
-	                                label="Channel Technology"
-	                                value={config.transfer?.technology || 'SIP'}
-	                                onChange={(e) => updateNestedConfig('transfer', 'technology', e.target.value)}
-	                                tooltip="Channel technology for extension transfers (SIP, PJSIP, IAX2, etc.). Default: SIP"
-	                                placeholder="SIP"
-	                            />
-                                <FormSwitch
+		                            <FormInput
+		                                label="Channel Technology"
+		                                value={config.transfer?.technology || 'SIP'}
+		                                onChange={(e) => updateNestedConfig('transfer', 'technology', e.target.value)}
+		                                tooltip="Channel technology for extension transfers (SIP, PJSIP, IAX2, etc.). Default: SIP"
+		                                placeholder="SIP"
+		                            />
+                                    <FormSwitch
+                                        label="Defer Transfer Until Playback Completes"
+                                        description="Speak the handoff message before executing blind, live-agent, or attended transfer actions."
+                                        checked={config.transfer?.defer_until_playback_complete ?? true}
+                                        onChange={(e) => updateNestedConfig('transfer', 'defer_until_playback_complete', e.target.checked)}
+                                        className="mb-0 border border-border rounded-lg p-3 bg-background/50"
+                                    />
+                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                        <FormInput
+                                            label="Default Extension Context"
+                                            value={config.transfer?.extension_context || 'from-internal'}
+                                            onChange={(e) => updateNestedConfig('transfer', 'extension_context', e.target.value)}
+                                            tooltip="Default Asterisk dialplan context for extension destinations. Destination-level context overrides this."
+                                            placeholder="from-internal"
+                                        />
+                                        <FormInput
+                                            label="Default Queue Context"
+                                            value={config.transfer?.queue_context || 'ext-queues'}
+                                            onChange={(e) => updateNestedConfig('transfer', 'queue_context', e.target.value)}
+                                            tooltip="Default Asterisk dialplan context for queue destinations. Destination-level context overrides this."
+                                            placeholder="ext-queues"
+                                        />
+                                        <FormInput
+                                            label="Default Ring Group Context"
+                                            value={config.transfer?.ringgroup_context || 'ext-group'}
+                                            onChange={(e) => updateNestedConfig('transfer', 'ringgroup_context', e.target.value)}
+                                            tooltip="Default Asterisk dialplan context for ring group destinations. Destination-level context overrides this."
+                                            placeholder="ext-group"
+                                        />
+                                    </div>
+	                                <FormSwitch
                                     label="Advanced: Route Live Agent via Destination"
                                     description={
                                         hasLiveAgents
@@ -1350,16 +1380,23 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 	                                {Object.entries(config.transfer?.destinations || {}).map(([key, dest]: [string, any]) => {
 	                                    // AAVA-199: Guard against null/undefined destinations
 	                                    if (!dest || typeof dest !== 'object') return null;
-	                                    const destType = dest.type || 'extension';
-	                                    const destTarget = dest.target || '';
-	                                    const destDescription = dest.description || '';
-	                                    return (
+		                                    const destType = dest.type || 'extension';
+		                                    const destTarget = dest.target || '';
+		                                    const destDescription = dest.description || '';
+                                            const defaultContext = destType === 'queue'
+                                                ? (config.transfer?.queue_context || 'ext-queues')
+                                                : destType === 'ringgroup'
+                                                    ? (config.transfer?.ringgroup_context || 'ext-group')
+                                                    : (config.transfer?.extension_context || 'from-internal');
+                                            const destContext = dest.dialplan_context || defaultContext;
+		                                    return (
 	                                    <div key={key} className="flex items-center justify-between p-3 bg-accent/30 rounded border border-border/50">
 	                                        <div>
 	                                            <div className="font-medium text-sm">{key}</div>
 	                                            <div className="text-xs text-muted-foreground">
-	                                                {destType} • {destTarget} • {destDescription}
-	                                                {destType === 'extension' && dest.attended_allowed ? ' • attended' : ''}
+		                                                {destType} • {destTarget} • {destDescription}
+                                                        {destContext ? ` • ctx: ${destContext}` : ''}
+		                                                {destType === 'extension' && dest.attended_allowed ? ' • attended' : ''}
 	                                                {destType === 'extension' && showLiveAgentRoutingAdvanced && dest.live_agent ? ' • live-agent' : ''}
 	                                            </div>
 	                                        </div>
@@ -3321,15 +3358,28 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 	                            disabled={!showLiveAgentRoutingAdvanced}
 	                        />
 	                    )}
-                    <FormInput
-                        label="Target Number"
-                        value={destinationForm.target || ''}
-                        onChange={(e) => setDestinationForm({ ...destinationForm, target: e.target.value })}
-                        placeholder="e.g., 6000"
-                    />
-                    <FormInput
-                        label="Description"
-                        value={destinationForm.description || ''}
+	                    <FormInput
+	                        label="Target Number"
+	                        value={destinationForm.target || ''}
+	                        onChange={(e) => setDestinationForm({ ...destinationForm, target: e.target.value })}
+	                        placeholder="e.g., 6000"
+	                    />
+                        <FormInput
+                            label="Dialplan Context"
+                            value={destinationForm.dialplan_context || ''}
+                            onChange={(e) => setDestinationForm({ ...destinationForm, dialplan_context: e.target.value })}
+                            placeholder={
+                                destinationForm.type === 'queue'
+                                    ? 'ext-queues'
+                                    : destinationForm.type === 'ringgroup'
+                                        ? 'ext-group'
+                                        : 'from-internal'
+                            }
+                            tooltip="Optional per-destination Asterisk dialplan context. Leave blank to use the transfer tool default for this destination type."
+                        />
+	                    <FormInput
+	                        label="Description"
+	                        value={destinationForm.description || ''}
                         onChange={(e) => setDestinationForm({ ...destinationForm, description: e.target.value })}
                         placeholder="e.g., Sales Support"
                     />

--- a/admin_ui/frontend/src/components/config/ToolForm.tsx
+++ b/admin_ui/frontend/src/components/config/ToolForm.tsx
@@ -1310,6 +1310,32 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
                                         className="mb-0 border border-border rounded-lg p-3 bg-background/50"
                                     />
                                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                        <FormSelect
+                                            label="Deferred Transfer Strategy"
+                                            value={config.transfer?.deferred_strategy || 'drain_then_dial'}
+                                            onChange={(e) => updateNestedConfig('transfer', 'deferred_strategy', e.target.value)}
+                                            options={[
+                                                { value: 'drain_then_dial', label: 'Drain, then dial' },
+                                                { value: 'predial_then_bridge', label: 'Pre-dial, then bridge' },
+                                            ]}
+                                            tooltip="Drain, then dial keeps the existing behavior. Pre-dial starts the destination leg while the handoff message plays, then bridges after playback completes."
+                                        />
+                                        <FormInput
+                                            label="Predial Bridge Wait (seconds)"
+                                            type="number"
+                                            value={config.transfer?.predial_bridge_wait_timeout_sec ?? 10}
+                                            onChange={(e) => updateNestedConfig('transfer', 'predial_bridge_wait_timeout_sec', parseFloat(e.target.value) || 10)}
+                                            tooltip="How long to wait after the handoff message for a pre-dialed destination to answer before falling back to the regular dialplan transfer."
+                                        />
+                                        <FormInput
+                                            label="Predial Dial Timeout (seconds)"
+                                            type="number"
+                                            value={config.transfer?.predial_timeout_seconds ?? 30}
+                                            onChange={(e) => updateNestedConfig('transfer', 'predial_timeout_seconds', parseInt(e.target.value) || 30)}
+                                            tooltip="How long Asterisk should keep ringing the pre-dialed destination leg."
+                                        />
+                                    </div>
+                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                                         <FormInput
                                             label="Default Extension Context"
                                             value={config.transfer?.extension_context || 'from-internal'}

--- a/admin_ui/frontend/src/components/config/ToolForm.tsx
+++ b/admin_ui/frontend/src/components/config/ToolForm.tsx
@@ -1381,17 +1381,23 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 	                                    label="Live Agent Destination Key (Advanced)"
 	                                    value={config.transfer?.live_agent_destination_key || ''}
 	                                    onChange={(e) => updateNestedConfig('transfer', 'live_agent_destination_key', e.target.value)}
-	                                    options={[
-	                                        { value: '', label: 'Not set (auto: destinations.live_agent or key live_agent)' },
-	                                        ...Object.entries(config.transfer?.destinations || {})
-	                                            .filter(([key, dest]: [string, any]) => key === 'live_agent' || Boolean(dest?.live_agent))
-	                                            .map(([key]) => key)
-	                                            .sort()
-	                                            .map((key) => ({ value: key, label: key })),
-	                                    ]}
+		                                    options={[
+		                                        { value: '', label: 'Not set (auto: destinations.live_agent or key live_agent)' },
+		                                        ...Object.entries(config.transfer?.destinations || {})
+		                                            .map(([key, dest]: [string, any]) => ({
+                                                        key,
+                                                        type: dest?.type || 'extension',
+                                                        target: dest?.target || '',
+                                                    }))
+		                                            .sort((a, b) => a.key.localeCompare(b.key))
+		                                            .map(({ key, type, target }) => ({
+                                                        value: key,
+                                                        label: target ? `${key} (${type}: ${target})` : `${key} (${type})`,
+                                                    })),
+		                                    ]}
 	                                    tooltip="Advanced/legacy override for live_agent_transfer. When set, live-agent requests route to this destination key instead of Live Agents."
 	                                />
-                                )}
+	                            )}
 	                            <div className="flex justify-between items-center">
 	                                <FormLabel>Destinations</FormLabel>
 	                                <button
@@ -1423,7 +1429,7 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
 		                                                {destType} • {destTarget} • {destDescription}
                                                         {destContext ? ` • ctx: ${destContext}` : ''}
 		                                                {destType === 'extension' && dest.attended_allowed ? ' • attended' : ''}
-	                                                {destType === 'extension' && showLiveAgentRoutingAdvanced && dest.live_agent ? ' • live-agent' : ''}
+		                                                {showLiveAgentRoutingAdvanced && dest.live_agent ? ' • live-agent' : ''}
 	                                            </div>
 	                                        </div>
 	                                        <div className="flex items-center gap-1">
@@ -3371,19 +3377,17 @@ const ToolForm = ({ config, contexts, hangupUsage, onChange, onContextsChange, o
                             onChange={(e) => setDestinationForm({ ...destinationForm, attended_allowed: e.target.checked })}
                         />
                     )}
-	                    {destinationForm.type === 'extension' && (
-	                        <FormSwitch
-	                            label="Use As Live Agent Destination"
-	                            description={
-	                                showLiveAgentRoutingAdvanced
-	                                    ? "Marks this destination as the live-agent target fallback when no explicit live_agent_destination_key is set."
-	                                    : "Disabled. Enable 'Advanced: Route Live Agent via Destination' to use destination-based live-agent routing."
-	                            }
-	                            checked={destinationForm.live_agent ?? false}
-	                            onChange={(e) => setDestinationForm({ ...destinationForm, live_agent: e.target.checked })}
-	                            disabled={!showLiveAgentRoutingAdvanced}
-	                        />
-	                    )}
+		                    <FormSwitch
+		                        label="Use As Live Agent Destination"
+		                        description={
+		                            showLiveAgentRoutingAdvanced
+		                                ? "Marks this destination as the live-agent target fallback when no explicit live_agent_destination_key is set."
+		                                : "Disabled. Enable 'Advanced: Route Live Agent via Destination' to use destination-based live-agent routing."
+		                        }
+		                        checked={destinationForm.live_agent ?? false}
+		                        onChange={(e) => setDestinationForm({ ...destinationForm, live_agent: e.target.checked })}
+		                        disabled={!showLiveAgentRoutingAdvanced}
+		                    />
 	                    <FormInput
 	                        label="Target Number"
 	                        value={destinationForm.target || ''}

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -2139,6 +2139,10 @@ tools:
     provider: ${SEND_EMAIL_PROVIDER:-resend}
   transfer:
     defer_until_playback_complete: true
+    deferred_strategy: drain_then_dial
+    predial_bridge_wait_timeout_sec: 10
+    predial_timeout_seconds: 30
+    predial_wait_moh_class: default
     extension_context: from-internal
     queue_context: ext-queues
     ringgroup_context: ext-group

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -2138,10 +2138,15 @@ tools:
     include_transcript: true
     provider: ${SEND_EMAIL_PROVIDER:-resend}
   transfer:
+    defer_until_playback_complete: true
+    extension_context: from-internal
+    queue_context: ext-queues
+    ringgroup_context: ext-group
     technology: PJSIP
     destinations:
       sales_agent:
         description: Sales agent
+        dialplan_context: from-internal
         target: '2765'
         type: extension
         live_agent: false

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -127,9 +127,9 @@ pipelines:
 
 **Transfer Types**:
 
-- **Extension**: Direct dial to specific agent (uses ARI `continue` to the configured dialplan context, default `from-internal`)
-- **Queue**: Transfer to ACD queue for next available agent (uses ARI `continue` to `ext-queues`)
-- **Ring Group**: Transfer to ring group that rings multiple agents (uses ARI `continue` to `ext-group`)
+- **Extension**: Direct dial to specific agent (uses ARI `continue` to the destination/default dialplan context, default `from-internal`)
+- **Queue**: Transfer to ACD queue for next available agent (uses ARI `continue` to the destination/default dialplan context, default `ext-queues`)
+- **Ring Group**: Transfer to ring group that rings multiple agents (uses ARI `continue` to the destination/default dialplan context, default `ext-group`)
 
 **Key Features**:
 - Single unified interface for all transfer types
@@ -156,7 +156,8 @@ AI: "Transferring you to Sales team ring group now."
 ```
 
 **Technical Implementation**:
-- Extension transfers use `continue` to the configured dialplan context (e.g., `from-internal`)
+- Transfer tools can defer the ARI action until caller-facing playback completes, so the handoff sentence is not cut off
+- Dialplan context precedence is `destinations.<key>.dialplan_context`, then the type default (`extension_context`, `queue_context`, `ringgroup_context`), then built-in FreePBX defaults
 - Queue/Ring Group transfers use `continue` (channel leaves Stasis, `transfer_active` flag prevents premature hangup)
 - All transfer types verified in production
 
@@ -773,15 +774,20 @@ tools:
   # ----------------------------------------------------------------------------
   # UNIFIED TRANSFER - Transfer to extensions, queues, or ring groups
   # ----------------------------------------------------------------------------
-  transfer:
-    enabled: true
-    destinations:
-      # Direct extension transfers (using redirect - stays in Stasis)
-      sales_agent:
-        type: extension
-        target: "2765"
-        description: "Sales agent"
-        attended_allowed: true         # Allows attended_transfer (warm transfer) to this destination
+	  transfer:
+	    enabled: true
+	    defer_until_playback_complete: true  # Speak handoff text before blind/live/attended transfer actions
+	    extension_context: "from-internal"   # Default for extension destinations
+	    queue_context: "ext-queues"          # Default for queue destinations
+	    ringgroup_context: "ext-group"       # Default for ring group destinations
+	    destinations:
+	      # Direct extension transfers
+	      sales_agent:
+	        type: extension
+	        target: "2765"
+	        description: "Sales agent"
+	        dialplan_context: "from-internal"  # Optional per-destination override
+	        attended_allowed: true         # Allows attended_transfer (warm transfer) to this destination
       
       support_agent:
         type: extension
@@ -790,10 +796,11 @@ tools:
         attended_allowed: true
       
       # Queue transfers (using continue to ext-queues)
-      sales_queue:
-        type: queue
-        target: "300"
-        description: "Sales team queue"
+	      sales_queue:
+	        type: queue
+	        target: "300"
+	        description: "Sales team queue"
+	        dialplan_context: "ext-queues"  # Optional per-destination override
       
       support_queue:
         type: queue
@@ -806,10 +813,11 @@ tools:
         description: "Billing department queue"
       
       # Ring group transfers (using continue to ext-group)
-      sales_team:
-        type: ringgroup
-        target: "600"
-        description: "Sales team ring group"
+	      sales_team:
+	        type: ringgroup
+	        target: "600"
+	        description: "Sales team ring group"
+	        dialplan_context: "ext-group"  # Optional per-destination override
       
       support_team:
         type: ringgroup

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -774,20 +774,25 @@ tools:
   # ----------------------------------------------------------------------------
   # UNIFIED TRANSFER - Transfer to extensions, queues, or ring groups
   # ----------------------------------------------------------------------------
-	  transfer:
-	    enabled: true
-	    defer_until_playback_complete: true  # Speak handoff text before blind/live/attended transfer actions
-	    extension_context: "from-internal"   # Default for extension destinations
-	    queue_context: "ext-queues"          # Default for queue destinations
-	    ringgroup_context: "ext-group"       # Default for ring group destinations
-	    destinations:
-	      # Direct extension transfers
-	      sales_agent:
-	        type: extension
-	        target: "2765"
-	        description: "Sales agent"
-	        dialplan_context: "from-internal"  # Optional per-destination override
-	        attended_allowed: true         # Allows attended_transfer (warm transfer) to this destination
+  transfer:
+    enabled: true
+    technology: "PJSIP"                    # Channel technology for direct extension dialing
+    defer_until_playback_complete: true    # Speak handoff text before blind/live/attended transfer actions
+    deferred_strategy: "drain_then_dial"   # Or "predial_then_bridge" to dial while handoff audio plays
+    predial_bridge_wait_timeout_sec: 10    # Wait after handoff audio for a predialed destination answer
+    predial_timeout_seconds: 30            # Asterisk originate timeout for predialed destination leg
+    predial_wait_moh_class: "default"      # MOH class while waiting for predial destination answer
+    extension_context: "from-internal"     # Default for extension destinations
+    queue_context: "ext-queues"            # Default for queue destinations
+    ringgroup_context: "ext-group"         # Default for ring group destinations
+    destinations:
+      # Direct extension transfers
+      sales_agent:
+        type: extension
+        target: "2765"
+        description: "Sales agent"
+        dialplan_context: "from-internal"  # Optional per-destination override
+        attended_allowed: true             # Allows attended_transfer (warm transfer) to this destination
       
       support_agent:
         type: extension
@@ -796,11 +801,11 @@ tools:
         attended_allowed: true
       
       # Queue transfers (using continue to ext-queues)
-	      sales_queue:
-	        type: queue
-	        target: "300"
-	        description: "Sales team queue"
-	        dialplan_context: "ext-queues"  # Optional per-destination override
+      sales_queue:
+        type: queue
+        target: "300"
+        description: "Sales team queue"
+        dialplan_context: "ext-queues"  # Optional per-destination override
       
       support_queue:
         type: queue
@@ -813,11 +818,11 @@ tools:
         description: "Billing department queue"
       
       # Ring group transfers (using continue to ext-group)
-	      sales_team:
-	        type: ringgroup
-	        target: "600"
-	        description: "Sales team ring group"
-	        dialplan_context: "ext-group"  # Optional per-destination override
+      sales_team:
+        type: ringgroup
+        target: "600"
+        description: "Sales team ring group"
+        dialplan_context: "ext-group"  # Optional per-destination override
       
       support_team:
         type: ringgroup

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -158,6 +158,7 @@ class CallSession:
     pending_actions: list = field(default_factory=list)  # Queue of pending actions
     current_action: Optional[Dict[str, Any]] = None      # Currently executing action
     transfer_context: Optional[Dict[str, Any]] = None    # Context to pass to transfer target
+    pending_deferred_transfer: Optional[Dict[str, Any]] = None  # Transfer action waiting for TTS/audio completion
     
     # Call history tracking (Milestone 21)
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)  # [{name, params, result, timestamp, duration_ms}]

--- a/src/core/streaming_playback_manager.py
+++ b/src/core/streaming_playback_manager.py
@@ -1274,6 +1274,20 @@ class StreamingPlaybackManager:
         except Exception:
             min_need = self.min_start_chunks
         available_frames = self._estimate_available_frames(call_id, jitter_buffer, include_remainder=True)
+        if bool(stream_info.get('producer_closed')) and available_frames > 0:
+            self._startup_ready[call_id] = True
+            stream_info['startup_ready'] = True
+            try:
+                logger.info(
+                    "Streaming startup released short final segment",
+                    call_id=call_id,
+                    stream_id=stream_id,
+                    buffered_frames=available_frames,
+                    min_start_chunks=min_need,
+                )
+            except Exception:
+                pass
+            return True
         if available_frames < min_need:
             return False
         self._startup_ready[call_id] = True

--- a/src/core/streaming_playback_manager.py
+++ b/src/core/streaming_playback_manager.py
@@ -3215,27 +3215,40 @@ class StreamingPlaybackManager:
                 logger.warning("No active streaming to stop", call_id=call_id)
                 return False
             stream_id = stream_info.get('stream_id') or ''
-            # Cancel streaming task
-            try:
-                task = stream_info.get('streaming_task')
-                if task:
-                    task.cancel()
-            except Exception:
-                pass
-            # Cancel pacer task
-            try:
-                ptask = stream_info.get('pacer_task')
-                if ptask:
-                    ptask.cancel()
-            except Exception:
-                pass
-            # Cancel keepalive task
-            if call_id in self.keepalive_tasks:
+            cancelled_tasks = []
+            seen_tasks = set()
+
+            def _cancel_task(task: Any) -> None:
+                if not task or not hasattr(task, "cancel"):
+                    return
+                task_id = id(task)
+                if task_id in seen_tasks:
+                    return
+                seen_tasks.add(task_id)
                 try:
-                    self.keepalive_tasks[call_id].cancel()
+                    if not task.done():
+                        task.cancel()
+                        cancelled_tasks.append(task)
                 except Exception:
                     pass
-                self.keepalive_tasks.pop(call_id, None)
+
+            _cancel_task(stream_info.get('streaming_task'))
+            _cancel_task(stream_info.get('pacer_task'))
+            _cancel_task(stream_info.get('keepalive_task'))
+            _cancel_task(self.keepalive_tasks.pop(call_id, None))
+
+            if cancelled_tasks:
+                try:
+                    _, pending = await asyncio.wait(cancelled_tasks, timeout=2.0)
+                    if pending:
+                        logger.debug(
+                            "Streaming stop tasks did not settle before cleanup",
+                            call_id=call_id,
+                            stream_id=stream_id,
+                            pending_tasks=len(pending),
+                        )
+                except Exception:
+                    logger.debug("Failed while waiting for streaming stop tasks", call_id=call_id, exc_info=True)
             # Cleanup resources and emit summaries
             await self._cleanup_stream(call_id, stream_id)
             logger.info("🎵 STREAMING PLAYBACK - Stopped", call_id=call_id, stream_id=stream_id)

--- a/src/core/streaming_playback_manager.py
+++ b/src/core/streaming_playback_manager.py
@@ -1274,7 +1274,16 @@ class StreamingPlaybackManager:
         except Exception:
             min_need = self.min_start_chunks
         available_frames = self._estimate_available_frames(call_id, jitter_buffer, include_remainder=True)
-        if bool(stream_info.get('producer_closed')) and available_frames > 0:
+        buffered_bytes = 0
+        with suppress(TypeError, ValueError):
+            buffered_bytes = int(stream_info.get('buffered_bytes', 0) or 0)
+        has_closed_tail = (
+            available_frames > 0
+            or buffered_bytes > 0
+            or bool(self.frame_remainders.get(call_id))
+            or not jitter_buffer.empty()
+        )
+        if bool(stream_info.get('producer_closed')) and has_closed_tail:
             self._startup_ready[call_id] = True
             stream_info['startup_ready'] = True
             try:
@@ -3207,7 +3216,7 @@ class StreamingPlaybackManager:
                         error=str(e))
 
     
-    async def stop_streaming_playback(self, call_id: str) -> bool:
+    async def stop_streaming_playback(self, call_id: str, *, drain: bool = False, drain_timeout: float = 120.0) -> bool:
         """Stop streaming playback for a call."""
         try:
             stream_info = self.active_streams.get(call_id)
@@ -3215,6 +3224,21 @@ class StreamingPlaybackManager:
                 logger.warning("No active streaming to stop", call_id=call_id)
                 return False
             stream_id = stream_info.get('stream_id') or ''
+
+            if drain:
+                task = stream_info.get('streaming_task')
+                if task and not task.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(task), timeout=max(0.5, float(drain_timeout)))
+                        logger.info("🎵 STREAMING PLAYBACK - Drained", call_id=call_id, stream_id=stream_id)
+                        return True
+                    except (asyncio.TimeoutError, TypeError, ValueError):
+                        logger.warning("Streaming drain timed out; aborting playback", call_id=call_id, stream_id=stream_id)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.debug("Streaming drain failed; aborting playback", call_id=call_id, stream_id=stream_id, exc_info=True)
+
             cancelled_tasks = []
             seen_tasks = set()
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -4311,7 +4311,7 @@ class Engine:
                 logger.debug("Failed to inspect predial bridge state while finalize was in progress", call_id=call_id, exc_info=True)
             if call_id in bridge_guard:
                 logger.info("Predial bridge finalize already in progress", call_id=call_id, predial_channel_id=predial_channel_id)
-                return True
+                return False
             return False
 
         bridge_guard.add(call_id)

--- a/src/engine.py
+++ b/src/engine.py
@@ -10081,6 +10081,9 @@ class Engine:
                 if streaming_done:
                     try:
                         session = await self.session_store.get_by_call_id(call_id)
+                        if session and isinstance(getattr(session, "pending_deferred_transfer", None), dict):
+                            await self._commit_pending_deferred_transfer_for_call(call_id, session)
+                            return
                         if session and getattr(session, 'cleanup_after_tts', False):
                             logger.info("🔚 Cleanup after TTS requested - hanging up call", call_id=call_id)
                             # Delay to ensure audio completes through RTP pipeline.
@@ -11779,6 +11782,45 @@ class Engine:
                                     except Exception:
                                         logger.debug("Failed to log pipeline tool call to session", call_id=call_id, exc_info=True)
 
+                                    try:
+                                        from src.tools.telephony.deferred_transfer import get_deferred_transfer_action
+                                        deferred_action = get_deferred_transfer_action(result)
+                                    except Exception:
+                                        deferred_action = None
+
+                                    if deferred_action:
+                                        transfer_message = str(result.get("message") or "").strip()
+                                        if transfer_message:
+                                            try:
+                                                conversation_history.append(_ts_msg("assistant", transfer_message))
+                                                session.conversation_history = list(conversation_history)
+                                                await self.session_store.upsert_call(session)
+                                            except Exception:
+                                                logger.debug("Failed to record deferred transfer message", call_id=call_id, exc_info=True)
+
+                                            try:
+                                                transfer_bytes = bytearray()
+                                                async for chunk in pipeline.tts_adapter.synthesize(call_id, transfer_message, pipeline.tts_options):
+                                                    if chunk:
+                                                        transfer_bytes.extend(chunk)
+                                                if transfer_bytes:
+                                                    transfer_pid = await self.playback_manager.play_audio(
+                                                        call_id,
+                                                        bytes(transfer_bytes),
+                                                        "pipeline-transfer",
+                                                    )
+                                                    if transfer_pid:
+                                                        await self.playback_manager.wait_for_playback_end(
+                                                            call_id,
+                                                            transfer_pid,
+                                                            timeout_sec=(len(transfer_bytes) / 8000.0 + 3.0),
+                                                        )
+                                            except Exception:
+                                                logger.error("Deferred transfer TTS failed; committing transfer anyway", call_id=call_id, exc_info=True)
+
+                                        await self._commit_pending_deferred_transfer_for_call(call_id, session)
+                                        return
+
                                     # Handle Hangup (AAVA-85 Fix)
                                     if result.get("will_hangup"):
                                         farewell = result.get("message")
@@ -11916,6 +11958,31 @@ class Engine:
                                                                     except Exception:
                                                                         logger.debug("Failed to speak slow-response message", call_id=call_id, exc_info=True)
                                                             next_result = await next_task
+                                                            try:
+                                                                from src.tools.telephony.deferred_transfer import get_deferred_transfer_action
+                                                                next_deferred_action = get_deferred_transfer_action(next_result)
+                                                            except Exception:
+                                                                next_deferred_action = None
+                                                            if next_deferred_action:
+                                                                transfer_message = str(next_result.get("message") or "").strip()
+                                                                if transfer_message:
+                                                                    conversation_history.append(_ts_msg("assistant", transfer_message))
+                                                                    session.conversation_history = list(conversation_history)
+                                                                    await self.session_store.upsert_call(session)
+                                                                    transfer_bytes = bytearray()
+                                                                    async for chunk in pipeline.tts_adapter.synthesize(call_id, transfer_message, pipeline.tts_options):
+                                                                        if chunk:
+                                                                            transfer_bytes.extend(chunk)
+                                                                    if transfer_bytes:
+                                                                        transfer_pid = await self.playback_manager.play_audio(call_id, bytes(transfer_bytes), "pipeline-transfer")
+                                                                        if transfer_pid:
+                                                                            await self.playback_manager.wait_for_playback_end(
+                                                                                call_id,
+                                                                                transfer_pid,
+                                                                                timeout_sec=(len(transfer_bytes) / 8000.0 + 3.0),
+                                                                            )
+                                                                await self._commit_pending_deferred_transfer_for_call(call_id, session)
+                                                                return
                                                             if next_result.get("will_hangup"):
                                                                 farewell = next_result.get("message", "Goodbye!")
                                                                 conversation_history.append(_ts_msg("assistant", farewell))
@@ -14396,6 +14463,42 @@ class Engine:
                     error=str(e),
                 )
         
+        return result
+
+    async def _commit_pending_deferred_transfer_for_call(
+        self,
+        call_id: str,
+        session: Optional["CallSession"] = None,
+    ) -> Optional[Dict[str, Any]]:
+        from src.tools.context import ToolExecutionContext
+        from src.tools.telephony.deferred_transfer import commit_pending_deferred_transfer
+
+        session = session or await self.session_store.get_by_call_id(call_id)
+        if not session or not isinstance(getattr(session, "pending_deferred_transfer", None), dict):
+            return None
+
+        provider_name = getattr(session, "provider_name", None) or getattr(self.config, "default_provider", None)
+        context = ToolExecutionContext(
+            call_id=call_id,
+            caller_channel_id=getattr(session, "caller_channel_id", None) or call_id,
+            bridge_id=getattr(session, "bridge_id", None),
+            caller_number=getattr(session, "caller_number", None),
+            called_number=getattr(session, "called_number", None),
+            caller_name=getattr(session, "caller_name", None),
+            context_name=getattr(session, "context_name", None),
+            session_store=self.session_store,
+            ari_client=self.ari_client,
+            config=self.config.dict() if hasattr(self.config, "dict") else {},
+            provider_name=provider_name,
+        )
+        result = await commit_pending_deferred_transfer(context)
+        if result:
+            logger.info(
+                "Deferred transfer commit result",
+                call_id=call_id,
+                status=result.get("status"),
+                message=result.get("message"),
+            )
         return result
 
     async def _execute_pre_call_tools(

--- a/src/engine.py
+++ b/src/engine.py
@@ -14722,6 +14722,10 @@ class Engine:
         if not session or not isinstance(getattr(session, "pending_deferred_transfer", None), dict):
             return None
 
+        local_handoff_played = await self._play_deferred_transfer_local_handoff(call_id, session)
+        if not local_handoff_played:
+            logger.debug("Deferred transfer local handoff skipped", call_id=call_id)
+
         await self._wait_for_deferred_transfer_audio_drain(call_id)
 
         provider_name = getattr(session, "provider_name", None) or getattr(self.config, "default_provider", None)
@@ -14747,6 +14751,99 @@ class Engine:
                 message=result.get("message"),
             )
         return result
+
+    def _deferred_transfer_local_handoff_providers(self) -> set[str]:
+        tools_cfg = getattr(self.config, "tools", {}) or {}
+        transfer_cfg = tools_cfg.get("transfer", {}) if isinstance(tools_cfg, dict) else {}
+        if not isinstance(transfer_cfg, dict):
+            transfer_cfg = {}
+
+        raw = transfer_cfg.get("local_handoff_audio_providers", ["deepgram"])
+        if raw is False or raw is None:
+            return set()
+        if raw is True:
+            raw = ["deepgram"]
+        if isinstance(raw, str):
+            raw = [item.strip() for item in raw.split(",")]
+        if not isinstance(raw, (list, tuple, set)):
+            raw = ["deepgram"]
+        return {str(item or "").strip().lower() for item in raw if str(item or "").strip()}
+
+    async def _play_deferred_transfer_local_handoff(self, call_id: str, session: "CallSession") -> bool:
+        provider_name = str(getattr(session, "provider_name", None) or getattr(self.config, "default_provider", "") or "").strip()
+        provider_key = (self._get_provider_kind(provider_name) or provider_name).strip().lower()
+        if provider_key not in self._deferred_transfer_local_handoff_providers():
+            return False
+
+        action = getattr(session, "pending_deferred_transfer", None)
+        if not isinstance(action, dict):
+            return False
+
+        description = str(action.get("description") or action.get("destination_key") or action.get("target") or "").strip()
+        if not description:
+            description = "your destination"
+
+        tools_cfg = getattr(self.config, "tools", {}) or {}
+        transfer_cfg = tools_cfg.get("transfer", {}) if isinstance(tools_cfg, dict) else {}
+        if not isinstance(transfer_cfg, dict):
+            transfer_cfg = {}
+        template = str(transfer_cfg.get("local_handoff_audio_template") or "Transferring you to {destination} now.").strip()
+        try:
+            message = template.format(destination=description)
+        except Exception:
+            message = f"Transferring you to {description} now."
+
+        try:
+            timeout_sec = float(transfer_cfg.get("local_handoff_audio_tts_timeout_sec", 3.0) or 3.0)
+        except (TypeError, ValueError):
+            timeout_sec = 3.0
+        timeout_sec = max(0.5, min(timeout_sec, 10.0))
+
+        try:
+            stream_info = self.streaming_playback_manager.active_streams.get(call_id)
+            if stream_info is not None:
+                stream_info["end_reason"] = "deferred-transfer-local-handoff"
+                await self.streaming_playback_manager.stop_streaming_playback(call_id)
+            self._provider_stream_queues.pop(call_id, None)
+            self._provider_stream_formats.pop(call_id, None)
+            self._provider_coalesce_buf.pop(call_id, None)
+            self._segment_tts_active.discard(call_id)
+        except Exception:
+            logger.debug("Failed to stop provider stream before local transfer handoff", call_id=call_id, exc_info=True)
+
+        audio = await self._local_ai_server_tts(call_id=call_id, text=message, timeout_sec=timeout_sec)
+        if not audio:
+            logger.warning(
+                "Deferred transfer local handoff TTS unavailable",
+                call_id=call_id,
+                provider=provider_name,
+            )
+            return False
+
+        playback_id = await self.playback_manager.play_audio(call_id, audio, "transfer-handoff")
+        if not playback_id:
+            logger.warning(
+                "Deferred transfer local handoff playback failed",
+                call_id=call_id,
+                provider=provider_name,
+            )
+            return False
+
+        wait_timeout = min(10.0, max(1.0, (len(audio) / 8000.0) + 1.0))
+        played = await self.playback_manager.wait_for_playback_end(
+            call_id,
+            playback_id,
+            timeout_sec=wait_timeout,
+        )
+        logger.info(
+            "Deferred transfer local handoff playback completed",
+            call_id=call_id,
+            provider=provider_name,
+            playback_id=playback_id,
+            played=played,
+            audio_bytes=len(audio),
+        )
+        return bool(played)
 
     async def _wait_for_deferred_transfer_audio_drain(self, call_id: str) -> bool:
         """Wait briefly for caller-facing transfer audio to leave the streaming path."""

--- a/src/engine.py
+++ b/src/engine.py
@@ -14180,6 +14180,8 @@ class Engine:
                 try:
                     provider._caller_channel_id = session.caller_channel_id
                     provider._bridge_id = session.bridge_id
+                    provider._caller_number = getattr(session, 'caller_number', None)
+                    provider._caller_name = getattr(session, 'caller_name', None)
                     provider._called_number = getattr(session, 'called_number', None)
                     provider._context_name = getattr(session, 'context_name', None)
                     provider._session_store = self.session_store

--- a/src/engine.py
+++ b/src/engine.py
@@ -14477,6 +14477,8 @@ class Engine:
         if not session or not isinstance(getattr(session, "pending_deferred_transfer", None), dict):
             return None
 
+        await self._wait_for_deferred_transfer_audio_drain(call_id)
+
         provider_name = getattr(session, "provider_name", None) or getattr(self.config, "default_provider", None)
         context = ToolExecutionContext(
             call_id=call_id,
@@ -14500,6 +14502,116 @@ class Engine:
                 message=result.get("message"),
             )
         return result
+
+    async def _wait_for_deferred_transfer_audio_drain(self, call_id: str) -> bool:
+        """Wait briefly for caller-facing transfer audio to leave the streaming path."""
+        tools_cfg = getattr(self.config, "tools", {}) or {}
+        transfer_cfg = tools_cfg.get("transfer", {}) if isinstance(tools_cfg, dict) else {}
+        if not isinstance(transfer_cfg, dict):
+            transfer_cfg = {}
+
+        try:
+            timeout_sec = float(transfer_cfg.get("deferred_audio_drain_timeout_sec", 5.0))
+        except (TypeError, ValueError):
+            timeout_sec = 5.0
+        try:
+            quiet_sec = float(transfer_cfg.get("deferred_audio_drain_quiet_ms", 500)) / 1000.0
+        except (TypeError, ValueError):
+            quiet_sec = 0.5
+        timeout_sec = max(0.0, min(timeout_sec, 30.0))
+        quiet_sec = max(0.0, min(quiet_sec, 5.0))
+
+        if timeout_sec <= 0:
+            return True
+
+        started_at = time.time()
+        quiet_started_at: Optional[float] = None
+        last_snapshot: Dict[str, Any] = {}
+
+        while (time.time() - started_at) < timeout_sec:
+            now = time.time()
+            pending_provider_chunks = 0
+            pending_stream_bytes = 0
+            pending_jitter_frames = 0
+            pending_remainder_bytes = 0
+            active_playbacks = 0
+            last_real_emit_ts: Optional[float] = None
+
+            try:
+                q = self._provider_stream_queues.get(call_id)
+                if q is not None:
+                    pending_provider_chunks = int(q.qsize())
+            except Exception:
+                pending_provider_chunks = 0
+
+            try:
+                spm = getattr(self, "streaming_playback_manager", None)
+                stream_info = (getattr(spm, "active_streams", {}) or {}).get(call_id) if spm else None
+                if stream_info:
+                    pending_stream_bytes = int(stream_info.get("buffered_bytes", 0) or 0)
+                    pending_jitter_frames = int(stream_info.get("jitter_depth", 0) or 0)
+                    emit_ts = stream_info.get("last_real_emit_ts")
+                    if emit_ts is not None:
+                        last_real_emit_ts = float(emit_ts)
+                remainders = getattr(spm, "frame_remainders", {}) if spm else {}
+                pending_remainder_bytes = len(remainders.get(call_id, b"") or b"")
+            except Exception:
+                pending_stream_bytes = 0
+                pending_jitter_frames = 0
+                pending_remainder_bytes = 0
+                last_real_emit_ts = None
+
+            try:
+                active_playbacks = len(await self.session_store.list_playbacks_for_call(call_id))
+            except Exception:
+                active_playbacks = 0
+
+            has_pending_audio = any(
+                (
+                    pending_provider_chunks > 0,
+                    pending_stream_bytes > 0,
+                    pending_jitter_frames > 0,
+                    pending_remainder_bytes > 0,
+                    active_playbacks > 0,
+                )
+            )
+
+            last_snapshot = {
+                "pending_provider_chunks": pending_provider_chunks,
+                "pending_stream_bytes": pending_stream_bytes,
+                "pending_jitter_frames": pending_jitter_frames,
+                "pending_remainder_bytes": pending_remainder_bytes,
+                "active_playbacks": active_playbacks,
+            }
+
+            if has_pending_audio:
+                quiet_started_at = None
+            else:
+                if quiet_started_at is None:
+                    quiet_started_at = now
+                quiet_elapsed = now - quiet_started_at
+                emit_elapsed = quiet_elapsed
+                if last_real_emit_ts is not None:
+                    emit_elapsed = now - last_real_emit_ts
+                if quiet_elapsed >= quiet_sec and emit_elapsed >= quiet_sec:
+                    logger.info(
+                        "Deferred transfer audio drain complete",
+                        call_id=call_id,
+                        wait_seconds=round(now - started_at, 3),
+                        quiet_ms=int(quiet_sec * 1000),
+                    )
+                    return True
+
+            await asyncio.sleep(0.02)
+
+        logger.warning(
+            "Deferred transfer audio drain timed out; committing transfer",
+            call_id=call_id,
+            timeout_sec=timeout_sec,
+            quiet_ms=int(quiet_sec * 1000),
+            **last_snapshot,
+        )
+        return False
 
     async def _execute_pre_call_tools(
         self,

--- a/src/engine.py
+++ b/src/engine.py
@@ -4301,6 +4301,7 @@ class Engine:
         except Exception:
             logger.debug("Failed to remove AI media channels during predial transfer", call_id=call_id, exc_info=True)
 
+        provider = self._call_providers.pop(call_id, None)
         try:
             start_task = self._provider_start_tasks.pop(call_id, None)
             if start_task:
@@ -4313,12 +4314,6 @@ class Engine:
             self._pipeline_forced.pop(call_id, None)
         except Exception:
             pass
-        provider = self._call_providers.pop(call_id, None)
-        if provider and hasattr(provider, "stop_session"):
-            try:
-                await provider.stop_session()
-            except Exception:
-                logger.debug("Failed to stop provider during predial transfer", call_id=call_id, exc_info=True)
 
         if not await self.ari_client.add_channel_to_bridge(session.bridge_id, predial_channel_id):
             return False
@@ -4344,7 +4339,23 @@ class Engine:
             bridge_id=getattr(session, "bridge_id", None),
             destination=getattr(session, "transfer_destination", None),
         )
+        if provider and hasattr(provider, "stop_session"):
+            self._fire_and_forget(
+                self._stop_provider_after_predial_bridge(call_id, provider, getattr(session, "provider_name", None)),
+                name=f"predial-provider-stop-{call_id}",
+            )
         return True
+
+    async def _stop_provider_after_predial_bridge(self, call_id: str, provider: Any, provider_name: Optional[str]) -> None:
+        try:
+            await provider.stop_session()
+            logger.info(
+                "AI provider session stopped after predial bridge",
+                call_id=call_id,
+                provider=provider_name,
+            )
+        except Exception:
+            logger.debug("Failed to stop provider after predial bridge", call_id=call_id, exc_info=True)
 
     def register_attended_transfer_agent_channel(self, call_id: str, agent_channel_id: str) -> None:
         """Register an attended transfer agent channel to resolve DTMF events back to a call."""

--- a/src/engine.py
+++ b/src/engine.py
@@ -274,6 +274,7 @@ class Engine:
         self._attended_transfer_dtmf_digits: Dict[str, str] = {}
         self._attended_transfer_agent_channel_to_call_id: Dict[str, str] = {}
         self._predial_transfer_channel_to_call_id: Dict[str, str] = {}
+        self._predial_bridge_in_progress: Set[str] = set()
         self._attended_transfer_helper_state_by_agent_channel: Dict[str, Dict[str, Any]] = {}
         self._attended_transfer_helper_external_media_to_agent_channel: Dict[str, str] = {}
         self._attended_transfer_screening_state_by_call: Dict[str, Dict[str, Any]] = {}
@@ -4291,81 +4292,130 @@ class Engine:
         if action.get("bridged"):
             return True
 
-        try:
-            await self.ari_client.send_command(method="DELETE", resource=f"channels/{session.caller_channel_id}/moh")
-        except Exception:
-            pass
-
-        try:
-            if session.external_media_id:
-                await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.external_media_id)
-            if session.audiosocket_channel_id:
-                await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.audiosocket_channel_id)
-        except Exception:
-            logger.debug("Failed to remove AI media channels during predial transfer", call_id=call_id, exc_info=True)
-
-        provider = self._call_providers.pop(call_id, None)
-        try:
-            start_task = self._provider_start_tasks.pop(call_id, None)
-            if start_task:
-                start_task.cancel()
-            task = getattr(self, "_pipeline_tasks", {}).pop(call_id, None)
-            if task and not task.done():
-                task.cancel()
-            getattr(self, "_pipeline_queues", {}).pop(call_id, None)
-            getattr(self, "_pipeline_transcript_queues", {}).pop(call_id, None)
-            self._pipeline_forced.pop(call_id, None)
-        except Exception:
-            logger.debug("Failed to stop predial provider tasks", call_id=call_id, exc_info=True)
-
-        if not await self.ari_client.add_channel_to_bridge(session.bridge_id, predial_channel_id):
-            self._unregister_predial_transfer_channel(predial_channel_id)
+        bridge_guard = getattr(self, "_predial_bridge_in_progress", None)
+        if bridge_guard is None:
+            bridge_guard = set()
+            self._predial_bridge_in_progress = bridge_guard
+        if call_id in bridge_guard:
+            deadline = time.time() + 5.0
+            while call_id in bridge_guard and time.time() < deadline:
+                await asyncio.sleep(0.025)
             try:
-                await self.ari_client.hangup_channel(predial_channel_id)
+                latest = await self.session_store.get_by_call_id(call_id)
+                latest_action = dict(getattr(latest, "current_action", None) or {}) if latest else {}
+                if latest_action.get("bridged"):
+                    return True
+                if latest_action.get("type") != "predial_transfer":
+                    return False
             except Exception:
-                logger.debug("Failed to hang up failed predial destination leg", call_id=call_id, predial_channel_id=predial_channel_id, exc_info=True)
+                logger.debug("Failed to inspect predial bridge state while finalize was in progress", call_id=call_id, exc_info=True)
+            if call_id in bridge_guard:
+                logger.info("Predial bridge finalize already in progress", call_id=call_id, predial_channel_id=predial_channel_id)
+                return True
+            return False
+
+        bridge_guard.add(call_id)
+        try:
             try:
-                latest = await self.session_store.get_by_call_id(call_id) or session
-                latest_action = dict(getattr(latest, "current_action", None) or {})
-                if latest_action.get("type") == "predial_transfer":
-                    latest.current_action = None
-                    await self._save_session(latest)
+                await self.ari_client.send_command(method="DELETE", resource=f"channels/{session.caller_channel_id}/moh")
             except Exception:
-                logger.debug("Failed to clear predial action after bridge failure", call_id=call_id, exc_info=True)
+                pass
+
+            try:
+                if session.external_media_id:
+                    await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.external_media_id)
+                if session.audiosocket_channel_id:
+                    await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.audiosocket_channel_id)
+            except Exception:
+                logger.debug("Failed to remove AI media channels during predial transfer", call_id=call_id, exc_info=True)
+
+            provider = self._call_providers.pop(call_id, None)
+            try:
+                start_task = self._provider_start_tasks.pop(call_id, None)
+                if start_task:
+                    start_task.cancel()
+                task = getattr(self, "_pipeline_tasks", {}).pop(call_id, None)
+                if task and not task.done():
+                    task.cancel()
+                getattr(self, "_pipeline_queues", {}).pop(call_id, None)
+                getattr(self, "_pipeline_transcript_queues", {}).pop(call_id, None)
+                self._pipeline_forced.pop(call_id, None)
+            except Exception:
+                logger.debug("Failed to stop predial provider tasks", call_id=call_id, exc_info=True)
+
+            if not await self.ari_client.add_channel_to_bridge(session.bridge_id, predial_channel_id):
+                self._unregister_predial_transfer_channel(predial_channel_id)
+                try:
+                    await self.ari_client.hangup_channel(predial_channel_id)
+                except Exception:
+                    logger.debug("Failed to hang up failed predial destination leg", call_id=call_id, predial_channel_id=predial_channel_id, exc_info=True)
+                try:
+                    latest = await self.session_store.get_by_call_id(call_id) or session
+                    latest_action = dict(getattr(latest, "current_action", None) or {})
+                    if latest_action.get("type") == "predial_transfer":
+                        latest.current_action = None
+                        await self._save_session(latest)
+                except Exception:
+                    logger.debug("Failed to clear predial action after bridge failure", call_id=call_id, exc_info=True)
+                if provider and hasattr(provider, "stop_session"):
+                    self._fire_and_forget(
+                        self._stop_provider_after_predial_bridge(call_id, provider, getattr(session, "provider_name", None)),
+                        name=f"predial-provider-stop-failed-{call_id}",
+                    )
+                return False
+
+            try:
+                session = await self.session_store.get_by_call_id(call_id) or session
+                action = dict(getattr(session, "current_action", None) or {})
+                action["answered"] = True
+                action["bridged"] = True
+                action["predial_channel_id"] = predial_channel_id
+                action["channel_id"] = predial_channel_id
+                session.current_action = action
+                session.transfer_state = "bridged"
+                session.transfer_destination = str(action.get("target_name") or action.get("target") or "")
+                await self._save_session(session)
+            except Exception:
+                logger.debug("Failed to persist predial transfer bridge state", call_id=call_id, exc_info=True)
+
+            logger.info(
+                "Predial transfer bridged",
+                call_id=call_id,
+                predial_channel_id=predial_channel_id,
+                bridge_id=getattr(session, "bridge_id", None),
+                destination=getattr(session, "transfer_destination", None),
+            )
             if provider and hasattr(provider, "stop_session"):
                 self._fire_and_forget(
                     self._stop_provider_after_predial_bridge(call_id, provider, getattr(session, "provider_name", None)),
-                    name=f"predial-provider-stop-failed-{call_id}",
+                    name=f"predial-provider-stop-{call_id}",
                 )
-            return False
+            return True
+        finally:
+            bridge_guard.discard(call_id)
 
+    async def _handle_unbridged_predial_transfer_channel_end(self, session: "CallSession", predial_channel_id: str) -> None:
+        """Handle a predial destination leg ending before it is bridged to the caller."""
+        call_id = session.call_id
+        self._unregister_predial_transfer_channel(predial_channel_id)
         try:
-            session = await self.session_store.get_by_call_id(call_id) or session
-            action = dict(getattr(session, "current_action", None) or {})
-            action["answered"] = True
-            action["bridged"] = True
-            action["predial_channel_id"] = predial_channel_id
-            action["channel_id"] = predial_channel_id
-            session.current_action = action
-            session.transfer_state = "bridged"
-            session.transfer_destination = str(action.get("target_name") or action.get("target") or "")
-            await self._save_session(session)
+            latest = await self.session_store.get_by_call_id(call_id) or session
+            action = dict(getattr(latest, "current_action", None) or {})
+            if action.get("type") == "predial_transfer" and not action.get("bridged"):
+                latest.current_action = None
+                await self._save_session(latest)
         except Exception:
-            logger.debug("Failed to persist predial transfer bridge state", call_id=call_id, exc_info=True)
-
+            logger.debug(
+                "Failed to clear unbridged predial transfer state",
+                call_id=call_id,
+                predial_channel_id=predial_channel_id,
+                exc_info=True,
+            )
         logger.info(
-            "Predial transfer bridged",
+            "Ignoring unbridged predial transfer destination leg cleanup",
             call_id=call_id,
             predial_channel_id=predial_channel_id,
-            bridge_id=getattr(session, "bridge_id", None),
-            destination=getattr(session, "transfer_destination", None),
         )
-        if provider and hasattr(provider, "stop_session"):
-            self._fire_and_forget(
-                self._stop_provider_after_predial_bridge(call_id, provider, getattr(session, "provider_name", None)),
-                name=f"predial-provider-stop-{call_id}",
-            )
-        return True
 
     async def _stop_provider_after_predial_bridge(self, call_id: str, provider: Any, provider_name: Optional[str]) -> None:
         try:
@@ -6118,7 +6168,13 @@ class Engine:
                 predial_channel_map = getattr(self, "_predial_transfer_channel_to_call_id", {})
                 mapped_call_id = predial_channel_map.get(channel_or_call_id)
                 if mapped_call_id:
-                    session = await self.session_store.get_by_call_id(mapped_call_id)
+                    mapped_session = await self.session_store.get_by_call_id(mapped_call_id)
+                    if mapped_session:
+                        action = dict(getattr(mapped_session, "current_action", None) or {})
+                        if action.get("type") != "predial_transfer" or not action.get("bridged"):
+                            await self._handle_unbridged_predial_transfer_channel_end(mapped_session, channel_or_call_id)
+                            return
+                        session = mapped_session
             if not session:
                 logger.debug("No session found during cleanup", identifier=channel_or_call_id)
                 # Codex P1: a single call has multiple channels (caller + aux media legs:

--- a/src/engine.py
+++ b/src/engine.py
@@ -270,6 +270,7 @@ class Engine:
         self._attended_transfer_dtmf_waiters: Dict[str, asyncio.Future] = {}
         self._attended_transfer_dtmf_digits: Dict[str, str] = {}
         self._attended_transfer_agent_channel_to_call_id: Dict[str, str] = {}
+        self._predial_transfer_channel_to_call_id: Dict[str, str] = {}
         self._attended_transfer_helper_state_by_agent_channel: Dict[str, Dict[str, Any]] = {}
         self._attended_transfer_helper_external_media_to_agent_channel: Dict[str, str] = {}
         self._attended_transfer_screening_state_by_call: Dict[str, Dict[str, Any]] = {}
@@ -4002,6 +4003,7 @@ class Engine:
         handlers = {
             'transfer': self._handle_transfer_answered,
             'warm-transfer': self._handle_transfer_answered,  # Warm transfer uses same handler
+            'predial-transfer': self._handle_predial_transfer_answered,
             'attended-transfer': self._handle_attended_transfer_answered,
             'transfer-failed': self._handle_transfer_failed,
             'voicemail-complete': self._handle_voicemail_complete,
@@ -4129,6 +4131,220 @@ class Engine:
             logger.error(f"🔀 TRANSFER - Failed to bridge: {e}",
                         channel_id=channel_id)
             await self.ari_client.hangup_channel(channel_id)
+
+    def register_predial_transfer_channel(self, call_id: str, channel_id: str) -> None:
+        """Register a predial destination leg so cleanup can resolve it back to the caller call."""
+        if channel_id:
+            self._predial_transfer_channel_to_call_id[channel_id] = call_id
+            self._seen_aux_channels.add(channel_id)
+
+    def _unregister_predial_transfer_channel(self, channel_id: str) -> None:
+        if channel_id:
+            self._predial_transfer_channel_to_call_id.pop(channel_id, None)
+
+    async def _handle_predial_transfer_answered(self, channel_id: str, args: list):
+        """
+        Handle a predial transfer destination leg entering Stasis on answer.
+        Args: ['predial-transfer', caller_id, destination_key]
+        """
+        caller_id = args[1] if len(args) > 1 else None
+        destination_key = args[2] if len(args) > 2 else ""
+        if not caller_id:
+            logger.error("Predial transfer answered without caller id", channel_id=channel_id, args=args)
+            await self.ari_client.hangup_channel(channel_id)
+            return
+
+        self.register_predial_transfer_channel(caller_id, channel_id)
+        session = await self.session_store.get_by_call_id(caller_id)
+        if not session:
+            logger.error("Predial transfer answered but session was not found", call_id=caller_id, channel_id=channel_id)
+            self._unregister_predial_transfer_channel(channel_id)
+            await self.ari_client.hangup_channel(channel_id)
+            return
+
+        action = dict(getattr(session, "current_action", None) or {})
+        if action.get("type") != "predial_transfer":
+            logger.info(
+                "Predial transfer answered but no matching action is active; hanging up destination leg",
+                call_id=caller_id,
+                channel_id=channel_id,
+                action_type=action.get("type"),
+            )
+            self._unregister_predial_transfer_channel(channel_id)
+            await self.ari_client.hangup_channel(channel_id)
+            return
+
+        action["answered"] = True
+        action["predial_channel_id"] = channel_id
+        if destination_key and not action.get("destination_key"):
+            action["destination_key"] = destination_key
+        session.current_action = action
+        await self._save_session(session)
+
+        logger.info(
+            "Predial transfer destination answered",
+            call_id=caller_id,
+            channel_id=channel_id,
+            destination_key=destination_key,
+            ready_to_bridge=bool(action.get("ready_to_bridge")),
+        )
+
+        if action.get("ready_to_bridge"):
+            await self._finalize_predial_transfer_bridge(session, channel_id)
+
+    async def finalize_predial_transfer(self, context: "ToolExecutionContext", action: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Called after caller-facing transfer audio drains; bridge an answered predial leg."""
+        call_id = context.call_id
+        transfer_cfg = {}
+        try:
+            tools_cfg = getattr(self.config, "tools", {}) or {}
+            transfer_cfg = tools_cfg.get("transfer") if isinstance(tools_cfg, dict) else {}
+            if not isinstance(transfer_cfg, dict):
+                transfer_cfg = {}
+        except Exception:
+            transfer_cfg = {}
+
+        try:
+            wait_timeout = float(transfer_cfg.get("predial_bridge_wait_timeout_sec", 10.0) or 10.0)
+        except (TypeError, ValueError):
+            wait_timeout = 10.0
+        wait_timeout = max(0.0, min(wait_timeout, 60.0))
+        moh_class = str(transfer_cfg.get("predial_wait_moh_class", "default") or "default")
+
+        session = await self.session_store.get_by_call_id(call_id)
+        if not session:
+            return {"status": "failed", "message": "Call session is no longer available for predial transfer."}
+
+        current = dict(getattr(session, "current_action", None) or {})
+        if current.get("type") != "predial_transfer":
+            return {"status": "failed", "message": "Predial transfer state is no longer active."}
+
+        current["ready_to_bridge"] = True
+        session.current_action = current
+        await self._save_session(session)
+
+        started_at = time.time()
+        moh_started = False
+        while (time.time() - started_at) <= wait_timeout:
+            session = await self.session_store.get_by_call_id(call_id)
+            if not session:
+                return {"status": "failed", "message": "Call session ended before predial transfer completed."}
+            current = dict(getattr(session, "current_action", None) or {})
+            predial_channel_id = str(
+                current.get("predial_channel_id")
+                or ((action.get("payload") or {}).get("predial") or {}).get("channel_id")
+                or ""
+            ).strip()
+            if current.get("bridged"):
+                return {
+                    "status": "success",
+                    "message": f"Transferring you to {current.get('target_name') or action.get('description') or 'the destination'} now.",
+                    "destination": current.get("target") or action.get("target"),
+                    "type": current.get("transfer_type") or action.get("transfer_type"),
+                    "strategy": "predial_then_bridge",
+                }
+            if predial_channel_id and current.get("answered"):
+                ok = await self._finalize_predial_transfer_bridge(session, predial_channel_id)
+                if ok:
+                    return {
+                        "status": "success",
+                        "message": f"Transferring you to {current.get('target_name') or action.get('description') or 'the destination'} now.",
+                        "destination": current.get("target") or action.get("target"),
+                        "type": current.get("transfer_type") or action.get("transfer_type"),
+                        "strategy": "predial_then_bridge",
+                    }
+                return {"status": "failed", "message": "Predial destination answered, but bridging failed."}
+
+            if not moh_started and moh_class:
+                try:
+                    await self.ari_client.send_command(
+                        method="POST",
+                        resource=f"channels/{session.caller_channel_id}/moh",
+                        params={"mohClass": moh_class},
+                    )
+                    moh_started = True
+                except Exception:
+                    logger.debug("Failed to start predial wait MOH", call_id=call_id, exc_info=True)
+
+            await asyncio.sleep(0.05)
+
+        session = await self.session_store.get_by_call_id(call_id)
+        current = dict(getattr(session, "current_action", None) or {}) if session else {}
+        predial_channel_id = str(current.get("predial_channel_id") or "").strip()
+        if predial_channel_id:
+            self._unregister_predial_transfer_channel(predial_channel_id)
+            with contextlib.suppress(Exception):
+                await self.ari_client.hangup_channel(predial_channel_id)
+        if session:
+            with contextlib.suppress(Exception):
+                await self.ari_client.send_command(method="DELETE", resource=f"channels/{session.caller_channel_id}/moh")
+            session.current_action = None
+            await self._save_session(session)
+        return {"status": "failed", "message": "Predial destination did not answer before the bridge timeout."}
+
+    async def _finalize_predial_transfer_bridge(self, session: "CallSession", predial_channel_id: str) -> bool:
+        call_id = session.call_id
+        action = dict(getattr(session, "current_action", None) or {})
+        if action.get("bridged"):
+            return True
+
+        try:
+            await self.ari_client.send_command(method="DELETE", resource=f"channels/{session.caller_channel_id}/moh")
+        except Exception:
+            pass
+
+        try:
+            if session.external_media_id:
+                await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.external_media_id)
+            if session.audiosocket_channel_id:
+                await self.ari_client.remove_channel_from_bridge(session.bridge_id, session.audiosocket_channel_id)
+        except Exception:
+            logger.debug("Failed to remove AI media channels during predial transfer", call_id=call_id, exc_info=True)
+
+        try:
+            start_task = self._provider_start_tasks.pop(call_id, None)
+            if start_task:
+                start_task.cancel()
+            task = getattr(self, "_pipeline_tasks", {}).pop(call_id, None)
+            if task and not task.done():
+                task.cancel()
+            getattr(self, "_pipeline_queues", {}).pop(call_id, None)
+            getattr(self, "_pipeline_transcript_queues", {}).pop(call_id, None)
+            self._pipeline_forced.pop(call_id, None)
+        except Exception:
+            pass
+        provider = self._call_providers.pop(call_id, None)
+        if provider and hasattr(provider, "stop_session"):
+            try:
+                await provider.stop_session()
+            except Exception:
+                logger.debug("Failed to stop provider during predial transfer", call_id=call_id, exc_info=True)
+
+        if not await self.ari_client.add_channel_to_bridge(session.bridge_id, predial_channel_id):
+            return False
+
+        try:
+            session = await self.session_store.get_by_call_id(call_id) or session
+            action = dict(getattr(session, "current_action", None) or {})
+            action["answered"] = True
+            action["bridged"] = True
+            action["predial_channel_id"] = predial_channel_id
+            action["channel_id"] = predial_channel_id
+            session.current_action = action
+            session.transfer_state = "bridged"
+            session.transfer_destination = str(action.get("target_name") or action.get("target") or "")
+            await self._save_session(session)
+        except Exception:
+            logger.debug("Failed to persist predial transfer bridge state", call_id=call_id, exc_info=True)
+
+        logger.info(
+            "Predial transfer bridged",
+            call_id=call_id,
+            predial_channel_id=predial_channel_id,
+            bridge_id=getattr(session, "bridge_id", None),
+            destination=getattr(session, "transfer_destination", None),
+        )
+        return True
 
     def register_attended_transfer_agent_channel(self, call_id: str, agent_channel_id: str) -> None:
         """Register an attended transfer agent channel to resolve DTMF events back to a call."""
@@ -5867,6 +6083,10 @@ class Engine:
                 if mapped_call_id:
                     session = await self.session_store.get_by_call_id(mapped_call_id)
             if not session:
+                mapped_call_id = self._predial_transfer_channel_to_call_id.get(channel_or_call_id)
+                if mapped_call_id:
+                    session = await self.session_store.get_by_call_id(mapped_call_id)
+            if not session:
                 logger.debug("No session found during cleanup", identifier=channel_or_call_id)
                 # Codex P1: a single call has multiple channels (caller + aux media legs:
                 # Local/AudioSocket/ExternalMedia). Aux legs are destroyed AFTER the main
@@ -6037,6 +6257,9 @@ class Engine:
                     # Legacy warm transfer path used `channel_id`
                     if action.get("channel_id"):
                         action_channels.append(str(action.get("channel_id")))
+                    # Predial transfer destination leg.
+                    if action.get("predial_channel_id"):
+                        action_channels.append(str(action.get("predial_channel_id")))
             except Exception:
                 action_channels = []
 
@@ -6288,6 +6511,15 @@ class Engine:
                 ]
                 for ch in stale:
                     self._unregister_attended_transfer_agent_channel(ch)
+            except Exception:
+                pass
+            try:
+                stale_predial = [
+                    ch for ch, cid in self._predial_transfer_channel_to_call_id.items()
+                    if cid == call_id
+                ]
+                for ch in stale_predial:
+                    self._unregister_predial_transfer_channel(ch)
             except Exception:
                 pass
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -19,7 +19,7 @@ import sqlite3
 from collections import deque
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
-from typing import Dict, Any, Optional, List, Set, Tuple, Callable
+from typing import TYPE_CHECKING, Dict, Any, Optional, List, Set, Tuple, Callable
 
 # Simple audio capture system removed - not used in production
 
@@ -79,6 +79,9 @@ from src.tools.telephony.hangup_policy import (
     text_is_short_polite_closing,
     normalize_marker_list,
 )
+
+if TYPE_CHECKING:
+    from src.tools.context import ToolExecutionContext
 
 logger = get_logger(__name__)
 
@@ -4313,9 +4316,27 @@ class Engine:
             getattr(self, "_pipeline_transcript_queues", {}).pop(call_id, None)
             self._pipeline_forced.pop(call_id, None)
         except Exception:
-            pass
+            logger.debug("Failed to stop predial provider tasks", call_id=call_id, exc_info=True)
 
         if not await self.ari_client.add_channel_to_bridge(session.bridge_id, predial_channel_id):
+            self._unregister_predial_transfer_channel(predial_channel_id)
+            try:
+                await self.ari_client.hangup_channel(predial_channel_id)
+            except Exception:
+                logger.debug("Failed to hang up failed predial destination leg", call_id=call_id, predial_channel_id=predial_channel_id, exc_info=True)
+            try:
+                latest = await self.session_store.get_by_call_id(call_id) or session
+                latest_action = dict(getattr(latest, "current_action", None) or {})
+                if latest_action.get("type") == "predial_transfer":
+                    latest.current_action = None
+                    await self._save_session(latest)
+            except Exception:
+                logger.debug("Failed to clear predial action after bridge failure", call_id=call_id, exc_info=True)
+            if provider and hasattr(provider, "stop_session"):
+                self._fire_and_forget(
+                    self._stop_provider_after_predial_bridge(call_id, provider, getattr(session, "provider_name", None)),
+                    name=f"predial-provider-stop-failed-{call_id}",
+                )
             return False
 
         try:
@@ -6094,7 +6115,8 @@ class Engine:
                 if mapped_call_id:
                     session = await self.session_store.get_by_call_id(mapped_call_id)
             if not session:
-                mapped_call_id = self._predial_transfer_channel_to_call_id.get(channel_or_call_id)
+                predial_channel_map = getattr(self, "_predial_transfer_channel_to_call_id", {})
+                mapped_call_id = predial_channel_map.get(channel_or_call_id)
                 if mapped_call_id:
                     session = await self.session_store.get_by_call_id(mapped_call_id)
             if not session:
@@ -11415,7 +11437,7 @@ class Engine:
                                     )
                                     # Wait for filler playback to finish, then release the
                                     # streaming slot so the real LLM→TTS overlap can use it.
-                                    await self.streaming_playback_manager.stop_streaming_playback(call_id)
+                                    await self.streaming_playback_manager.stop_streaming_playback(call_id, drain=True)
                                     # Backdate tts_ended_ts so the post_tts_end_protection_ms
                                     # window has already expired. This avoids blocking barge-in
                                     # between filler and real response, while keeping the echo

--- a/src/engine.py
+++ b/src/engine.py
@@ -12209,21 +12209,28 @@ class Engine:
                                                             if next_deferred_action:
                                                                 transfer_message = str(next_result.get("message") or "").strip()
                                                                 if transfer_message:
-                                                                    conversation_history.append(_ts_msg("assistant", transfer_message))
-                                                                    session.conversation_history = list(conversation_history)
-                                                                    await self.session_store.upsert_call(session)
-                                                                    transfer_bytes = bytearray()
-                                                                    async for chunk in pipeline.tts_adapter.synthesize(call_id, transfer_message, pipeline.tts_options):
-                                                                        if chunk:
-                                                                            transfer_bytes.extend(chunk)
-                                                                    if transfer_bytes:
-                                                                        transfer_pid = await self.playback_manager.play_audio(call_id, bytes(transfer_bytes), "pipeline-transfer")
-                                                                        if transfer_pid:
-                                                                            await self.playback_manager.wait_for_playback_end(
-                                                                                call_id,
-                                                                                transfer_pid,
-                                                                                timeout_sec=(len(transfer_bytes) / 8000.0 + 3.0),
-                                                                            )
+                                                                    try:
+                                                                        conversation_history.append(_ts_msg("assistant", transfer_message))
+                                                                        session.conversation_history = list(conversation_history)
+                                                                        await self.session_store.upsert_call(session)
+                                                                    except Exception:
+                                                                        logger.debug("Failed to record follow-up deferred transfer message", call_id=call_id, exc_info=True)
+
+                                                                    try:
+                                                                        transfer_bytes = bytearray()
+                                                                        async for chunk in pipeline.tts_adapter.synthesize(call_id, transfer_message, pipeline.tts_options):
+                                                                            if chunk:
+                                                                                transfer_bytes.extend(chunk)
+                                                                        if transfer_bytes:
+                                                                            transfer_pid = await self.playback_manager.play_audio(call_id, bytes(transfer_bytes), "pipeline-transfer")
+                                                                            if transfer_pid:
+                                                                                await self.playback_manager.wait_for_playback_end(
+                                                                                    call_id,
+                                                                                    transfer_pid,
+                                                                                    timeout_sec=(len(transfer_bytes) / 8000.0 + 3.0),
+                                                                                )
+                                                                    except Exception:
+                                                                        logger.error("Follow-up deferred transfer TTS failed; committing transfer anyway", call_id=call_id, exc_info=True)
                                                                 await self._commit_pending_deferred_transfer_for_call(call_id, session)
                                                                 return
                                                             if next_result.get("will_hangup"):

--- a/src/providers/deepgram.py
+++ b/src/providers/deepgram.py
@@ -947,6 +947,8 @@ class DeepgramProvider(AIProviderInterface):
                 'call_id': self.call_id,
                 'caller_channel_id': getattr(self, '_caller_channel_id', None),
                 'bridge_id': getattr(self, '_bridge_id', None),
+                'caller_number': getattr(self, '_caller_number', None),
+                'caller_name': getattr(self, '_caller_name', None),
                 'called_number': getattr(self, '_called_number', None),
                 'context_name': getattr(self, '_context_name', None),
                 'session_store': getattr(self, '_session_store', None),

--- a/src/providers/google_live.py
+++ b/src/providers/google_live.py
@@ -2021,6 +2021,8 @@ class GoogleLiveProvider(AIProviderInterface):
                     call_id=self._call_id,
                     caller_channel_id=getattr(self, '_caller_channel_id', None),
                     bridge_id=getattr(self, '_bridge_id', None),
+                    caller_number=getattr(self, '_caller_number', None),
+                    caller_name=getattr(self, '_caller_name', None),
                     called_number=getattr(self, '_called_number', None),
                     context_name=getattr(self, '_context_name', None),
                     session_store=getattr(self, '_session_store', None),

--- a/src/providers/grok.py
+++ b/src/providers/grok.py
@@ -709,6 +709,8 @@ class GrokProvider(AIProviderInterface):
                 'call_id': self._call_id,
                 'caller_channel_id': getattr(self, '_caller_channel_id', None),
                 'bridge_id': getattr(self, '_bridge_id', None),
+                'caller_number': getattr(self, '_caller_number', None),
+                'caller_name': getattr(self, '_caller_name', None),
                 'called_number': getattr(self, '_called_number', None),
                 'context_name': getattr(self, '_context_name', None),
                 'session_store': getattr(self, '_session_store', None),

--- a/src/providers/openai_realtime.py
+++ b/src/providers/openai_realtime.py
@@ -686,6 +686,8 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 'call_id': self._call_id,
                 'caller_channel_id': getattr(self, '_caller_channel_id', None),
                 'bridge_id': getattr(self, '_bridge_id', None),
+                'caller_number': getattr(self, '_caller_number', None),
+                'caller_name': getattr(self, '_caller_name', None),
                 'called_number': getattr(self, '_called_number', None),
                 'context_name': getattr(self, '_context_name', None),
                 'session_store': getattr(self, '_session_store', None),

--- a/src/tools/adapters/deepgram.py
+++ b/src/tools/adapters/deepgram.py
@@ -149,6 +149,8 @@ class DeepgramToolAdapter:
             call_id=context['call_id'],
             caller_channel_id=context.get('caller_channel_id'),
             bridge_id=context.get('bridge_id'),
+            caller_number=context.get('caller_number'),
+            caller_name=context.get('caller_name'),
             called_number=context.get('called_number'),
             context_name=context.get('context_name'),
             session_store=context['session_store'],

--- a/src/tools/adapters/grok.py
+++ b/src/tools/adapters/grok.py
@@ -135,6 +135,8 @@ class GrokToolAdapter:
             call_id=context['call_id'],
             caller_channel_id=context.get('caller_channel_id'),
             bridge_id=context.get('bridge_id'),
+            caller_number=context.get('caller_number'),
+            caller_name=context.get('caller_name'),
             called_number=context.get('called_number'),
             context_name=context.get('context_name'),
             session_store=context['session_store'],

--- a/src/tools/adapters/openai.py
+++ b/src/tools/adapters/openai.py
@@ -170,6 +170,8 @@ class OpenAIToolAdapter:
             call_id=context['call_id'],
             caller_channel_id=context.get('caller_channel_id'),
             bridge_id=context.get('bridge_id'),
+            caller_number=context.get('caller_number'),
+            caller_name=context.get('caller_name'),
             called_number=context.get('called_number'),
             context_name=context.get('context_name'),
             session_store=context['session_store'],

--- a/src/tools/telephony/attended_transfer.py
+++ b/src/tools/telephony/attended_transfer.py
@@ -15,6 +15,12 @@ import structlog
 
 from src.tools.base import Tool, ToolCategory, ToolDefinition, ToolParameter
 from src.tools.context import ToolExecutionContext
+from src.tools.telephony.deferred_transfer import (
+    build_deferred_transfer_action,
+    build_deferred_transfer_result,
+    store_pending_deferred_transfer,
+    transfer_deferral_enabled,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -125,15 +131,69 @@ class AttendedTransferTool(Tool):
         caller_screening_max_seconds = float(cfg.get("caller_screening_max_seconds", 6) or 6)
         caller_screening_silence_ms = int(cfg.get("caller_screening_silence_ms", 1200) or 1200)
 
+        message = (
+            caller_screening_prompt
+            if screening_mode == "caller_recording"
+            else f"Please hold while I connect you to {description}."
+        )
+        action = build_deferred_transfer_action(
+            source_tool="attended_transfer",
+            commit_tool="attended_transfer",
+            transfer_type="attended_transfer",
+            target=extension,
+            description=description,
+            destination_key=destination,
+            payload={
+                "dial_endpoint": dial_endpoint,
+                "dial_timeout_seconds": dial_timeout_sec,
+                "moh_class": moh_class,
+                "screening_mode": screening_mode,
+                "caller_screening_prompt": caller_screening_prompt,
+                "caller_screening_max_seconds": caller_screening_max_seconds,
+                "caller_screening_silence_ms": caller_screening_silence_ms,
+            },
+        )
+
+        if transfer_deferral_enabled(context):
+            await store_pending_deferred_transfer(context, action)
+            return build_deferred_transfer_result(
+                action=action,
+                message=message,
+                extra={
+                    "destination": destination,
+                    "type": "attended_transfer",
+                },
+            )
+
+        return await self.commit_deferred_action(action, context)
+
+    async def commit_deferred_action(
+        self,
+        action: Dict[str, Any],
+        context: ToolExecutionContext,
+    ) -> Dict[str, Any]:
+        payload = action.get("payload") if isinstance(action.get("payload"), dict) else {}
+        destination = str(action.get("destination_key") or "").strip()
+        extension = str(action.get("target") or "").strip()
+        description = str(action.get("description") or extension or "").strip()
+        dial_endpoint = str(payload.get("dial_endpoint") or "").strip()
+        dial_timeout_sec = int(payload.get("dial_timeout_seconds", 30) or 30)
+        moh_class = str(payload.get("moh_class", "default") or "default")
+        screening_mode = str(payload.get("screening_mode") or "basic_tts")
+        caller_screening_prompt = str(payload.get("caller_screening_prompt") or "").strip()
+        caller_screening_max_seconds = float(payload.get("caller_screening_max_seconds", 6) or 6)
+        caller_screening_silence_ms = int(payload.get("caller_screening_silence_ms", 1200) or 1200)
+
         session = await context.get_session()
         call_id = session.call_id
 
         logger.info(
-            "📞 Attended transfer requested",
+            "📞 Attended transfer commit requested",
             call_id=call_id,
             destination_key=destination,
             extension=extension,
             dial_endpoint=dial_endpoint,
+            deferred_action_id=action.get("id"),
         )
 
         session.current_action = {

--- a/src/tools/telephony/cancel_transfer.py
+++ b/src/tools/telephony/cancel_transfer.py
@@ -59,21 +59,47 @@ class CancelTransferTool(Tool):
                     "message": "Session not found"
                 }
             
-            # Check if there's an active transfer
-            if not session.current_action or session.current_action.get('type') not in {'transfer', 'attended_transfer'}:
+            pending_deferred = getattr(session, "pending_deferred_transfer", None)
+            if not isinstance(pending_deferred, dict) or pending_deferred.get("kind") != "transfer":
+                pending_deferred = None
+
+            current_action = session.current_action if isinstance(session.current_action, dict) else None
+            active_action = (
+                current_action
+                if current_action and current_action.get("type") in {"transfer", "attended_transfer", "predial_transfer"}
+                else None
+            )
+
+            # Check if there's an active or deferred transfer.
+            if not active_action and not pending_deferred:
                 return {
                     "status": "no_transfer",
                     "message": "There's no transfer in progress to cancel."
                 }
             
-            action = session.current_action
-            channel_id = action.get('channel_id') or action.get('agent_channel_id')
+            action = active_action or pending_deferred or {}
+            predial_payload = (
+                (pending_deferred.get("payload") or {}).get("predial")
+                if isinstance(pending_deferred, dict) and isinstance(pending_deferred.get("payload"), dict)
+                else None
+            )
+            channel_id = (
+                action.get('channel_id')
+                or action.get('agent_channel_id')
+                or action.get("predial_channel_id")
+                or (predial_payload or {}).get("channel_id")
+            )
             engine = getattr(context.ari_client, "engine", None)
             
             # Check if transfer was answered
             # (If we're here and it was answered, the engine would have already
             # cleared current_action, so this check is safety)
-            if action.get('answered', False):
+            if action.get('answered', False) and action.get("type") != "predial_transfer":
+                return {
+                    "status": "error",
+                    "message": "The transfer has already been connected. I cannot cancel it now."
+                }
+            if action.get("type") == "predial_transfer" and action.get("bridged"):
                 return {
                     "status": "error",
                     "message": "The transfer has already been connected. I cannot cancel it now."
@@ -86,6 +112,8 @@ class CancelTransferTool(Tool):
                     # BEFORE hanging up so the agent leg teardown doesn't trigger full call cleanup.
                     if action.get("type") == "attended_transfer" and engine and hasattr(engine, "_unregister_attended_transfer_agent_channel"):
                         engine._unregister_attended_transfer_agent_channel(channel_id)
+                    if (action.get("type") == "predial_transfer" or predial_payload) and engine and hasattr(engine, "_unregister_predial_transfer_channel"):
+                        engine._unregister_predial_transfer_channel(channel_id)
                 except Exception:
                     pass
                 try:
@@ -106,6 +134,7 @@ class CancelTransferTool(Tool):
             
             # Clear the action from session
             session.current_action = None
+            session.pending_deferred_transfer = None
             session.transfer_context = None
             try:
                 session.audio_capture_enabled = True

--- a/src/tools/telephony/deferred_transfer.py
+++ b/src/tools/telephony/deferred_transfer.py
@@ -124,9 +124,6 @@ async def commit_pending_deferred_transfer(
     if not isinstance(action, dict):
         return None
 
-    session.pending_deferred_transfer = None
-    await context.session_store.upsert_call(session)
-
     try:
         logger.info(
             "Committing deferred transfer",
@@ -136,8 +133,25 @@ async def commit_pending_deferred_transfer(
             commit_tool=action.get("commit_tool"),
             transfer_type=action.get("transfer_type"),
         )
-        return await commit_deferred_transfer_action(action, context)
+        result = await commit_deferred_transfer_action(action, context)
+        if isinstance(result, dict) and result.get("status") == "success":
+            latest = await context.session_store.get_by_call_id(context.call_id) or session
+            pending = getattr(latest, "pending_deferred_transfer", None)
+            if isinstance(pending, dict) and pending.get("id") == action.get("id"):
+                latest.pending_deferred_transfer = None
+                await context.session_store.upsert_call(latest)
+        else:
+            logger.warning(
+                "Deferred transfer commit did not succeed; keeping pending action",
+                call_id=context.call_id,
+                action_id=action.get("id"),
+                result=result,
+            )
+        return result
     except Exception as exc:
+        latest = await context.session_store.get_by_call_id(context.call_id) or session
+        latest.pending_deferred_transfer = dict(action)
+        await context.session_store.upsert_call(latest)
         logger.error(
             "Deferred transfer commit failed",
             call_id=context.call_id,

--- a/src/tools/telephony/deferred_transfer.py
+++ b/src/tools/telephony/deferred_transfer.py
@@ -1,0 +1,148 @@
+"""Helpers for transfer actions that should run after caller-facing audio."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+import structlog
+
+from src.tools.context import ToolExecutionContext
+
+logger = structlog.get_logger(__name__)
+
+DEFERRED_TRANSFER_RESULT_KEY = "deferred_transfer"
+
+
+def transfer_deferral_enabled(context: ToolExecutionContext) -> bool:
+    transfer_cfg = context.get_config_value("tools.transfer") or {}
+    if not isinstance(transfer_cfg, dict):
+        return True
+    return bool(transfer_cfg.get("defer_until_playback_complete", True))
+
+
+def build_deferred_transfer_action(
+    *,
+    source_tool: str,
+    commit_tool: str,
+    transfer_type: str,
+    target: str,
+    description: str,
+    dialplan_context: Optional[str] = None,
+    destination_key: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    action = {
+        "id": str(uuid.uuid4()),
+        "kind": "transfer",
+        "source_tool": source_tool,
+        "commit_tool": commit_tool,
+        "transfer_type": transfer_type,
+        "target": str(target or ""),
+        "description": str(description or target or ""),
+        "dialplan_context": str(dialplan_context or "").strip(),
+        "destination_key": str(destination_key or "").strip(),
+        "created_at": time.time(),
+    }
+    if payload:
+        action["payload"] = dict(payload)
+    return action
+
+
+async def store_pending_deferred_transfer(
+    context: ToolExecutionContext,
+    action: Dict[str, Any],
+) -> None:
+    session = await context.get_session()
+    session.pending_deferred_transfer = dict(action)
+    await context.session_store.upsert_call(session)
+    logger.info(
+        "Deferred transfer armed",
+        call_id=context.call_id,
+        action_id=action.get("id"),
+        source_tool=action.get("source_tool"),
+        commit_tool=action.get("commit_tool"),
+        transfer_type=action.get("transfer_type"),
+        target=action.get("target"),
+        dialplan_context=action.get("dialplan_context"),
+    )
+
+
+def build_deferred_transfer_result(
+    *,
+    action: Dict[str, Any],
+    message: str,
+    status: str = "success",
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    result = {
+        "status": status,
+        "message": message,
+        "defer_until_playback_complete": True,
+        DEFERRED_TRANSFER_RESULT_KEY: dict(action),
+    }
+    if extra:
+        result.update(extra)
+    return result
+
+
+def get_deferred_transfer_action(result: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(result, dict):
+        return None
+    action = result.get(DEFERRED_TRANSFER_RESULT_KEY)
+    if isinstance(action, dict) and action.get("kind") == "transfer":
+        return action
+    return None
+
+
+async def commit_deferred_transfer_action(
+    action: Dict[str, Any],
+    context: ToolExecutionContext,
+) -> Dict[str, Any]:
+    from src.tools.registry import tool_registry
+
+    commit_tool = str(action.get("commit_tool") or "").strip()
+    tool = tool_registry.get(commit_tool) if commit_tool else None
+    if not tool or not hasattr(tool, "commit_deferred_action"):
+        message = f"Deferred transfer commit tool unavailable: {commit_tool or 'unknown'}"
+        logger.error(message, call_id=context.call_id, action=action)
+        return {"status": "error", "message": message}
+
+    return await tool.commit_deferred_action(action, context)
+
+
+async def commit_pending_deferred_transfer(
+    context: ToolExecutionContext,
+) -> Optional[Dict[str, Any]]:
+    session = await context.session_store.get_by_call_id(context.call_id)
+    if not session:
+        logger.warning("Cannot commit deferred transfer - session missing", call_id=context.call_id)
+        return None
+
+    action = getattr(session, "pending_deferred_transfer", None)
+    if not isinstance(action, dict):
+        return None
+
+    session.pending_deferred_transfer = None
+    await context.session_store.upsert_call(session)
+
+    try:
+        logger.info(
+            "Committing deferred transfer",
+            call_id=context.call_id,
+            action_id=action.get("id"),
+            source_tool=action.get("source_tool"),
+            commit_tool=action.get("commit_tool"),
+            transfer_type=action.get("transfer_type"),
+        )
+        return await commit_deferred_transfer_action(action, context)
+    except Exception as exc:
+        logger.error(
+            "Deferred transfer commit failed",
+            call_id=context.call_id,
+            action_id=action.get("id"),
+            error=str(exc),
+            exc_info=True,
+        )
+        return {"status": "error", "message": str(exc)}

--- a/src/tools/telephony/deferred_transfer.py
+++ b/src/tools/telephony/deferred_transfer.py
@@ -135,11 +135,12 @@ async def commit_pending_deferred_transfer(
         )
         result = await commit_deferred_transfer_action(action, context)
         if isinstance(result, dict) and result.get("status") == "success":
-            latest = await context.session_store.get_by_call_id(context.call_id) or session
-            pending = getattr(latest, "pending_deferred_transfer", None)
-            if isinstance(pending, dict) and pending.get("id") == action.get("id"):
-                latest.pending_deferred_transfer = None
-                await context.session_store.upsert_call(latest)
+            latest = await context.session_store.get_by_call_id(context.call_id)
+            if latest:
+                pending = getattr(latest, "pending_deferred_transfer", None)
+                if isinstance(pending, dict) and pending.get("id") == action.get("id"):
+                    latest.pending_deferred_transfer = None
+                    await context.session_store.upsert_call(latest)
         else:
             logger.warning(
                 "Deferred transfer commit did not succeed; keeping pending action",

--- a/src/tools/telephony/deferred_transfer.py
+++ b/src/tools/telephony/deferred_transfer.py
@@ -150,9 +150,10 @@ async def commit_pending_deferred_transfer(
             )
         return result
     except Exception as exc:
-        latest = await context.session_store.get_by_call_id(context.call_id) or session
-        latest.pending_deferred_transfer = dict(action)
-        await context.session_store.upsert_call(latest)
+        latest = await context.session_store.get_by_call_id(context.call_id)
+        if latest:
+            latest.pending_deferred_transfer = dict(action)
+            await context.session_store.upsert_call(latest)
         logger.error(
             "Deferred transfer commit failed",
             call_id=context.call_id,

--- a/src/tools/telephony/live_agent_transfer.py
+++ b/src/tools/telephony/live_agent_transfer.py
@@ -62,9 +62,9 @@ class LiveAgentTransferTool(Tool):
         configured_key = str(transfer_cfg.get("live_agent_destination_key") or "").strip()
         if configured_key:
             cfg = destinations.get(configured_key)
-            # Prevent misrouting "live agent" to arbitrary destinations: only accept
-            # keys explicitly marked live_agent (or the conventional key name).
-            if isinstance(cfg, dict) and (bool(cfg.get("live_agent")) or configured_key == "live_agent"):
+            # An explicit override is operator intent; allow it to point at any
+            # configured transfer destination (extension, queue, or ring group).
+            if isinstance(cfg, dict):
                 return configured_key, "config.live_agent_destination_key"
             return None, "configured_key_missing"
 

--- a/src/tools/telephony/live_agent_transfer.py
+++ b/src/tools/telephony/live_agent_transfer.py
@@ -297,7 +297,14 @@ class LiveAgentTransferTool(Tool):
                     extension=extension,
                     resolution_source=ext_source,
                 )
-                return await unified._transfer_to_extension(context, extension, description)
+                return await unified.prepare_or_execute_extension_transfer(
+                    context,
+                    extension,
+                    description,
+                    source_tool="live_agent_transfer",
+                    destination_key=target or extension,
+                    dest_config=ext_entry,
+                )
 
             if ext_source.endswith("_ambiguous"):
                 logger.warning(
@@ -353,7 +360,14 @@ class LiveAgentTransferTool(Tool):
                 extension=extension,
                 resolution_source=ext_source,
             )
-            return await unified._transfer_to_extension(context, extension, description)
+            return await unified.prepare_or_execute_extension_transfer(
+                context,
+                extension,
+                description,
+                source_tool="live_agent_transfer",
+                destination_key=extension,
+                dest_config=ext_entry,
+            )
 
         if ext_source.endswith("_ambiguous"):
             logger.warning(

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -621,6 +621,12 @@ class UnifiedTransferTool(Tool):
         """
         logger.info("Queue transfer", call_id=context.call_id,
                    queue=queue, description=description)
+
+        config = context.get_config_value("tools.transfer") or {}
+        dialplan_context = (
+            str(dialplan_context or "").strip()
+            or self._resolve_dialplan_context("queue", {}, config if isinstance(config, dict) else {})
+        )
         
         # Set transfer_active flag BEFORE continue() - this prevents cleanup
         # from hanging up the caller when StasisEnd fires
@@ -673,6 +679,12 @@ class UnifiedTransferTool(Tool):
         """
         logger.info("Ring group transfer", call_id=context.call_id,
                    ringgroup=ringgroup, description=description)
+
+        config = context.get_config_value("tools.transfer") or {}
+        dialplan_context = (
+            str(dialplan_context or "").strip()
+            or self._resolve_dialplan_context("ringgroup", {}, config if isinstance(config, dict) else {})
+        )
         
         # Set transfer_active flag BEFORE continue() - this prevents cleanup
         # from hanging up the caller when StasisEnd fires
@@ -702,14 +714,3 @@ class UnifiedTransferTool(Tool):
             "destination": ringgroup,
             "type": "ringgroup"
         }
-        config = context.get_config_value("tools.transfer") or {}
-        dialplan_context = (
-            str(dialplan_context or "").strip()
-            or self._resolve_dialplan_context("queue", {}, config if isinstance(config, dict) else {})
-        )
-
-        config = context.get_config_value("tools.transfer") or {}
-        dialplan_context = (
-            str(dialplan_context or "").strip()
-            or self._resolve_dialplan_context("ringgroup", {}, config if isinstance(config, dict) else {})
-        )

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -10,6 +10,12 @@ import structlog
 
 from ..base import Tool, ToolDefinition, ToolParameter, ToolCategory
 from ..context import ToolExecutionContext
+from .deferred_transfer import (
+    build_deferred_transfer_action,
+    build_deferred_transfer_result,
+    store_pending_deferred_transfer,
+    transfer_deferral_enabled,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -56,6 +62,86 @@ class UnifiedTransferTool(Tool):
     @staticmethod
     def _normalize_text(value: str) -> str:
         return " ".join(str(value or "").strip().lower().replace("_", " ").replace("-", " ").split())
+
+    @staticmethod
+    def _resolve_dialplan_context(
+        transfer_type: str,
+        dest_config: Dict[str, Any],
+        transfer_config: Dict[str, Any],
+    ) -> str:
+        configured = ""
+        if isinstance(dest_config, dict):
+            configured = str(dest_config.get("dialplan_context") or dest_config.get("context") or "").strip()
+        if configured:
+            return configured
+
+        if transfer_type == "extension":
+            return str((transfer_config or {}).get("extension_context") or "from-internal").strip() or "from-internal"
+        if transfer_type == "queue":
+            return str((transfer_config or {}).get("queue_context") or "ext-queues").strip() or "ext-queues"
+        if transfer_type == "ringgroup":
+            return str((transfer_config or {}).get("ringgroup_context") or "ext-group").strip() or "ext-group"
+        return "from-internal"
+
+    async def _defer_or_commit_transfer(
+        self,
+        *,
+        context: ToolExecutionContext,
+        source_tool: str,
+        transfer_type: str,
+        target: str,
+        description: str,
+        dialplan_context: str,
+        destination_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        action = build_deferred_transfer_action(
+            source_tool=source_tool,
+            commit_tool="blind_transfer",
+            transfer_type=transfer_type,
+            target=target,
+            description=description,
+            dialplan_context=dialplan_context,
+            destination_key=destination_key,
+        )
+
+        if transfer_deferral_enabled(context):
+            await store_pending_deferred_transfer(context, action)
+            return build_deferred_transfer_result(
+                action=action,
+                message=f"Transferring you to {description} now.",
+                extra={
+                    "destination": target,
+                    "type": transfer_type,
+                },
+            )
+
+        return await self.commit_deferred_action(action, context)
+
+    async def prepare_or_execute_extension_transfer(
+        self,
+        context: ToolExecutionContext,
+        extension: str,
+        description: str,
+        *,
+        source_tool: str = "blind_transfer",
+        destination_key: Optional[str] = None,
+        dest_config: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        transfer_config = context.get_config_value("tools.transfer") or {}
+        dialplan_context = self._resolve_dialplan_context(
+            "extension",
+            dest_config or {},
+            transfer_config if isinstance(transfer_config, dict) else {},
+        )
+        return await self._defer_or_commit_transfer(
+            context=context,
+            source_tool=source_tool,
+            transfer_type="extension",
+            target=extension,
+            description=description,
+            dialplan_context=dialplan_context,
+            destination_key=destination_key,
+        )
 
     def _resolve_destination_key(self, destination: Any, destinations: Dict[str, Any]) -> Tuple[Optional[str], str]:
         raw = str(destination or "").strip()
@@ -231,25 +317,79 @@ class UnifiedTransferTool(Tool):
             target=target
         )
         
+        dialplan_context = self._resolve_dialplan_context(
+            str(transfer_type or ""),
+            dest_config if isinstance(dest_config, dict) else {},
+            config if isinstance(config, dict) else {},
+        )
+
         # Route based on transfer type
         if transfer_type == 'extension':
-            return await self._transfer_to_extension(context, target, description)
+            return await self._defer_or_commit_transfer(
+                context=context,
+                source_tool="blind_transfer",
+                transfer_type="extension",
+                target=target,
+                description=description,
+                dialplan_context=dialplan_context,
+                destination_key=str(destination),
+            )
         elif transfer_type == 'queue':
-            return await self._transfer_to_queue(context, target, description)
+            return await self._defer_or_commit_transfer(
+                context=context,
+                source_tool="blind_transfer",
+                transfer_type="queue",
+                target=target,
+                description=description,
+                dialplan_context=dialplan_context,
+                destination_key=str(destination),
+            )
         elif transfer_type == 'ringgroup':
-            return await self._transfer_to_ringgroup(context, target, description)
+            return await self._defer_or_commit_transfer(
+                context=context,
+                source_tool="blind_transfer",
+                transfer_type="ringgroup",
+                target=target,
+                description=description,
+                dialplan_context=dialplan_context,
+                destination_key=str(destination),
+            )
         else:
             logger.error("Invalid transfer type", type=transfer_type)
             return {
                 "status": "failed",
                 "message": f"Invalid transfer type: {transfer_type}"
             }
+
+    async def commit_deferred_action(
+        self,
+        action: Dict[str, Any],
+        context: ToolExecutionContext,
+    ) -> Dict[str, Any]:
+        transfer_type = str(action.get("transfer_type") or "").strip()
+        target = str(action.get("target") or "").strip()
+        description = str(action.get("description") or target or "").strip()
+        dialplan_context = str(action.get("dialplan_context") or "").strip()
+
+        if transfer_type == "extension":
+            return await self._transfer_to_extension(context, target, description, dialplan_context=dialplan_context)
+        if transfer_type == "queue":
+            return await self._transfer_to_queue(context, target, description, dialplan_context=dialplan_context)
+        if transfer_type == "ringgroup":
+            return await self._transfer_to_ringgroup(context, target, description, dialplan_context=dialplan_context)
+
+        return {
+            "status": "failed",
+            "message": f"Invalid deferred transfer type: {transfer_type}",
+        }
     
     async def _transfer_to_extension(
         self,
         context: ToolExecutionContext,
         extension: str,
-        description: str
+        description: str,
+        *,
+        dialplan_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Transfer to a direct extension using ARI redirect.
@@ -268,7 +408,10 @@ class UnifiedTransferTool(Tool):
         
         # Get dialplan context for extension transfers (default: from-internal for FreePBX)
         config = context.get_config_value("tools.transfer") or {}
-        dialplan_context = config.get("extension_context", "from-internal")
+        dialplan_context = (
+            str(dialplan_context or "").strip()
+            or self._resolve_dialplan_context("extension", {}, config if isinstance(config, dict) else {})
+        )
         
         # Set transfer_active flag BEFORE continue() - this prevents cleanup
         # from hanging up the caller when StasisEnd fires
@@ -303,7 +446,9 @@ class UnifiedTransferTool(Tool):
         self,
         context: ToolExecutionContext,
         queue: str,
-        description: str
+        description: str,
+        *,
+        dialplan_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Transfer to a queue using ARI continue to FreePBX ext-queues context.
@@ -333,7 +478,7 @@ class UnifiedTransferTool(Tool):
             method="POST",
             resource=f"channels/{context.caller_channel_id}/continue",
             params={
-                "context": "ext-queues",
+                "context": dialplan_context,
                 "extension": queue,
                 "priority": 1
             }
@@ -353,7 +498,9 @@ class UnifiedTransferTool(Tool):
         self,
         context: ToolExecutionContext,
         ringgroup: str,
-        description: str
+        description: str,
+        *,
+        dialplan_context: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Transfer to a ring group using ARI continue to FreePBX ext-group context.
@@ -383,7 +530,7 @@ class UnifiedTransferTool(Tool):
             method="POST",
             resource=f"channels/{context.caller_channel_id}/continue",
             params={
-                "context": "ext-group",
+                "context": dialplan_context,
                 "extension": ringgroup,
                 "priority": 1
             }
@@ -398,3 +545,14 @@ class UnifiedTransferTool(Tool):
             "destination": ringgroup,
             "type": "ringgroup"
         }
+        config = context.get_config_value("tools.transfer") or {}
+        dialplan_context = (
+            str(dialplan_context or "").strip()
+            or self._resolve_dialplan_context("queue", {}, config if isinstance(config, dict) else {})
+        )
+
+        config = context.get_config_value("tools.transfer") or {}
+        dialplan_context = (
+            str(dialplan_context or "").strip()
+            or self._resolve_dialplan_context("ringgroup", {}, config if isinstance(config, dict) else {})
+        )

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -229,18 +229,19 @@ class UnifiedTransferTool(Tool):
             result = await context.ari_client.send_command(
                 method="POST",
                 resource="channels",
-                data={
+                params={
                     "endpoint": endpoint,
+                    "app": app,
+                    "appArgs": f"predial-transfer,{context.call_id},{destination_key}",
                     "callerId": self._caller_id_for_predial(context),
                     "timeout": dial_timeout_sec,
-                    "variables": {
+                    "channelVars": {
                         "AGENT_ACTION": "predial_transfer",
                         "AGENT_CALL_ID": context.call_id,
                         "AGENT_TARGET": str(action.get("target") or ""),
                         "AAVA_TRANSFER_DESTINATION_KEY": destination_key,
                     },
                 },
-                params={"app": app, "appArgs": f"predial-transfer,{context.call_id},{destination_key}"},
             )
         except Exception:
             logger.warning("Predial transfer originate failed", call_id=context.call_id, endpoint=endpoint, exc_info=True)

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -94,6 +94,30 @@ class UnifiedTransferTool(Tool):
         dialplan_context: str,
         destination_key: Optional[str] = None,
     ) -> Dict[str, Any]:
+        if transfer_deferral_enabled(context):
+            try:
+                session = await context.get_session()
+                pending = getattr(session, "pending_deferred_transfer", None)
+                if isinstance(pending, dict) and pending.get("kind") == "transfer":
+                    logger.info(
+                        "Suppressing duplicate deferred transfer request",
+                        call_id=context.call_id,
+                        existing_action_id=pending.get("id"),
+                        existing_target=pending.get("target"),
+                        requested_target=target,
+                    )
+                    return build_deferred_transfer_result(
+                        action=pending,
+                        message=f"Transferring you to {pending.get('description') or description} now.",
+                        extra={
+                            "destination": pending.get("target") or target,
+                            "type": pending.get("transfer_type") or transfer_type,
+                            "duplicate_suppressed": True,
+                        },
+                    )
+            except Exception:
+                logger.debug("Failed to check duplicate deferred transfer", call_id=context.call_id, exc_info=True)
+
         action = build_deferred_transfer_action(
             source_tool=source_tool,
             commit_tool="blind_transfer",

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -99,6 +99,25 @@ class UnifiedTransferTool(Tool):
                 session = await context.get_session()
                 pending = getattr(session, "pending_deferred_transfer", None)
                 if isinstance(pending, dict) and pending.get("kind") == "transfer":
+                    same_pending_transfer = (
+                        str(pending.get("transfer_type") or "").strip() == str(transfer_type or "").strip()
+                        and str(pending.get("target") or "").strip() == str(target or "").strip()
+                        and str(pending.get("dialplan_context") or "").strip() == str(dialplan_context or "").strip()
+                    )
+                    if not same_pending_transfer:
+                        logger.warning(
+                            "Conflicting deferred transfer request while another transfer is pending",
+                            call_id=context.call_id,
+                            existing_action_id=pending.get("id"),
+                            existing_target=pending.get("target"),
+                            existing_transfer_type=pending.get("transfer_type"),
+                            requested_target=target,
+                            requested_transfer_type=transfer_type,
+                        )
+                        return {
+                            "status": "failed",
+                            "message": "A transfer is already pending. Please wait for it to complete.",
+                        }
                     logger.info(
                         "Suppressing duplicate deferred transfer request",
                         call_id=context.call_id,

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -105,6 +105,7 @@ class UnifiedTransferTool(Tool):
         )
 
         if transfer_deferral_enabled(context):
+            await self._maybe_start_predial_transfer(context, action)
             await store_pending_deferred_transfer(context, action)
             return build_deferred_transfer_result(
                 action=action,
@@ -116,6 +117,124 @@ class UnifiedTransferTool(Tool):
             )
 
         return await self.commit_deferred_action(action, context)
+
+    def _deferred_strategy(self, context: ToolExecutionContext) -> str:
+        transfer_config = context.get_config_value("tools.transfer") or {}
+        if not isinstance(transfer_config, dict):
+            return "drain_then_dial"
+        strategy = str(transfer_config.get("deferred_strategy") or "drain_then_dial").strip().lower()
+        if strategy in {"predial", "pre_dial", "pre-dial", "predial_then_bridge"}:
+            return "predial_then_bridge"
+        return "drain_then_dial"
+
+    def _predial_endpoint_for_action(self, action: Dict[str, Any]) -> str:
+        target = str(action.get("target") or "").strip()
+        dialplan_context = str(action.get("dialplan_context") or "").strip()
+        if not target or not dialplan_context:
+            return ""
+        return f"Local/{target}@{dialplan_context}"
+
+    def _caller_id_for_predial(self, context: ToolExecutionContext) -> str:
+        number = str(context.caller_number or "").strip()
+        name = str(context.caller_name or "").strip()
+        if name and number:
+            safe_name = name.replace('"', "").replace("<", "").replace(">", "").strip()
+            return f'"{safe_name}" <{number}>'
+        return number or name or ""
+
+    async def _maybe_start_predial_transfer(
+        self,
+        context: ToolExecutionContext,
+        action: Dict[str, Any],
+    ) -> None:
+        if self._deferred_strategy(context) != "predial_then_bridge":
+            return
+
+        endpoint = self._predial_endpoint_for_action(action)
+        if not endpoint:
+            logger.warning("Predial transfer skipped - endpoint unavailable", call_id=context.call_id, action=action)
+            return
+
+        app = str(context.get_config_value("asterisk.app_name", "asterisk-ai-voice-agent") or "asterisk-ai-voice-agent")
+        transfer_config = context.get_config_value("tools.transfer") or {}
+        try:
+            dial_timeout_sec = int((transfer_config if isinstance(transfer_config, dict) else {}).get("predial_timeout_seconds", 30) or 30)
+        except (TypeError, ValueError):
+            dial_timeout_sec = 30
+
+        destination_key = str(action.get("destination_key") or action.get("target") or "").strip()
+        try:
+            session = await context.get_session()
+            session.current_action = {
+                "type": "predial_transfer",
+                "deferred_action_id": action.get("id"),
+                "destination_key": destination_key,
+                "target": action.get("target"),
+                "target_name": action.get("description"),
+                "transfer_type": action.get("transfer_type"),
+                "dialplan_context": action.get("dialplan_context"),
+                "endpoint": endpoint,
+                "answered": False,
+                "ready_to_bridge": False,
+                "bridged": False,
+            }
+            await context.session_store.upsert_call(session)
+        except Exception:
+            logger.debug("Failed to persist predial transfer action state", call_id=context.call_id, exc_info=True)
+
+        try:
+            result = await context.ari_client.send_command(
+                method="POST",
+                resource="channels",
+                data={
+                    "endpoint": endpoint,
+                    "callerId": self._caller_id_for_predial(context),
+                    "timeout": dial_timeout_sec,
+                    "variables": {
+                        "AGENT_ACTION": "predial_transfer",
+                        "AGENT_CALL_ID": context.call_id,
+                        "AGENT_TARGET": str(action.get("target") or ""),
+                        "AAVA_TRANSFER_DESTINATION_KEY": destination_key,
+                    },
+                },
+                params={"app": app, "appArgs": f"predial-transfer,{context.call_id},{destination_key}"},
+            )
+        except Exception:
+            logger.warning("Predial transfer originate failed", call_id=context.call_id, endpoint=endpoint, exc_info=True)
+            return
+
+        if not isinstance(result, dict) or not result.get("id"):
+            logger.warning("Predial transfer originate returned no channel", call_id=context.call_id, endpoint=endpoint, response=result)
+            return
+
+        predial_channel_id = str(result["id"])
+        action["payload"] = {
+            **(action.get("payload") if isinstance(action.get("payload"), dict) else {}),
+            "predial": {
+                "enabled": True,
+                "endpoint": endpoint,
+                "channel_id": predial_channel_id,
+                "destination_key": destination_key,
+            },
+        }
+        try:
+            session = await context.get_session()
+            if isinstance(session.current_action, dict) and session.current_action.get("type") == "predial_transfer":
+                session.current_action["predial_channel_id"] = predial_channel_id
+                await context.session_store.upsert_call(session)
+            engine = getattr(context.ari_client, "engine", None)
+            if engine and hasattr(engine, "register_predial_transfer_channel"):
+                engine.register_predial_transfer_channel(context.call_id, predial_channel_id)
+        except Exception:
+            logger.debug("Failed to register predial transfer channel", call_id=context.call_id, predial_channel_id=predial_channel_id, exc_info=True)
+
+        logger.info(
+            "Predial transfer leg originated",
+            call_id=context.call_id,
+            endpoint=endpoint,
+            predial_channel_id=predial_channel_id,
+            destination_key=destination_key,
+        )
 
     async def prepare_or_execute_extension_transfer(
         self,
@@ -370,6 +489,20 @@ class UnifiedTransferTool(Tool):
         target = str(action.get("target") or "").strip()
         description = str(action.get("description") or target or "").strip()
         dialplan_context = str(action.get("dialplan_context") or "").strip()
+        payload = action.get("payload") if isinstance(action.get("payload"), dict) else {}
+        predial = payload.get("predial") if isinstance(payload.get("predial"), dict) else None
+
+        if predial and predial.get("enabled"):
+            engine = getattr(context.ari_client, "engine", None)
+            if engine and hasattr(engine, "finalize_predial_transfer"):
+                result = await engine.finalize_predial_transfer(context, action)
+                if result and result.get("status") == "success":
+                    return result
+                logger.warning(
+                    "Predial transfer finalize failed; falling back to dialplan transfer",
+                    call_id=context.call_id,
+                    result=result,
+                )
 
         if transfer_type == "extension":
             return await self._transfer_to_extension(context, target, description, dialplan_context=dialplan_context)

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -762,6 +762,36 @@ async def test_predial_transfer_finalize_is_serialized():
 
 
 @pytest.mark.asyncio
+async def test_predial_transfer_finalize_in_progress_does_not_report_success(monkeypatch):
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial-in-flight",
+        caller_channel_id="caller-predial-in-flight",
+        bridge_id="bridge-predial-in-flight",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "bridged": False,
+        "predial_channel_id": "SIP/6000-00000006",
+    }
+    await engine.session_store.upsert_call(session)
+    engine._predial_bridge_in_progress.add("call-predial-in-flight")
+
+    ticks = iter([0.0, 10.0])
+    monkeypatch.setattr("src.engine.time.time", lambda: next(ticks, 10.0))
+
+    ok = await engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000006")
+
+    assert ok is False
+    assert "call-predial-in-flight" in engine._predial_bridge_in_progress
+    updated = await engine.session_store.get_by_call_id("call-predial-in-flight")
+    assert updated.current_action["bridged"] is False
+
+
+@pytest.mark.asyncio
 async def test_unbridged_predial_leg_cleanup_does_not_cleanup_caller():
     engine = _build_engine({"enabled": True})
     session = CallSession(

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -533,19 +533,21 @@ async def test_deferred_transfer_audio_drain_waits_for_streaming_buffer():
         "last_real_emit_ts": time.time(),
     }
     engine.streaming_playback_manager.frame_remainders[call_id] = b""
+    observations = []
 
     async def clear_buffer():
         await asyncio.sleep(0.05)
+        observations.append(("before_clear", engine.streaming_playback_manager.active_streams[call_id]["buffered_bytes"]))
         engine.streaming_playback_manager.active_streams[call_id]["buffered_bytes"] = 0
         engine.streaming_playback_manager.active_streams[call_id]["last_real_emit_ts"] = time.time()
 
-    started = time.time()
     clear_task = asyncio.create_task(clear_buffer())
     drained = await engine._wait_for_deferred_transfer_audio_drain(call_id)
     await clear_task
 
     assert drained is True
-    assert time.time() - started >= 0.1
+    assert observations == [("before_clear", 160)]
+    assert engine.streaming_playback_manager.active_streams[call_id]["buffered_bytes"] == 0
 
 
 @pytest.mark.asyncio
@@ -653,6 +655,65 @@ async def test_predial_transfer_bridges_before_slow_provider_shutdown():
     stop_release.set()
     await asyncio.wait_for(stop_done.wait(), timeout=1)
     assert order[-1] == "provider-stop-done"
+
+
+@pytest.mark.asyncio
+async def test_predial_transfer_bridge_failure_cleans_destination_leg_and_provider():
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial-fail",
+        caller_channel_id="caller-predial-fail",
+        bridge_id="bridge-predial-fail",
+        provider_name="google_live",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "predial_channel_id": "SIP/6000-00000003",
+    }
+    await engine.session_store.upsert_call(session)
+    engine.register_predial_transfer_channel("call-predial-fail", "SIP/6000-00000003")
+
+    stopped = asyncio.Event()
+    hung_up = []
+    scheduled = []
+
+    class Provider:
+        async def stop_session(self):
+            stopped.set()
+
+    engine._call_providers["call-predial-fail"] = Provider()
+    engine.ari_client.add_channel_to_bridge = types.MethodType(
+        lambda self, bridge_id, channel_id: asyncio.sleep(0, result=False),
+        engine.ari_client,
+    )
+    engine.ari_client.send_command = types.MethodType(
+        lambda self, **kwargs: asyncio.sleep(0, result={"status": 204}),
+        engine.ari_client,
+    )
+
+    async def fake_hangup(channel_id):
+        hung_up.append(channel_id)
+        return True
+
+    def fake_fire_and_forget(coro, *, name=None):
+        scheduled.append(name)
+        return asyncio.create_task(coro)
+
+    engine.ari_client.hangup_channel = fake_hangup
+    engine._fire_and_forget = fake_fire_and_forget
+
+    ok = await engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000003")
+
+    assert ok is False
+    assert "SIP/6000-00000003" not in engine._predial_transfer_channel_to_call_id
+    assert hung_up == ["SIP/6000-00000003"]
+    assert scheduled == ["predial-provider-stop-failed-call-predial-fail"]
+    await asyncio.wait_for(stopped.wait(), timeout=1)
+    updated = await engine.session_store.get_by_call_id("call-predial-fail")
+    assert updated.current_action is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -717,6 +717,88 @@ async def test_predial_transfer_bridge_failure_cleans_destination_leg_and_provid
 
 
 @pytest.mark.asyncio
+async def test_predial_transfer_finalize_is_serialized():
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial-race",
+        caller_channel_id="caller-predial-race",
+        bridge_id="bridge-predial-race",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "predial_channel_id": "SIP/6000-00000004",
+    }
+    await engine.session_store.upsert_call(session)
+
+    add_started = asyncio.Event()
+    release_add = asyncio.Event()
+    add_calls = []
+
+    async def fake_add(self, bridge_id, channel_id):
+        add_calls.append((bridge_id, channel_id))
+        add_started.set()
+        await release_add.wait()
+        return True
+
+    engine.ari_client.add_channel_to_bridge = types.MethodType(fake_add, engine.ari_client)
+    engine.ari_client.send_command = types.MethodType(
+        lambda self, **kwargs: asyncio.sleep(0, result={"status": 204}),
+        engine.ari_client,
+    )
+
+    first = asyncio.create_task(engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000004"))
+    await asyncio.wait_for(add_started.wait(), timeout=1)
+    second = asyncio.create_task(engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000004"))
+    await asyncio.sleep(0)
+    release_add.set()
+
+    assert await asyncio.wait_for(first, timeout=1) is True
+    assert await asyncio.wait_for(second, timeout=1) is True
+    assert add_calls == [("bridge-predial-race", "SIP/6000-00000004")]
+    assert "call-predial-race" not in engine._predial_bridge_in_progress
+
+
+@pytest.mark.asyncio
+async def test_unbridged_predial_leg_cleanup_does_not_cleanup_caller():
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial-unbridged",
+        caller_channel_id="caller-predial-unbridged",
+        bridge_id="bridge-predial-unbridged",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "ready_to_bridge": False,
+        "bridged": False,
+        "predial_channel_id": "SIP/6000-00000005",
+    }
+    await engine.session_store.upsert_call(session)
+    engine.register_predial_transfer_channel("call-predial-unbridged", "SIP/6000-00000005")
+
+    destroyed_bridges = []
+
+    async def fake_destroy_bridge(bridge_id):
+        destroyed_bridges.append(bridge_id)
+        return True
+
+    engine.ari_client.destroy_bridge = fake_destroy_bridge
+
+    await engine._cleanup_call("SIP/6000-00000005")
+
+    assert destroyed_bridges == []
+    assert "SIP/6000-00000005" not in engine._predial_transfer_channel_to_call_id
+    updated = await engine.session_store.get_by_call_id("call-predial-unbridged")
+    assert updated is not None
+    assert updated.current_action is None
+
+
+@pytest.mark.asyncio
 async def test_attended_transfer_ai_briefing_falls_back_to_basic_tts_when_generation_unavailable(monkeypatch):
     engine = _build_engine(
         {

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -1,4 +1,6 @@
+import asyncio
 import sys
+import time
 import types
 
 import pytest
@@ -415,6 +417,73 @@ def test_attended_transfer_ai_briefing_rejects_local_ai_fallback_text():
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_deferred_transfer_commit_waits_for_audio_drain(monkeypatch):
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-deferred",
+        caller_channel_id="caller-deferred",
+        context_name="support",
+    )
+    session.pending_deferred_transfer = {
+        "kind": "transfer",
+        "commit_tool": "blind_transfer",
+        "transfer_type": "extension",
+        "target": "6000",
+        "description": "Support agent",
+    }
+    await engine.session_store.upsert_call(session)
+
+    calls = []
+
+    async def fake_wait(call_id):
+        calls.append(("drain", call_id))
+        return True
+
+    async def fake_commit(context):
+        calls.append(("commit", context.call_id))
+        return {"status": "success", "message": "ok"}
+
+    monkeypatch.setattr(engine, "_wait_for_deferred_transfer_audio_drain", fake_wait)
+    monkeypatch.setattr(
+        "src.tools.telephony.deferred_transfer.commit_pending_deferred_transfer",
+        fake_commit,
+    )
+
+    result = await engine._commit_pending_deferred_transfer_for_call("call-deferred", session)
+
+    assert result == {"status": "success", "message": "ok"}
+    assert calls == [("drain", "call-deferred"), ("commit", "call-deferred")]
+
+
+@pytest.mark.asyncio
+async def test_deferred_transfer_audio_drain_waits_for_streaming_buffer():
+    engine = _build_engine({"enabled": True})
+    engine.config.tools["transfer"]["deferred_audio_drain_timeout_sec"] = 1.0
+    engine.config.tools["transfer"]["deferred_audio_drain_quiet_ms"] = 60
+
+    call_id = "call-drain"
+    engine.streaming_playback_manager.active_streams[call_id] = {
+        "buffered_bytes": 160,
+        "jitter_depth": 0,
+        "last_real_emit_ts": time.time(),
+    }
+    engine.streaming_playback_manager.frame_remainders[call_id] = b""
+
+    async def clear_buffer():
+        await asyncio.sleep(0.05)
+        engine.streaming_playback_manager.active_streams[call_id]["buffered_bytes"] = 0
+        engine.streaming_playback_manager.active_streams[call_id]["last_real_emit_ts"] = time.time()
+
+    started = time.time()
+    clear_task = asyncio.create_task(clear_buffer())
+    drained = await engine._wait_for_deferred_transfer_audio_drain(call_id)
+    await clear_task
+
+    assert drained is True
+    assert time.time() - started >= 0.1
 
 
 @pytest.mark.asyncio

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -459,6 +459,68 @@ async def test_deferred_transfer_commit_waits_for_audio_drain(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_deferred_transfer_deepgram_plays_local_handoff_before_commit(monkeypatch):
+    engine = _build_engine({"enabled": True})
+    engine.config.tools["transfer"]["local_handoff_audio_providers"] = ["deepgram"]
+    session = CallSession(
+        call_id="call-deepgram-handoff",
+        caller_channel_id="caller-deepgram-handoff",
+        context_name="support",
+        provider_name="deepgram",
+    )
+    session.pending_deferred_transfer = {
+        "kind": "transfer",
+        "commit_tool": "blind_transfer",
+        "transfer_type": "extension",
+        "target": "6000",
+        "description": "Support agent",
+    }
+    await engine.session_store.upsert_call(session)
+
+    calls = []
+
+    async def fake_tts(*, call_id, text, timeout_sec):
+        calls.append(("tts", call_id, text))
+        return b"\xff" * 1600
+
+    async def fake_wait(call_id):
+        calls.append(("drain", call_id))
+        return True
+
+    async def fake_commit(context):
+        calls.append(("commit", context.call_id))
+        return {"status": "success", "message": "ok"}
+
+    class _Playback:
+        async def play_audio(self, call_id, audio, playback_type):
+            calls.append(("play", call_id, playback_type, len(audio)))
+            return "pb-handoff"
+
+        async def wait_for_playback_end(self, call_id, playback_id, *, timeout_sec):
+            calls.append(("wait-playback", call_id, playback_id))
+            return True
+
+    engine.playback_manager = _Playback()
+    monkeypatch.setattr(engine, "_local_ai_server_tts", fake_tts)
+    monkeypatch.setattr(engine, "_wait_for_deferred_transfer_audio_drain", fake_wait)
+    monkeypatch.setattr(
+        "src.tools.telephony.deferred_transfer.commit_pending_deferred_transfer",
+        fake_commit,
+    )
+
+    result = await engine._commit_pending_deferred_transfer_for_call("call-deepgram-handoff", session)
+
+    assert result == {"status": "success", "message": "ok"}
+    assert calls == [
+        ("tts", "call-deepgram-handoff", "Transferring you to Support agent now."),
+        ("play", "call-deepgram-handoff", "transfer-handoff", 1600),
+        ("wait-playback", "call-deepgram-handoff", "pb-handoff"),
+        ("drain", "call-deepgram-handoff"),
+        ("commit", "call-deepgram-handoff"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_deferred_transfer_audio_drain_waits_for_streaming_buffer():
     engine = _build_engine({"enabled": True})
     engine.config.tools["transfer"]["deferred_audio_drain_timeout_sec"] = 1.0

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -487,6 +487,47 @@ async def test_deferred_transfer_audio_drain_waits_for_streaming_buffer():
 
 
 @pytest.mark.asyncio
+async def test_predial_transfer_finalize_removes_ai_media_and_bridges_destination():
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial",
+        caller_channel_id="caller-predial",
+        bridge_id="bridge-predial",
+        audiosocket_channel_id="audiosocket-predial",
+        external_media_id="rtp-predial",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "predial_channel_id": "SIP/6000-00000001",
+    }
+    await engine.session_store.upsert_call(session)
+    engine.ari_client.remove_channel_from_bridge = types.MethodType(
+        lambda self, bridge_id, channel_id: asyncio.sleep(0, result=True),
+        engine.ari_client,
+    )
+    engine.ari_client.add_channel_to_bridge = types.MethodType(
+        lambda self, bridge_id, channel_id: asyncio.sleep(0, result=True),
+        engine.ari_client,
+    )
+    engine.ari_client.send_command = types.MethodType(
+        lambda self, **kwargs: asyncio.sleep(0, result={"status": 204}),
+        engine.ari_client,
+    )
+
+    ok = await engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000001")
+
+    assert ok is True
+    updated = await engine.session_store.get_by_call_id("call-predial")
+    assert updated.current_action["bridged"] is True
+    assert updated.current_action["channel_id"] == "SIP/6000-00000001"
+    assert updated.transfer_state == "bridged"
+    assert updated.transfer_destination == "Support agent"
+
+
+@pytest.mark.asyncio
 async def test_attended_transfer_ai_briefing_falls_back_to_basic_tts_when_generation_unavailable(monkeypatch):
     engine = _build_engine(
         {

--- a/tests/test_attended_transfer_streaming.py
+++ b/tests/test_attended_transfer_streaming.py
@@ -528,6 +528,72 @@ async def test_predial_transfer_finalize_removes_ai_media_and_bridges_destinatio
 
 
 @pytest.mark.asyncio
+async def test_predial_transfer_bridges_before_slow_provider_shutdown():
+    engine = _build_engine({"enabled": True})
+    session = CallSession(
+        call_id="call-predial-fast",
+        caller_channel_id="caller-predial-fast",
+        bridge_id="bridge-predial-fast",
+        audiosocket_channel_id="audiosocket-predial-fast",
+        external_media_id="rtp-predial-fast",
+        provider_name="google_live",
+    )
+    session.current_action = {
+        "type": "predial_transfer",
+        "target": "6000",
+        "target_name": "Support agent",
+        "answered": True,
+        "predial_channel_id": "SIP/6000-00000002",
+    }
+    await engine.session_store.upsert_call(session)
+
+    order = []
+    stop_started = asyncio.Event()
+    stop_release = asyncio.Event()
+    stop_done = asyncio.Event()
+
+    class SlowProvider:
+        async def stop_session(self):
+            order.append("provider-stop-start")
+            stop_started.set()
+            await stop_release.wait()
+            order.append("provider-stop-done")
+            stop_done.set()
+
+    engine._call_providers["call-predial-fast"] = SlowProvider()
+
+    async def fake_remove(self, bridge_id, channel_id):
+        order.append(f"remove:{channel_id}")
+        return True
+
+    async def fake_add(self, bridge_id, channel_id):
+        order.append(f"add:{channel_id}")
+        return True
+
+    engine.ari_client.remove_channel_from_bridge = types.MethodType(fake_remove, engine.ari_client)
+    engine.ari_client.add_channel_to_bridge = types.MethodType(fake_add, engine.ari_client)
+    engine.ari_client.send_command = types.MethodType(
+        lambda self, **kwargs: asyncio.sleep(0, result={"status": 204}),
+        engine.ari_client,
+    )
+
+    ok = await engine._finalize_predial_transfer_bridge(session, "SIP/6000-00000002")
+
+    assert ok is True
+    assert order[:3] == [
+        "remove:rtp-predial-fast",
+        "remove:audiosocket-predial-fast",
+        "add:SIP/6000-00000002",
+    ]
+    assert "provider-stop-done" not in order
+
+    await asyncio.wait_for(stop_started.wait(), timeout=1)
+    stop_release.set()
+    await asyncio.wait_for(stop_done.wait(), timeout=1)
+    assert order[-1] == "provider-stop-done"
+
+
+@pytest.mark.asyncio
 async def test_attended_transfer_ai_briefing_falls_back_to_basic_tts_when_generation_unavailable(monkeypatch):
     engine = _build_engine(
         {

--- a/tests/test_attended_transfer_tool.py
+++ b/tests/test_attended_transfer_tool.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.core.models import CallSession
+from src.tools.telephony.deferred_transfer import DEFERRED_TRANSFER_RESULT_KEY
 from src.tools.telephony.attended_transfer import AttendedTransferTool
 
 
@@ -125,6 +126,46 @@ def test_resolve_dial_endpoint_honors_dial_string_then_internal_mapping_then_tec
 
 
 @pytest.mark.asyncio
+async def test_execute_deferred_attended_transfer_arms_pending_action_without_originate():
+    tool = AttendedTransferTool()
+    call_id = "1760000000.0003"
+    session = CallSession(call_id=call_id, caller_channel_id=call_id)
+    ari = _FakeAriClient(originate_response={"id": "agent-chan-3"})
+    context = _FakeContext(
+        config={
+            "asterisk": {"app_name": "asterisk-ai-voice-agent"},
+            "tools": {
+                "attended_transfer": {"enabled": True, "moh_class": "default", "dial_timeout_seconds": 30},
+                "transfer": {
+                    "defer_until_playback_complete": True,
+                    "technology": "SIP",
+                    "destinations": {
+                        "support_agent": {
+                            "type": "extension",
+                            "target": "6000",
+                            "description": "Support agent",
+                            "attended_allowed": True,
+                        }
+                    },
+                },
+            },
+        },
+        caller_channel_id=call_id,
+        ari_client=ari,
+        session=session,
+    )
+
+    result = await tool.execute({"destination": "support_agent"}, context)
+
+    assert result["status"] == "success"
+    assert result["defer_until_playback_complete"] is True
+    assert result[DEFERRED_TRANSFER_RESULT_KEY]["commit_tool"] == "attended_transfer"
+    assert session.pending_deferred_transfer["target"] == "6000"
+    assert session.current_action is None
+    assert ari.calls == []
+
+
+@pytest.mark.asyncio
 async def test_execute_success_sets_action_and_originates_agent_leg():
     tool = AttendedTransferTool()
     call_id = "1760000000.0000"
@@ -137,6 +178,7 @@ async def test_execute_success_sets_action_and_originates_agent_leg():
                 "ai_identity": {"name": "Ava", "number": "6789"},
                 "attended_transfer": {"enabled": True, "moh_class": "default", "dial_timeout_seconds": 30},
                 "transfer": {
+                    "defer_until_playback_complete": False,
                     "technology": "SIP",
                     "destinations": {
                         "support_agent": {
@@ -179,6 +221,7 @@ async def test_execute_originate_failure_stops_moh_and_clears_action():
             "tools": {
                 "attended_transfer": {"enabled": True, "moh_class": "default", "dial_timeout_seconds": 1},
                 "transfer": {
+                    "defer_until_playback_complete": False,
                     "technology": "SIP",
                     "destinations": {
                         "support_agent": {
@@ -224,6 +267,7 @@ async def test_execute_caller_recording_mode_stages_transfer_before_originate():
                     "caller_screening_silence_ms": 1200,
                 },
                 "transfer": {
+                    "defer_until_playback_complete": False,
                     "technology": "SIP",
                     "destinations": {
                         "support_agent": {

--- a/tests/test_continuous_stream.py
+++ b/tests/test_continuous_stream.py
@@ -82,7 +82,10 @@ def test_first_segment_releases_short_audio_after_producer_closes():
         'target_sample_rate': 8000,
     }
     jitter = asyncio.Queue()
-    jitter.put_nowait(b"\xff" * 160)
+    payload = b"\xff" * 80
+    stream_info["buffered_bytes"] = len(payload)
+    mgr.active_streams[call_id] = stream_info
+    jitter.put_nowait(payload)
 
     ready = mgr._ensure_startup_ready(call_id, stream_id, jitter, stream_info)
 

--- a/tests/test_continuous_stream.py
+++ b/tests/test_continuous_stream.py
@@ -69,6 +69,28 @@ def test_first_segment_requires_min_start_when_empty():
     assert mgr._startup_ready.get(call_id) is False
 
 
+def test_first_segment_releases_short_audio_after_producer_closes():
+    mgr = make_manager()
+    call_id = "test-call-short"
+    stream_id = "stream:resp:test-call-short:1"
+    mgr._startup_ready[call_id] = False
+    stream_info = {
+        'segments_played': 0,
+        'min_start_chunks': 7,
+        'producer_closed': True,
+        'target_format': 'ulaw',
+        'target_sample_rate': 8000,
+    }
+    jitter = asyncio.Queue()
+    jitter.put_nowait(b"\xff" * 160)
+
+    ready = mgr._ensure_startup_ready(call_id, stream_id, jitter, stream_info)
+
+    assert ready is True
+    assert mgr._startup_ready.get(call_id) is True
+    assert stream_info.get('startup_ready') is True
+
+
 @pytest.mark.asyncio
 async def test_mark_segment_boundary_increments_and_resets_attack():
     mgr = make_manager()

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -161,6 +161,9 @@ def tool_config():
                     }
                 }
             },
+            "transfer": {
+                "defer_until_playback_complete": False,
+            },
             "ai_identity": {
                 "name": "AI Agent",
                 "number": "6789"

--- a/tests/tools/telephony/test_cancel_transfer_tool.py
+++ b/tests/tools/telephony/test_cancel_transfer_tool.py
@@ -9,7 +9,7 @@ Tests cancel transfer functionality including:
 """
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 from src.tools.telephony.cancel_transfer import CancelTransferTool
 
 
@@ -94,6 +94,74 @@ class TestCancelTransferTool:
         # Get updated session
         updated_session = mock_session_store.upsert_call.call_args[0][0]
         assert updated_session.current_action is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_deferred_transfer(
+        self, cancel_tool, tool_context, sample_call_session, mock_session_store, mock_ari_client
+    ):
+        """Test canceling a deferred transfer before playback drain commits it."""
+        sample_call_session.current_action = None
+        sample_call_session.pending_deferred_transfer = {
+            "id": "deferred-transfer",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support agent",
+        }
+
+        result = await cancel_tool.execute(
+            parameters={},
+            context=tool_context
+        )
+
+        assert result["status"] == "success"
+        mock_ari_client.hangup_channel.assert_not_called()
+        updated_session = mock_session_store.upsert_call.call_args[0][0]
+        assert updated_session.current_action is None
+        assert updated_session.pending_deferred_transfer is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_predial_deferred_transfer_hangs_up_leg(
+        self, cancel_tool, tool_context, sample_call_session, mock_session_store, mock_ari_client
+    ):
+        """Test canceling a deferred predial transfer before it bridges to the caller."""
+        sample_call_session.current_action = {
+            "type": "predial_transfer",
+            "answered": True,
+            "bridged": False,
+            "predial_channel_id": "SIP/6000-00000004",
+        }
+        sample_call_session.pending_deferred_transfer = {
+            "id": "predial-deferred-transfer",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support agent",
+            "payload": {
+                "predial": {
+                    "enabled": True,
+                    "channel_id": "SIP/6000-00000004",
+                }
+            },
+        }
+        engine = Mock()
+        mock_ari_client.engine = engine
+
+        result = await cancel_tool.execute(
+            parameters={},
+            context=tool_context
+        )
+
+        assert result["status"] == "success"
+        engine._unregister_predial_transfer_channel.assert_called_once_with("SIP/6000-00000004")
+        mock_ari_client.hangup_channel.assert_awaited_once_with("SIP/6000-00000004")
+        updated_session = mock_session_store.upsert_call.call_args[0][0]
+        assert updated_session.current_action is None
+        assert updated_session.pending_deferred_transfer is None
     
     @pytest.mark.asyncio
     async def test_cancel_stops_hold_music(

--- a/tests/tools/telephony/test_live_agent_transfer_tool.py
+++ b/tests/tools/telephony/test_live_agent_transfer_tool.py
@@ -273,13 +273,12 @@ class TestLiveAgentTransferTool:
         assert call_args["params"]["extension"] == "7007"
 
     @pytest.mark.asyncio
-    async def test_ignores_misconfigured_live_agent_destination_key_and_uses_internal_extension(
+    async def test_explicit_destination_override_does_not_require_live_agent_flag(
         self, tool, tool_context, mock_ari_client
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
             "defer_until_playback_complete": False,
-            # Misconfigured: points at a normal destination (not marked live_agent).
             "live_agent_destination_key": "support_agent",
             "destinations": {
                 "support_agent": {"type": "extension", "target": "2765", "description": "Support agent"},
@@ -294,10 +293,10 @@ class TestLiveAgentTransferTool:
         result = await tool.execute({}, tool_context)
 
         assert result["status"] == "success"
-        assert result["destination"] == "6000"
+        assert result["destination"] == "2765"
         call_args = mock_ari_client.send_command.call_args.kwargs
         assert call_args["resource"] == f"channels/{tool_context.caller_channel_id}/continue"
-        assert call_args["params"]["extension"] == "6000"
+        assert call_args["params"]["extension"] == "2765"
 
     @pytest.mark.asyncio
     async def test_prefers_internal_live_agents_over_destination_live_agent_flag_when_no_explicit_override(
@@ -351,13 +350,12 @@ class TestLiveAgentTransferTool:
         assert call_args["params"]["extension"] == "6000"
 
     @pytest.mark.asyncio
-    async def test_misconfigured_destination_override_does_not_prevent_destination_fallback_scan(
+    async def test_explicit_destination_override_wins_without_live_agent_flag(
         self, tool, tool_context, mock_ari_client
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
             "defer_until_playback_complete": False,
-            # Misconfigured: points to non-live destination.
             "live_agent_destination_key": "support_agent",
             "destinations": {
                 "support_agent": {"type": "extension", "target": "2765", "description": "Support agent"},
@@ -370,10 +368,38 @@ class TestLiveAgentTransferTool:
         result = await tool.execute({}, tool_context)
 
         assert result["status"] == "success"
-        assert result["destination"] == "6000"
+        assert result["destination"] == "2765"
         call_args = mock_ari_client.send_command.call_args.kwargs
         assert call_args["resource"] == f"channels/{tool_context.caller_channel_id}/continue"
-        assert call_args["params"]["extension"] == "6000"
+        assert call_args["params"]["extension"] == "2765"
+
+    @pytest.mark.asyncio
+    async def test_explicit_destination_override_supports_ringgroup(
+        self, tool, tool_context, mock_ari_client
+    ):
+        tool_context.config["tools"]["transfer"] = {
+            "enabled": True,
+            "defer_until_playback_complete": False,
+            "live_agent_destination_key": "after_hours_group",
+            "destinations": {
+                "after_hours_group": {
+                    "type": "ringgroup",
+                    "target": "600",
+                    "description": "After-hours ring group",
+                },
+            },
+        }
+        tool_context.config["tools"]["extensions"] = {"internal": {}}
+
+        result = await tool.execute({}, tool_context)
+
+        assert result["status"] == "success"
+        assert result["destination"] == "600"
+        assert result["type"] == "ringgroup"
+        call_args = mock_ari_client.send_command.call_args.kwargs
+        assert call_args["resource"] == f"channels/{tool_context.caller_channel_id}/continue"
+        assert call_args["params"]["context"] == "ext-group"
+        assert call_args["params"]["extension"] == "600"
 
     @pytest.mark.asyncio
     async def test_fails_when_internal_live_agents_are_ambiguous_even_if_destination_live_agent_exists(

--- a/tests/tools/telephony/test_live_agent_transfer_tool.py
+++ b/tests/tools/telephony/test_live_agent_transfer_tool.py
@@ -25,6 +25,7 @@ class TestLiveAgentTransferTool:
     async def test_uses_explicit_live_agent_destination_key(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "live_agent_destination_key": "tier2_live",
             "destinations": {
                 "sales_agent": {"type": "extension", "target": "2765", "description": "Sales"},
@@ -91,6 +92,7 @@ class TestLiveAgentTransferTool:
     async def test_destination_override_takes_precedence_over_explicit_target(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "live_agent_destination_key": "tier2_live",
             "destinations": {
                 "tier2_live": {"type": "extension", "target": "6000", "description": "Tier 2", "live_agent": True},
@@ -176,6 +178,7 @@ class TestLiveAgentTransferTool:
     async def test_falls_back_to_live_agent_key_when_config_not_set(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {
                 "live_agent": {"type": "extension", "target": "6001", "description": "Live Agent"},
             },
@@ -195,6 +198,7 @@ class TestLiveAgentTransferTool:
     async def test_fails_when_live_agent_destination_not_configured(self, tool, tool_context):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {
                 "sales_agent": {"type": "extension", "target": "2765", "description": "Sales"},
             },
@@ -215,6 +219,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {
                 "support_agent": {"type": "extension", "target": "6000", "description": "Support agent"},
                 "live_agent": {"type": "extension", "target": "6000", "description": "Live Agent"},
@@ -245,6 +250,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {},
         }
         tool_context.config["tools"]["extensions"] = {
@@ -272,6 +278,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             # Misconfigured: points at a normal destination (not marked live_agent).
             "live_agent_destination_key": "support_agent",
             "destinations": {
@@ -298,6 +305,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {
                 "tier2_live": {"type": "extension", "target": "6000", "description": "Tier 2", "live_agent": True},
             },
@@ -322,6 +330,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "live_agent_destination_key": "tier2_live",
             "destinations": {
                 "tier2_live": {"type": "extension", "target": "6000", "description": "Tier 2", "live_agent": True},
@@ -347,6 +356,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             # Misconfigured: points to non-live destination.
             "live_agent_destination_key": "support_agent",
             "destinations": {
@@ -371,6 +381,7 @@ class TestLiveAgentTransferTool:
     ):
         tool_context.config["tools"]["transfer"] = {
             "enabled": True,
+            "defer_until_playback_complete": False,
             "destinations": {
                 "tier2_live": {"type": "extension", "target": "6000", "description": "Tier 2", "live_agent": True},
             },

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -222,6 +222,32 @@ class TestUnifiedTransferTool:
         assert call_args["params"]["extension"] == "301"
 
     @pytest.mark.asyncio
+    async def test_direct_queue_transfer_without_context_uses_default_context(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["transfer"] = {
+            "queue_context": "custom-queues",
+        }
+
+        result = await tool._transfer_to_queue(tool_context, "301", "Support Queue")
+
+        assert result["status"] == "success"
+        call_args = mock_ari_client.send_command.call_args.kwargs
+        assert call_args["params"]["context"] == "custom-queues"
+        assert call_args["params"]["extension"] == "301"
+
+    @pytest.mark.asyncio
+    async def test_direct_ringgroup_transfer_without_context_uses_default_context(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["transfer"] = {
+            "ringgroup_context": "custom-groups",
+        }
+
+        result = await tool._transfer_to_ringgroup(tool_context, "600", "Support Ring Group")
+
+        assert result["status"] == "success"
+        call_args = mock_ari_client.send_command.call_args.kwargs
+        assert call_args["params"]["context"] == "custom-groups"
+        assert call_args["params"]["extension"] == "600"
+
+    @pytest.mark.asyncio
     async def test_human_intent_without_extension_destination_fails(self, tool, tool_context):
         tool_context.config["tools"]["transfer"] = {
             "destinations": {

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -143,9 +143,12 @@ class TestUnifiedTransferTool:
         assert tool_context.session_store.get_by_call_id.return_value.current_action["type"] == "predial_transfer"
         call_args = mock_ari_client.send_command.call_args.kwargs
         assert call_args["resource"] == "channels"
-        assert call_args["data"]["endpoint"] == "Local/6000@from-support"
-        assert call_args["data"]["callerId"] == '"WIRELESS CALLER" <13164619284>'
+        assert "data" not in call_args or call_args["data"] is None
+        assert call_args["params"]["endpoint"] == "Local/6000@from-support"
+        assert call_args["params"]["callerId"] == '"WIRELESS CALLER" <13164619284>'
+        assert call_args["params"]["timeout"] == 12
         assert call_args["params"]["appArgs"].startswith("predial-transfer,test_call_123,support_agent")
+        assert call_args["params"]["channelVars"]["AGENT_ACTION"] == "predial_transfer"
         engine.register_predial_transfer_channel.assert_called_once_with("test_call_123", "SIP/6000-00000001")
 
     @pytest.mark.asyncio

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -3,6 +3,7 @@ Unit tests for UnifiedTransferTool destination resolution.
 """
 
 import pytest
+from unittest.mock import AsyncMock, Mock
 
 from src.tools.telephony.deferred_transfer import DEFERRED_TRANSFER_RESULT_KEY
 from src.tools.telephony.unified_transfer import UnifiedTransferTool
@@ -110,6 +111,64 @@ class TestUnifiedTransferTool:
         assert result[DEFERRED_TRANSFER_RESULT_KEY]["dialplan_context"] == "from-support"
         assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer["target"] == "6000"
         mock_ari_client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_predial_strategy_originates_local_leg_during_deferral(self, tool, tool_context, mock_ari_client):
+        engine = Mock()
+        engine.register_predial_transfer_channel = Mock()
+        mock_ari_client.engine = engine
+        tool_context.config["tools"]["transfer"] = {
+            "deferred_strategy": "predial_then_bridge",
+            "extension_context": "from-internal",
+            "predial_timeout_seconds": 12,
+            "destinations": {
+                "support_agent": {
+                    "type": "extension",
+                    "target": "6000",
+                    "description": "Support Agent",
+                    "dialplan_context": "from-support",
+                }
+            },
+        }
+
+        result = await tool.execute({"destination": "support_agent"}, tool_context)
+
+        assert result["status"] == "success"
+        action = result[DEFERRED_TRANSFER_RESULT_KEY]
+        assert action["payload"]["predial"]["enabled"] is True
+        assert action["payload"]["predial"]["endpoint"] == "Local/6000@from-support"
+        assert tool_context.session_store.get_by_call_id.return_value.current_action["type"] == "predial_transfer"
+        call_args = mock_ari_client.send_command.call_args.kwargs
+        assert call_args["resource"] == "channels"
+        assert call_args["data"]["endpoint"] == "Local/6000@from-support"
+        assert call_args["params"]["appArgs"].startswith("predial-transfer,test_call_123,support_agent")
+        engine.register_predial_transfer_channel.assert_called_once_with("test_call_123", "SIP/6000-00000001")
+
+    @pytest.mark.asyncio
+    async def test_commit_predial_uses_engine_finalize(self, tool, tool_context, mock_ari_client):
+        engine = Mock()
+        engine.finalize_predial_transfer = AsyncMock(
+            return_value={"status": "success", "strategy": "predial_then_bridge"}
+        )
+        mock_ari_client.engine = engine
+        action = {
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+            "payload": {
+                "predial": {
+                    "enabled": True,
+                    "endpoint": "Local/6000@from-internal",
+                    "channel_id": "SIP/6000-00000001",
+                }
+            },
+        }
+
+        result = await tool.commit_deferred_action(action, tool_context)
+
+        assert result == {"status": "success", "strategy": "predial_then_bridge"}
+        engine.finalize_predial_transfer.assert_awaited_once_with(tool_context, action)
 
     @pytest.mark.asyncio
     async def test_commit_deferred_queue_uses_destination_context(self, tool, tool_context, mock_ari_client):

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -117,6 +117,8 @@ class TestUnifiedTransferTool:
         engine = Mock()
         engine.register_predial_transfer_channel = Mock()
         mock_ari_client.engine = engine
+        tool_context.caller_name = "WIRELESS CALLER"
+        tool_context.caller_number = "13164619284"
         tool_context.config["tools"]["transfer"] = {
             "deferred_strategy": "predial_then_bridge",
             "extension_context": "from-internal",
@@ -141,6 +143,7 @@ class TestUnifiedTransferTool:
         call_args = mock_ari_client.send_command.call_args.kwargs
         assert call_args["resource"] == "channels"
         assert call_args["data"]["endpoint"] == "Local/6000@from-support"
+        assert call_args["data"]["callerId"] == '"WIRELESS CALLER" <13164619284>'
         assert call_args["params"]["appArgs"].startswith("predial-transfer,test_call_123,support_agent")
         engine.register_predial_transfer_channel.assert_called_once_with("test_call_123", "SIP/6000-00000001")
 

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -148,6 +148,38 @@ class TestUnifiedTransferTool:
         engine.register_predial_transfer_channel.assert_called_once_with("test_call_123", "SIP/6000-00000001")
 
     @pytest.mark.asyncio
+    async def test_duplicate_deferred_transfer_reuses_pending_action(self, tool, tool_context, mock_ari_client):
+        existing_action = {
+            "id": "existing-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer = existing_action
+        tool_context.config["tools"]["transfer"] = {
+            "deferred_strategy": "predial_then_bridge",
+            "extension_context": "from-internal",
+            "destinations": {
+                "support_agent": {
+                    "type": "extension",
+                    "target": "6000",
+                    "description": "Support Agent",
+                }
+            },
+        }
+
+        result = await tool.execute({"destination": "support_agent"}, tool_context)
+
+        assert result["status"] == "success"
+        assert result["duplicate_suppressed"] is True
+        assert result[DEFERRED_TRANSFER_RESULT_KEY] == existing_action
+        mock_ari_client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_commit_predial_uses_engine_finalize(self, tool, tool_context, mock_ari_client):
         engine = Mock()
         engine.finalize_predial_transfer = AsyncMock(

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -5,6 +5,7 @@ Unit tests for UnifiedTransferTool destination resolution.
 import pytest
 from unittest.mock import AsyncMock, Mock
 
+from src.tools.telephony import deferred_transfer as deferred_transfer_mod
 from src.tools.telephony.deferred_transfer import DEFERRED_TRANSFER_RESULT_KEY
 from src.tools.telephony.unified_transfer import UnifiedTransferTool
 
@@ -178,6 +179,85 @@ class TestUnifiedTransferTool:
         assert result["duplicate_suppressed"] is True
         assert result[DEFERRED_TRANSFER_RESULT_KEY] == existing_action
         mock_ari_client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_conflicting_deferred_transfer_request_does_not_reuse_pending_action(self, tool, tool_context, mock_ari_client):
+        existing_action = {
+            "id": "existing-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer = existing_action
+        tool_context.config["tools"]["transfer"] = {
+            "extension_context": "from-internal",
+            "destinations": {
+                "billing_agent": {
+                    "type": "extension",
+                    "target": "7000",
+                    "description": "Billing Agent",
+                }
+            },
+        }
+
+        result = await tool.execute({"destination": "billing_agent"}, tool_context)
+
+        assert result["status"] == "failed"
+        assert "already pending" in result["message"]
+        assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer == existing_action
+        mock_ari_client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_pending_deferred_transfer_commit_keeps_action_for_retry(self, tool_context, monkeypatch):
+        action = {
+            "id": "retry-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer = dict(action)
+
+        async def fake_commit(action_arg, context_arg):
+            return {"status": "error", "message": "temporary failure"}
+
+        monkeypatch.setattr(deferred_transfer_mod, "commit_deferred_transfer_action", fake_commit)
+
+        result = await deferred_transfer_mod.commit_pending_deferred_transfer(tool_context)
+
+        assert result == {"status": "error", "message": "temporary failure"}
+        assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer == action
+
+    @pytest.mark.asyncio
+    async def test_successful_pending_deferred_transfer_commit_clears_action(self, tool_context, monkeypatch):
+        action = {
+            "id": "success-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer = dict(action)
+
+        async def fake_commit(action_arg, context_arg):
+            return {"status": "success", "message": "ok"}
+
+        monkeypatch.setattr(deferred_transfer_mod, "commit_deferred_transfer_action", fake_commit)
+
+        result = await deferred_transfer_mod.commit_pending_deferred_transfer(tool_context)
+
+        assert result == {"status": "success", "message": "ok"}
+        assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer is None
 
     @pytest.mark.asyncio
     async def test_commit_predial_uses_engine_finalize(self, tool, tool_context, mock_ari_client):

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -4,6 +4,7 @@ Unit tests for UnifiedTransferTool destination resolution.
 
 import pytest
 
+from src.tools.telephony.deferred_transfer import DEFERRED_TRANSFER_RESULT_KEY
 from src.tools.telephony.unified_transfer import UnifiedTransferTool
 
 
@@ -21,6 +22,7 @@ class TestUnifiedTransferTool:
     @pytest.mark.asyncio
     async def test_resolves_destination_by_description_match(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["transfer"] = {
+            "defer_until_playback_complete": False,
             "destinations": {
                 "tier2_desk": {
                     "type": "extension",
@@ -43,6 +45,7 @@ class TestUnifiedTransferTool:
     @pytest.mark.asyncio
     async def test_human_intent_maps_to_single_extension_destination(self, tool, tool_context):
         tool_context.config["tools"]["transfer"] = {
+            "defer_until_playback_complete": False,
             "destinations": {
                 "frontdesk": {
                     "type": "extension",
@@ -66,6 +69,7 @@ class TestUnifiedTransferTool:
     @pytest.mark.asyncio
     async def test_resolves_destination_by_exact_target_number(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["transfer"] = {
+            "defer_until_playback_complete": False,
             "destinations": {
                 "support_agent": {
                     "type": "extension",
@@ -84,6 +88,44 @@ class TestUnifiedTransferTool:
         call_args = mock_ari_client.send_command.call_args.kwargs
         assert call_args["resource"] == f"channels/{tool_context.caller_channel_id}/continue"
         assert call_args["params"]["extension"] == "6000"
+
+    @pytest.mark.asyncio
+    async def test_default_defers_transfer_and_stores_destination_context(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["transfer"] = {
+            "extension_context": "from-internal",
+            "destinations": {
+                "support_agent": {
+                    "type": "extension",
+                    "target": "6000",
+                    "description": "Support Agent",
+                    "dialplan_context": "from-support",
+                }
+            },
+        }
+
+        result = await tool.execute({"destination": "support_agent"}, tool_context)
+
+        assert result["status"] == "success"
+        assert result["defer_until_playback_complete"] is True
+        assert result[DEFERRED_TRANSFER_RESULT_KEY]["dialplan_context"] == "from-support"
+        assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer["target"] == "6000"
+        mock_ari_client.send_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_commit_deferred_queue_uses_destination_context(self, tool, tool_context, mock_ari_client):
+        action = {
+            "transfer_type": "queue",
+            "target": "301",
+            "description": "Support Queue",
+            "dialplan_context": "custom-queues",
+        }
+
+        result = await tool.commit_deferred_action(action, tool_context)
+
+        assert result["status"] == "success"
+        call_args = mock_ari_client.send_command.call_args.kwargs
+        assert call_args["params"]["context"] == "custom-queues"
+        assert call_args["params"]["extension"] == "301"
 
     @pytest.mark.asyncio
     async def test_human_intent_without_extension_destination_fails(self, tool, tool_context):

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -260,6 +260,33 @@ class TestUnifiedTransferTool:
         assert tool_context.session_store.get_by_call_id.return_value.pending_deferred_transfer is None
 
     @pytest.mark.asyncio
+    async def test_successful_pending_deferred_transfer_commit_does_not_resurrect_removed_session(self, tool_context, monkeypatch):
+        action = {
+            "id": "cleanup-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        session = tool_context.session_store.get_by_call_id.return_value
+        session.pending_deferred_transfer = dict(action)
+        tool_context.session_store.get_by_call_id.side_effect = [session, None]
+        tool_context.session_store.upsert_call.reset_mock()
+
+        async def fake_commit(action_arg, context_arg):
+            return {"status": "success", "message": "ok"}
+
+        monkeypatch.setattr(deferred_transfer_mod, "commit_deferred_transfer_action", fake_commit)
+
+        result = await deferred_transfer_mod.commit_pending_deferred_transfer(tool_context)
+
+        assert result == {"status": "success", "message": "ok"}
+        tool_context.session_store.upsert_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_commit_predial_uses_engine_finalize(self, tool, tool_context, mock_ari_client):
         engine = Mock()
         engine.finalize_predial_transfer = AsyncMock(

--- a/tests/tools/telephony/test_unified_transfer_tool.py
+++ b/tests/tools/telephony/test_unified_transfer_tool.py
@@ -287,6 +287,33 @@ class TestUnifiedTransferTool:
         tool_context.session_store.upsert_call.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_failed_pending_deferred_transfer_commit_does_not_resurrect_removed_session(self, tool_context, monkeypatch):
+        action = {
+            "id": "cleanup-error-action",
+            "kind": "transfer",
+            "source_tool": "blind_transfer",
+            "commit_tool": "blind_transfer",
+            "transfer_type": "extension",
+            "target": "6000",
+            "description": "Support Agent",
+            "dialplan_context": "from-internal",
+        }
+        session = tool_context.session_store.get_by_call_id.return_value
+        session.pending_deferred_transfer = dict(action)
+        tool_context.session_store.get_by_call_id.side_effect = [session, None]
+        tool_context.session_store.upsert_call.reset_mock()
+
+        async def fake_commit(action_arg, context_arg):
+            raise RuntimeError("channel gone")
+
+        monkeypatch.setattr(deferred_transfer_mod, "commit_deferred_transfer_action", fake_commit)
+
+        result = await deferred_transfer_mod.commit_pending_deferred_transfer(tool_context)
+
+        assert result == {"status": "error", "message": "channel gone"}
+        tool_context.session_store.upsert_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_commit_predial_uses_engine_finalize(self, tool, tool_context, mock_ari_client):
         engine = Mock()
         engine.finalize_predial_transfer = AsyncMock(


### PR DESCRIPTION
## Summary
- add deferred transfer execution for blind, live-agent, and attended transfer flows so caller-facing handoff audio can finish before transfer commit
- add destination-level dialplan context routing for extensions, queues, and ring groups, with UI/config/docs coverage
- add predial-then-bridge support, Deepgram deterministic handoff audio, duplicate suppression, caller-ID propagation, and streaming stop cleanup

Fixes #479.

## Reporter comment coverage
- Preserves named destination transfers through `blind_transfer` and improves destination/target matching.
- Keeps `live_agent_transfer` scoped to a single configured/default live-agent route, while named destinations remain a `blind_transfer` path.
- Supports queue and ring group destinations through the same destination-level `dialplan_context` handling used by extensions.
- Replaces fixed pre-transfer delay behavior with deferred playback drain/commit, plus predial bridging for lower answer-to-audio delay.

## Validation
- `62 passed`: `tests/tools/telephony/test_unified_transfer_tool.py`, `tests/tools/telephony/test_live_agent_transfer_tool.py`, `tests/test_attended_transfer_tool.py`, `tests/test_attended_transfer_streaming.py`, `tests/test_continuous_stream.py`, `tests/test_tool_adapter_allowlist.py`
- `py_compile`: transfer tools, engine, streaming playback manager
- Deployed and smoke-tested on voiprnd with AudioSocket; Google/OpenAI/Deepgram provider readiness verified after restart


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “defer transfer until playback completes” for unified and attended transfers, including predial-then-bridge.
  * Expanded transfer configuration with deferred/predial timing, MOH options, and per-transfer-type dialplan context defaults/overrides.
  * Updated admin Transfer UI with channel/strategy options, improved destination selection, and dialplan-context display.

* **Bug Fixes**
  * Improved continuous-stream warmup for short final segments; improved streaming stop with draining support.
  * Hardened predial transfer finalization/cleanup and safer deferred-transfer commit behavior.

* **Documentation**
  * Updated tool calling guide for deferred execution and dialplan context precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->