### PR TITLE
Google Live: persist resample state across chunks (split from #441)

### DIFF
--- a/src/providers/google_live.py
+++ b/src/providers/google_live.py
@@ -718,6 +718,10 @@ class GoogleLiveProvider(AIProviderInterface):
         self._last_final_assistant_text = ""
         self._last_input_transcription_fragment = ""
         self._last_output_transcription_fragment = ""
+        # Reset resampler state for new session (prevents stale FIR/phase
+        # state from a previous call leaking into this one).
+        self._input_resample_state = None
+        self._output_resample_state = None
         # Per-call tool allowlist (contexts are the source of truth).
         # Missing/None is treated as [] for safety.
         if context and "tools" in context:
@@ -1254,10 +1258,11 @@ class GoogleLiveProvider(AIProviderInterface):
             # Resample to provider's input rate (16kHz for Gemini Live)
             provider_rate = self.config.provider_input_sample_rate_hz
             if src_rate != provider_rate:
-                pcm16_provider, _ = resample_audio(
+                pcm16_provider, self._input_resample_state = resample_audio(
                     pcm16_src,
                     source_rate=src_rate,
                     target_rate=provider_rate,
+                    state=getattr(self, "_input_resample_state", None),
                 )
             else:
                 pcm16_provider = pcm16_src
@@ -1858,10 +1863,11 @@ class GoogleLiveProvider(AIProviderInterface):
                 logger.debug("Failed to emit Google Live output PCM rate log", call_id=self._call_id, exc_info=True)
             
             if provider_output_rate != target_rate:
-                pcm16_target, _ = resample_audio(
+                pcm16_target, self._output_resample_state = resample_audio(
                     pcm16_provider,
                     source_rate=provider_output_rate,
                     target_rate=target_rate,
+                    state=getattr(self, "_output_resample_state", None),
                 )
             else:
                 pcm16_target = pcm16_provider
@@ -2435,6 +2441,10 @@ class GoogleLiveProvider(AIProviderInterface):
             self._model_text_buffer = ""
             self._input_transcription_buffer = ""
             self._output_transcription_buffer = ""
+            # Defensive: clear resampler state on teardown too, in case the
+            # provider instance is pooled/reused without a fresh start_session.
+            self._input_resample_state = None
+            self._output_resample_state = None
             self._closing = False
             self._closed = True
 


### PR DESCRIPTION
## Summary

Fixes audible per-chunk audio pops in the Google Live (Gemini Live) voice path. `resample_audio()`'s returned filter/phase state was discarded on every call (`_, _ = resample_audio(...)`), so each audio chunk was resampled from a cold filter state instead of continuing from the previous chunk's state — producing a pop at every chunk boundary in both the inbound (caller → provider) and outbound (provider → caller) resampling paths.

This PR persists that state across chunks for the lifetime of a session and resets it cleanly at session start and teardown.

This is a narrow split of #441 — the original PR also included a broader FIR-filter rewrite of the shared `resampler.py`. Per maintainer feedback, that rewrite is being split into its own PR; this PR only touches `google_live.py` and changes no resampler internals.


## Related Issue(s)

- GitHub issue(s): #441 (split from)

## Implementation Notes

- Key files touched (code/config/docs):
  - `src/providers/google_live.py`
- High-level design decisions:
  - Added `self._input_resample_state` / `self._output_resample_state` instance attributes, threaded through the existing `resample_audio(...)` calls in the input and output audio paths via a new `state=` kwarg.
  - Both reset to `None` in `start_session()` (fresh session, no stale state) and again on teardown (defensive, in case a provider instance is pooled/reused without a fresh `start_session()`).
  - No changes to `resampler.py`'s resample algorithm itself — this PR only fixes how `google_live.py` calls it.


If you used AVA (project manager persona defined in `AVA.mdc`) to plan this work, summarize the agreed plan briefly.

## Testing

List the tests and checks you performed:

- [x] Integration / manual tests — this exact fix has been running in our production deployment since June 21, 2026 (~1 week of live call traffic) with no reports of per-chunk audio pops since.

For telephony changes, include:

- Test call IDs:
  - 
- Providers/pipelines involved:
  - Google Live (Gemini Live) provider, both inbound and outbound audio resampling
- Brief call behavior summary (any issues, notable findings):
  - 

## Documentation

Which docs were updated (if any)?

- [ ] `docs/contributing/architecture-deep-dive.md`
- [ ] `docs/ROADMAP.md` / `docs/milestones/*`
- [ ] `docs/TOOL_CALLING_GUIDE.md`
- [ ] Provider/tool-specific docs
- [ ] `docs/DEVELOPER_ONBOARDING.md` / other onboarding content

If no docs were needed, explain why.

No docs updated — this is an internal bugfix to existing resampling behavior with no API, config, or architectural surface change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live audio handling so audio quality stays consistent across a session.
  * Fixed resampling behavior for both incoming and outgoing audio streams, helping preserve continuity between chunks.
  * Cleared audio processing state when a session ends to avoid leftover session data affecting future calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->