### PR TITLE
Feature/resampler fir rewrite (split from #441)

### DIFF
--- a/src/audio/resampler.py
+++ b/src/audio/resampler.py
@@ -2,22 +2,44 @@
 Audio resampling and format conversion helpers.
 
 These utilities provide common conversions required when bridging between
-provider audio formats (OpenAI Realtime PCM16 @ 24 kHz, etc.) and the
-AudioSocket expectations (typically μ-law or PCM16 at 8 kHz).
+provider audio formats (OpenAI Realtime PCM16 @ 24 kHz, Google Live PCM16 @
+24 kHz, etc.) and the AudioSocket expectations (typically μ-law or PCM16 at
+8 kHz).
 
-The ``resample_audio`` function uses numpy linear interpolation with exact
-``arange * step`` positioning and 1-sample state carry so that chunk
-boundaries are interpolated correctly — zero crackling.
+``resample_audio`` does two things when downsampling:
+  1. Applies a streaming-safe FIR lowpass (anti-aliasing) filter so that
+     high-frequency content above the new Nyquist (target_rate / 2) is
+     attenuated before decimation. Without this, sibilant/fricative energy
+     (roughly 4-9 kHz) in 24 kHz TTS output folds back into the audible band
+     when decimated straight to 8 kHz, producing a scratchy/fuzzy artifact
+     on "s"/"sh" sounds.
+  2. Performs the original numpy linear interpolation with exact
+     ``arange * step`` positioning and 1-sample state carry so that chunk
+     boundaries are interpolated correctly.
+
+When upsampling or when source_rate == target_rate, the lowpass stage is
+skipped entirely (no aliasing risk in that direction for this project's use
+case) and behavior is identical to before.
 """
-
 from __future__ import annotations
 
 import audioop
 import numpy as np
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 # Default sample width for PCM16 little-endian audio
 _PCM_SAMPLE_WIDTH = 2
+
+# Cache of designed FIR lowpass kernels keyed by (source_rate, target_rate)
+# so we don't recompute the sinc/window design on every chunk.
+_FIR_KERNEL_CACHE: Dict[Tuple[int, int], np.ndarray] = {}
+
+# Number of taps for the anti-aliasing FIR. Odd length -> symmetric kernel
+# with a clean integer group delay of (num_taps - 1) / 2 samples at the
+# source rate. 63 taps gives a reasonably sharp rolloff with negligible
+# CPU cost per chunk and ~1.3ms of added latency at 24kHz (inaudible/
+# irrelevant for telephony jitter budgets).
+_FIR_NUM_TAPS = 31
 
 
 def mulaw_to_pcm16le(data: bytes) -> bytes:
@@ -38,6 +60,30 @@ def pcm16le_to_mulaw(data: bytes) -> bytes:
     return audioop.lin2ulaw(data, _PCM_SAMPLE_WIDTH)
 
 
+def _design_lowpass_kernel(source_rate: int, target_rate: int, num_taps: int = _FIR_NUM_TAPS) -> np.ndarray:
+    """
+    Design a windowed-sinc FIR lowpass filter for anti-aliasing before
+    decimating from source_rate to target_rate.
+
+    Cutoff is placed at 90% of the new Nyquist (target_rate / 2) to leave a
+    guard band before the new Nyquist, expressed as a fraction of the
+    *source* Nyquist for use directly against samples at source_rate.
+    """
+    new_nyquist_hz = target_rate / 2.0
+    cutoff_hz = new_nyquist_hz * 0.9
+    normalized_cutoff = cutoff_hz / (source_rate / 2.0)  # fraction of source Nyquist, 0..1
+    normalized_cutoff = min(max(normalized_cutoff, 1e-6), 0.999)
+
+    n = np.arange(num_taps, dtype=np.float64) - (num_taps - 1) / 2.0
+    h = normalized_cutoff * np.sinc(normalized_cutoff * n)
+    window = np.blackman(num_taps)
+    h *= window
+    h_sum = np.sum(h)
+    if h_sum != 0:
+        h /= h_sum  # unity DC gain
+    return h.astype(np.float64)
+
+
 def resample_audio(
     pcm_bytes: bytes,
     source_rate: int,
@@ -51,64 +97,101 @@ def resample_audio(
     # but are not used by the NumPy interpolation implementation.
     """
     Resample PCM audio between sample rates.
-
-    Uses numpy linear interpolation with exact ``arange * step`` positioning
-    and 1-sample state carry for seamless chunk-by-chunk streaming.
-
-    The state tuple carries ``(prev_last_sample_float,)`` so that the
-    boundary between consecutive chunks is interpolated correctly.
-
-    Note: state does not track fractional phase, so non-integer rate ratios
-    (e.g. 24 k→8 k) with variable chunk sizes may accumulate sample-count
-    drift over very long streams.  All production ratios in this project are
-    integer multiples (8 k↔16 k = 2:1) where this is not a concern.
-
+    When downsampling (target_rate < source_rate), a streaming FIR lowpass
+    is applied first to prevent aliasing, then a phase-locked linear
+    interpolation performs the actual rate conversion.
+    The state tuple carries ``(phase, last_sample, fir_tail_or_None)``.
+    ``phase`` is the fractional input-sample position (relative to the
+    start of the *next* chunk) of the next output sample to be produced.
+    Carrying it forward exactly -- using the true, un-rounded
+    source/target rate ratio on every chunk, rather than a step recomputed
+    from that chunk's own rounded sample count -- keeps the decimation
+    grid phase-locked across chunk boundaries no matter how the caller
+    slices audio into chunks (the previous implementation re-derived step
+    per chunk, which silently shifted the grid at every boundary whenever
+    a chunk size wasn't an exact multiple of the rate ratio -- audible as
+    a click/pop at every chunk boundary). ``last_sample`` is the final
+    post-filter sample of the previous chunk, used as a single sample of
+    lookback when ``phase`` is slightly negative (the next output falls
+    just before the new chunk starts). ``fir_tail`` holds the last
+    ``num_taps - 1`` pre-filter samples from the previous chunk so the FIR
+    filter itself is continuous across chunk boundaries; it is
+    ``None``/unused when not downsampling.
     Returns a tuple of (converted_bytes, new_state).
     """
     if not pcm_bytes or source_rate == target_rate:
         return pcm_bytes, state
-
     audio = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float64)
     n_in = len(audio)
-    n_out = int(round(n_in * target_rate / source_rate))
-    if n_out == 0:
+    if n_in == 0:
         return b"", state
-
-    # Recover last input sample from previous chunk
+    is_downsample = target_rate < source_rate
+    prev_phase: float = 0.0
     prev_last: Optional[float] = None
-    if state is not None:
+    prev_fir_tail: Optional[np.ndarray] = None
+    if state is not None and isinstance(state, tuple) and len(state) > 0:
         try:
-            if isinstance(state, tuple) and len(state) > 0:
-                prev_last = float(state[0])
+            prev_phase = float(state[0])
         except (TypeError, ValueError, IndexError):
-            prev_last = None
-
-    # Exact step between output samples in input-sample units.
-    # For 2× upsampling (8 k→16 k): step = 0.5 exactly.
-    step = float(n_in) / float(n_out)
-
-    if prev_last is not None:
-        # Prepend previous chunk's last sample for boundary interpolation.
-        #   extended[0] = prev_last  (position −1 relative to current chunk)
-        #   extended[1] = audio[0]   (position 0)
-        #   extended[k] = audio[k-1]
-        #
-        # Output positions (extended-index space):
-        #   1*step, 2*step, …, n_out*step
-        # e.g. for 2×: 0.5, 1.0, 1.5, …, 160.0
-        #   pos 0.5 → (prev_last + audio[0]) / 2  ← smooth boundary
-        #   pos 1.0 → audio[0]
-        extended = np.empty(n_in + 1, dtype=np.float64)
-        extended[0] = prev_last
-        extended[1:] = audio
-        out_pos = np.arange(1, n_out + 1, dtype=np.float64) * step
-        resampled = np.interp(out_pos, np.arange(n_in + 1, dtype=np.float64), extended)
+            prev_phase = 0.0
+        if len(state) > 1 and state[1] is not None:
+            try:
+                prev_last = float(state[1])
+            except (TypeError, ValueError):
+                prev_last = None
+        if len(state) > 2 and state[2] is not None:
+            prev_fir_tail = state[2]
+    new_fir_tail: Optional[np.ndarray] = None
+    if is_downsample:
+        kernel = _FIR_KERNEL_CACHE.get((source_rate, target_rate))
+        if kernel is None:
+            kernel = _design_lowpass_kernel(source_rate, target_rate)
+            _FIR_KERNEL_CACHE[(source_rate, target_rate)] = kernel
+        num_taps = len(kernel)
+        history_len = num_taps - 1
+        if prev_fir_tail is not None and len(prev_fir_tail) == history_len:
+            history = prev_fir_tail
+        else:
+            history = np.zeros(history_len, dtype=np.float64)
+        extended_for_filter = np.concatenate([history, audio])
+        # 'valid' mode with (num_taps - 1) samples of history prepended
+        # yields exactly n_in output samples, correctly centered/delayed
+        # for this symmetric kernel, continuous across chunk boundaries.
+        filtered = np.convolve(extended_for_filter, kernel, mode="valid")
+        new_fir_tail = extended_for_filter[-history_len:] if history_len > 0 else np.zeros(0, dtype=np.float64)
+        working = filtered
     else:
-        # First chunk — no history.
-        out_pos = np.arange(n_out, dtype=np.float64) * step
-        resampled = np.interp(out_pos, np.arange(n_in, dtype=np.float64), audio)
-
-    new_state: Optional[tuple] = (float(audio[-1]),)
+        working = audio
+    n_work = len(working)
+    # Exact (un-rounded) input-samples-per-output-sample ratio, fixed for
+    # the life of the call -- see docstring for why this matters.
+    step = float(source_rate) / float(target_rate)
+    if not (-1.0 <= prev_phase < step + 1.0):
+        # Defensive clamp; shouldn't occur in normal operation.
+        prev_phase = 0.0
+    lookback = prev_last if prev_last is not None else (float(working[0]) if n_work > 0 else 0.0)
+    extended = np.empty(n_work + 1, dtype=np.float64)
+    extended[0] = lookback
+    extended[1:] = working
+    # extended index 0 = lookback (local position -1); index i (i>=1) =
+    # working[i-1] (local position i-1). So local position p -> index p+1.
+    if n_work - 1 - prev_phase < 0:
+        n_out = 0
+    else:
+        n_out = int(np.floor((n_work - 1 - prev_phase) / step)) + 1
+    n_out = max(n_out, 0)
+    if n_out == 0:
+        new_phase = prev_phase - n_work
+        new_last = float(working[-1]) if n_work > 0 else lookback
+        new_state: Optional[tuple] = (new_phase, new_last, new_fir_tail)
+        return b"", new_state
+    local_pos = prev_phase + np.arange(n_out, dtype=np.float64) * step
+    out_pos = local_pos + 1.0
+    resampled = np.interp(out_pos, np.arange(n_work + 1, dtype=np.float64), extended)
+    next_local_pos = prev_phase + n_out * step
+    new_phase = next_local_pos - n_work
+    new_last = float(working[-1])
+    new_state = (new_phase, new_last, new_fir_tail)
     resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
     return resampled.tobytes(), new_state
 
@@ -121,7 +204,6 @@ def convert_pcm16le_to_target_format(pcm_bytes: bytes, target_format: str) -> by
     """
     if not pcm_bytes:
         return b""
-
     fmt = (target_format or "").lower()
     if fmt in ("ulaw", "mulaw", "mu-law"):
         return pcm16le_to_mulaw(pcm_bytes)

--- a/src/audio/resampler.py
+++ b/src/audio/resampler.py
@@ -175,10 +175,21 @@ def resample_audio(
     extended[1:] = working
     # extended index 0 = lookback (local position -1); index i (i>=1) =
     # working[i-1] (local position i-1). So local position p -> index p+1.
-    if n_work - 1 - prev_phase < 0:
+    # Largest n_out such that every output position
+    # prev_phase + k * step  (k = 0 .. n_out - 1)
+    # stays strictly before n_work (the position of the next sample we
+    # don't have yet). ceil() -- with a tiny epsilon to guard against
+    # float noise landing on either side of an exact integer -- gives the
+    # correct count for both downsampling (step >= 1) and upsampling
+    # (step < 1). The previous floor(...)+1 form was only correct for
+    # step >= 1; for step < 1 (upsampling) it silently dropped output
+    # samples (e.g. 8kHz->16kHz dropped exactly 1 sample per call; more
+    # extreme upsample ratios dropped proportionally more).
+    remaining = n_work - prev_phase
+    if remaining <= 0:
         n_out = 0
     else:
-        n_out = int(np.floor((n_work - 1 - prev_phase) / step)) + 1
+        n_out = int(np.ceil(remaining / step - 1e-9))
     n_out = max(n_out, 0)
     if n_out == 0:
         new_phase = prev_phase - n_work

--- a/src/providers/google_live.py
+++ b/src/providers/google_live.py
@@ -1242,10 +1242,11 @@ class GoogleLiveProvider(AIProviderInterface):
             # Resample to provider's input rate (16kHz for Gemini Live)
             provider_rate = self.config.provider_input_sample_rate_hz
             if src_rate != provider_rate:
-                pcm16_provider, _ = resample_audio(
+                pcm16_provider, self._input_resample_state = resample_audio(
                     pcm16_src,
                     source_rate=src_rate,
                     target_rate=provider_rate,
+                    state=getattr(self, "_input_resample_state", None),
                 )
             else:
                 pcm16_provider = pcm16_src
@@ -1846,10 +1847,11 @@ class GoogleLiveProvider(AIProviderInterface):
                 logger.debug("Failed to emit Google Live output PCM rate log", call_id=self._call_id, exc_info=True)
             
             if provider_output_rate != target_rate:
-                pcm16_target, _ = resample_audio(
+                pcm16_target, self._output_resample_state = resample_audio(
                     pcm16_provider,
                     source_rate=provider_output_rate,
                     target_rate=target_rate,
+                    state=getattr(self, "_output_resample_state", None),
                 )
             else:
                 pcm16_target = pcm16_provider

--- a/tests/test_audio_resampler.py
+++ b/tests/test_audio_resampler.py
@@ -120,3 +120,77 @@ def test_single_sample_upsample():
     out, state = resample_audio(pcm, 8000, 16000)
     assert len(out) == 4  # 1 sample @ 8k → 2 samples @ 16k = 4 bytes
     assert state is not None
+
+
+# ── Regression coverage: maintainer-requested test cases ──────────────
+
+
+def test_consecutive_chunks_total_length_matches_one_shot():
+    """Resampling many irregularly-sized consecutive chunks (state carried
+    chunk-to-chunk) must, in total, produce the same number of output
+    samples as a single one-shot resample of the same concatenated signal.
+
+    This guards against the upsampling n_out off-by-N regression: the
+    previous floor(...)+1 formula silently dropped output samples on every
+    call when step < 1 (upsampling), and the loss compounded across many
+    chunks instead of just costing one sample at the very end.
+    """
+    import math
+    import random
+
+    random.seed(1234)
+    freq, sr = 440, 8000
+    total_samples = 4000
+
+    samples = [
+        int(8000 * math.sin(2 * math.pi * freq * i / sr))
+        for i in range(total_samples)
+    ]
+    full_pcm = struct.pack(f"<{total_samples}h", *samples)
+
+    # One-shot reference resample of the entire signal.
+    one_shot_out, _ = resample_audio(full_pcm, 8000, 24000)
+
+    # Chunked resample with state carried across irregular chunk sizes
+    # (not a clean multiple of the rate ratio) so the phase must be
+    # carried correctly to avoid drift/loss.
+    state = None
+    chunked_out = b""
+    offset = 0
+    while offset < len(full_pcm):
+        chunk_samples = random.choice([37, 53, 80, 113, 160])
+        chunk_bytes = chunk_samples * 2
+        chunk = full_pcm[offset:offset + chunk_bytes]
+        out, state = resample_audio(chunk, 8000, 24000, state=state)
+        chunked_out += out
+        offset += chunk_bytes
+
+    assert len(chunked_out) == len(one_shot_out)
+
+
+def test_fresh_session_state_is_independent_of_prior_calls():
+    """A fresh call with state=None must be fully reproducible and must
+    not be influenced by phase/state left over from a separate, unrelated
+    prior call -- guards against hidden module-level state leaking between
+    sessions/calls when the caller correctly starts a new session with
+    state=None (as Google Live's start_session now does).
+    """
+    chunk = b"\x10\x00" * 160  # 160 samples, 20 ms @ 24 kHz
+
+    # An unrelated "prior session": one downsample call leaves a
+    # non-trivial residual phase in its returned state (24kHz->16kHz has
+    # a non-integer 1.5x ratio, so a clean 160-sample chunk does not
+    # divide evenly -- the leftover phase is carried forward for the
+    # *next* chunk of that same session, not discarded).
+    _, prior_state = resample_audio(chunk, 24000, 16000)
+    assert prior_state is not None and prior_state[0] != 0
+
+    # A brand-new session (state=None) on the same input, called twice,
+    # must produce identical output both times -- regardless of the
+    # unrelated prior_state computed above still being in scope. If the
+    # resampler held any hidden module-level session state, the second
+    # "fresh" call could drift from the first.
+    out_fresh_a, _ = resample_audio(chunk, 24000, 16000)
+    out_fresh_b, _ = resample_audio(chunk, 24000, 16000)
+    assert out_fresh_a == out_fresh_b
+    assert len(out_fresh_a) > 0


### PR DESCRIPTION
## Summary

Replaces the resampler's plain numpy linear interpolation with a phase-locked, state-carrying resampler that adds a streaming-safe FIR anti-aliasing lowpass before decimation, and fixes a sample-count bug in the upsampling path found while addressing review feedback on #441.

This is the second of two PRs split out of #441 per maintainer feedback — see #481 for the narrower Google Live resample-state-persistence fix.


## Related Issue(s)

Continues from #441 (closing in favor of this split). Related: #481.

## Implementation Notes

- **FIR anti-aliasing**: when downsampling, a windowed-sinc lowpass (Blackman window, 31 taps) is applied before decimation so high-frequency content above the new Nyquist doesn't fold back into the audible band (fixes scratchy/fuzzy "s"/"sh" artifacts when decimating e.g. 24kHz TTS output to 8kHz). Skipped entirely when upsampling or when rates match — no aliasing risk in that direction.
- **Phase-locked interpolation**: `step = source_rate / target_rate` is computed once and held fixed for the call; the exact fractional input position of the next output sample (`phase`) is carried forward in `state` across chunks, rather than recomputed per chunk from that chunk's own rounded sample count. The previous implementation re-derived the step per chunk, which silently shifted the sampling grid at every chunk boundary whenever a chunk size wasn't an exact multiple of the rate ratio — audible as a click/pop at chunk boundaries.
- **FIR continuity**: the last `num_taps - 1` pre-filter samples are carried in `state` too, so the convolution itself is continuous across chunk boundaries.
- **Bug fix (found during this work)**: the output-sample-count formula `floor((n_work - 1 - prev_phase) / step) + 1` was only correct for downsampling (`step >= 1`). For upsampling (`step < 1`), dividing the `-1` term by a fractional step amplified the loss, silently dropping output samples on every call — exactly 1 sample at a clean 2x ratio, proportionally more at higher upsample ratios. Replaced with a `ceil`-based bound (the largest `n_out` such that every output position stays strictly before the next not-yet-received input sample), correct in both directions.


## Testing

- `tests/test_audio_resampler.py`: 12/12 passing, including 2 new regression tests added per review feedback:
  - `test_consecutive_chunks_total_length_matches_one_shot` — many irregularly-sized chunks with carried state must sum to the same total output length as a single one-shot resample (guards against the off-by-N regression compounding across chunks).
  - `test_fresh_session_state_is_independent_of_prior_calls` — a fresh `state=None` call is unaffected by an unrelated prior call's residual phase.
- Full repo test suite run locally: 893 passed. A handful of unrelated failures present in this environment are pre-existing on `main` (confirmed identical with this change reverted) and unrelated to this PR.
- Battle-tested in production on this fork prior to opening this PR.



## Documentation

Which docs were updated (if any)?

- [ ] `docs/contributing/architecture-deep-dive.md`
- [ ] `docs/ROADMAP.md` / `docs/milestones/*`
- [ ] `docs/TOOL_CALLING_GUIDE.md`
- [ ] Provider/tool-specific docs
- [ ] `docs/DEVELOPER_ONBOARDING.md` / other onboarding content

If no docs were needed, explain why.

No user-facing documentation changes required — internal audio-pipeline implementation detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio resampling stability for chunked PCM input and output, helping keep playback timing and sample counts consistent across streamed audio.
  * Preserved resampling continuity between successive audio chunks to reduce drift and off-by-one sample loss.
  * Added stronger anti-aliasing when downsampling audio for better sound quality.

* **Tests**
  * Added regression coverage for chunked resampling consistency and session independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->