### PR TITLE
Add per-agent OpenAI Realtime voice override support

### DIFF
--- a/src/core/agent_store.py
+++ b/src/core/agent_store.py
@@ -125,6 +125,7 @@ class EngineAgentStore:
         return ContextConfig(
             prompt=r["prompt"], greeting=r["greeting"], profile=r["audio_profile"],
             provider=r["provider"],
+            voice=r["voice"],
             tools=tools,
             email_recipient=email_recipient,
             email_from=email_from,

--- a/src/core/transport_orchestrator.py
+++ b/src/core/transport_orchestrator.py
@@ -44,6 +44,7 @@ class ContextConfig:
     greeting: Optional[str] = None
     profile: Optional[str] = None
     provider: Optional[str] = None
+    voice: Optional[str] = None
     pipeline: Optional[str] = None  # Pipeline name for modular STT/LLM/TTS (e.g., local_hybrid)
     tools: Optional[list] = None  # In-call tool names for function calling
     background_music: Optional[str] = None  # MOH class name for background music during calls

--- a/src/engine.py
+++ b/src/engine.py
@@ -13801,6 +13801,13 @@ class Engine:
                             provider_context["greeting"] = self._apply_prompt_template_substitution(greeting_override, session)
                         elif hasattr(context_config, 'greeting') and context_config.greeting:
                             provider_context['greeting'] = self._apply_prompt_template_substitution(context_config.greeting, session)
+
+                        # Per-agent/per-context voice override for OpenAI Realtime.
+                        voice_override = overrides.get("voice")
+                        if isinstance(voice_override, str) and voice_override.strip():
+                            provider_context["voice"] = voice_override.strip()
+                        elif hasattr(context_config, "voice") and getattr(context_config, "voice"):
+                            provider_context["voice"] = str(getattr(context_config, "voice")).strip()
             except Exception as e:
                 logger.warning(f"Failed to build provider context: {e}", call_id=call_id, exc_info=True)
             

--- a/src/providers/openai_realtime.py
+++ b/src/providers/openai_realtime.py
@@ -105,6 +105,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         self._beta_warned: bool = False
 
         self._call_id: Optional[str] = None
+        self._session_voice: Optional[str] = None  # Per-call voice override from agent/context
         self._pending_response: bool = False
         self._current_response_id: Optional[str] = None  # Track active response for cancellation
         self._greeting_response_id: Optional[str] = None  # Track greeting to protect from barge-in
@@ -392,6 +393,12 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             self._allowed_tools = list(context.get("tools") or [])
         else:
             self._allowed_tools = []
+
+        # Per-call voice override. Falls back to provider config voice.
+        self._session_voice = None
+        if context and isinstance(context.get("voice"), str) and context.get("voice").strip():
+            self._session_voice = context.get("voice").strip()
+            logger.info("Using per-call OpenAI voice override", call_id=call_id, voice=self._session_voice)
 
         self._reset_output_meter()
 
@@ -889,6 +896,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 logger.debug("Failed to release response.done sentinels on stop_session", exc_info=True)
             self.websocket = None
             self._call_id = None
+            self._session_voice = None
             self._closing = False
             self._closed = True
             self._pending_response = False
@@ -904,7 +912,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             "name": "OpenAIRealtimeProvider",
             "type": "cloud",
             "model": self.config.model,
-            "voice": self.config.voice,
+            "voice": self._session_voice or self.config.voice,
             "supported_codecs": self.supported_codecs,
         }
 
@@ -978,6 +986,8 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         if not output_modalities:
             output_modalities = ["audio"]
 
+        effective_voice = self._session_voice or self.config.voice
+
         # CRITICAL FIX: Use output_encoding (what OpenAI sends), NOT target_encoding (downstream format)
         output_enc = (self.config.output_encoding or "linear16").lower()
         input_enc = (getattr(self.config, "provider_input_encoding", None) or "linear16").lower()
@@ -1036,7 +1046,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                     "input": audio_input,
                     "output": {
                         "format": {"type": "audio/pcm", "rate": 24000},
-                        "voice": self.config.voice,
+                        "voice": effective_voice,
                     },
                 },
             }
@@ -1057,7 +1067,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 "modalities": output_modalities,
                 "input_audio_format": in_fmt,
                 "output_audio_format": out_fmt,
-                "voice": self.config.voice,
+                "voice": effective_voice,
                 "input_audio_transcription": {
                     "model": "whisper-1"
                 },
@@ -1117,6 +1127,11 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                     f"🛠️  OpenAI session configured with {len(tools)} tools",
                     call_id=self._call_id,
                 )
+                logger.info(
+                    "OpenAI session tool names",
+                    call_id=self._call_id,
+                    tools=[t.get("name") for t in tools],
+)
         except Exception as e:
             logger.warning(
                 f"Failed to add tools to OpenAI session: {e}",


### PR DESCRIPTION
## Summary

This PR adds support for per-agent voice selection when using the OpenAI Realtime provider.

The operator database already includes a `voice` field for each agent, but that value was not being carried through the runtime path to the OpenAI Realtime provider. As a result, all agents used the provider-level default voice.

This change threads the agent voice through the call flow so each agent can use its own configured voice, while preserving the existing provider default when no agent voice is set.

## Changes

- Added `voice` to `ContextConfig`
- Loaded the agent `voice` field from `agents.db`
- Passed the voice into `provider_context`
- Added per-session voice override support in `OpenAIRealtimeProvider`
- Kept the provider-level configured voice as the fallback

## Testing

Tested in a production FreePBX / Asterisk AVA deployment with multiple DIDs routed to separate agents.

Verified:
- Agent voice values are loaded from `agents.db`
- `provider_context` includes the configured voice
- OpenAI Realtime applies the per-call voice override
- Existing prompt, greeting, tool, and transfer behavior remains unchanged

Log confirmation:
```text
Using per-call OpenAI voice override

Why this matters

This allows a single AVA deployment to support multiple businesses, departments, or use cases with distinct voices and personalities without requiring separate provider configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice selection support across agent context and realtime sessions.
  * Per-call voice overrides now take effect during session setup, with fallback to the configured default voice.

* **Bug Fixes**
  * Agent context now carries the stored voice value through to session configuration, helping ensure the intended voice is used consistently.

* **Style**
  * Tool setup logging now shows the tool names explicitly for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->