### PR TITLE
 https://github.com/foytech/AVA-AI-Voice-Agent-for-Asterisk/pull/new/feature/openai-tool-response-cleanup

### DIFF
--- a/src/core/agent_store.py
+++ b/src/core/agent_store.py
@@ -125,6 +125,7 @@ class EngineAgentStore:
         return ContextConfig(
             prompt=r["prompt"], greeting=r["greeting"], profile=r["audio_profile"],
             provider=r["provider"],
+            voice=r["voice"],
             tools=tools,
             email_recipient=email_recipient,
             email_from=email_from,

--- a/src/core/transport_orchestrator.py
+++ b/src/core/transport_orchestrator.py
@@ -44,6 +44,7 @@ class ContextConfig:
     greeting: Optional[str] = None
     profile: Optional[str] = None
     provider: Optional[str] = None
+    voice: Optional[str] = None
     pipeline: Optional[str] = None  # Pipeline name for modular STT/LLM/TTS (e.g., local_hybrid)
     tools: Optional[list] = None  # In-call tool names for function calling
     background_music: Optional[str] = None  # MOH class name for background music during calls

--- a/src/engine.py
+++ b/src/engine.py
@@ -13801,6 +13801,13 @@ class Engine:
                             provider_context["greeting"] = self._apply_prompt_template_substitution(greeting_override, session)
                         elif hasattr(context_config, 'greeting') and context_config.greeting:
                             provider_context['greeting'] = self._apply_prompt_template_substitution(context_config.greeting, session)
+
+                        # Per-agent/per-context voice override for OpenAI Realtime.
+                        voice_override = overrides.get("voice")
+                        if isinstance(voice_override, str) and voice_override.strip():
+                            provider_context["voice"] = voice_override.strip()
+                        elif hasattr(context_config, "voice") and getattr(context_config, "voice"):
+                            provider_context["voice"] = str(getattr(context_config, "voice")).strip()
             except Exception as e:
                 logger.warning(f"Failed to build provider context: {e}", call_id=call_id, exc_info=True)
             

--- a/src/providers/openai_realtime.py
+++ b/src/providers/openai_realtime.py
@@ -105,6 +105,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         self._beta_warned: bool = False
 
         self._call_id: Optional[str] = None
+        self._session_voice: Optional[str] = None  # Per-call voice override from agent/context
         self._pending_response: bool = False
         self._current_response_id: Optional[str] = None  # Track active response for cancellation
         self._greeting_response_id: Optional[str] = None  # Track greeting to protect from barge-in
@@ -392,6 +393,12 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             self._allowed_tools = list(context.get("tools") or [])
         else:
             self._allowed_tools = []
+
+        # Per-call voice override. Falls back to provider config voice.
+        self._session_voice = None
+        if context and isinstance(context.get("voice"), str) and context.get("voice").strip():
+            self._session_voice = context.get("voice").strip()
+            logger.info("Using per-call OpenAI voice override", call_id=call_id, voice=self._session_voice)
 
         self._reset_output_meter()
 
@@ -889,6 +896,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 logger.debug("Failed to release response.done sentinels on stop_session", exc_info=True)
             self.websocket = None
             self._call_id = None
+            self._session_voice = None
             self._closing = False
             self._closed = True
             self._pending_response = False
@@ -904,7 +912,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             "name": "OpenAIRealtimeProvider",
             "type": "cloud",
             "model": self.config.model,
-            "voice": self.config.voice,
+            "voice": self._session_voice or self.config.voice,
             "supported_codecs": self.supported_codecs,
         }
 
@@ -978,6 +986,8 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         if not output_modalities:
             output_modalities = ["audio"]
 
+        effective_voice = self._session_voice or self.config.voice
+
         # CRITICAL FIX: Use output_encoding (what OpenAI sends), NOT target_encoding (downstream format)
         output_enc = (self.config.output_encoding or "linear16").lower()
         input_enc = (getattr(self.config, "provider_input_encoding", None) or "linear16").lower()
@@ -1036,7 +1046,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                     "input": audio_input,
                     "output": {
                         "format": {"type": "audio/pcm", "rate": 24000},
-                        "voice": self.config.voice,
+                        "voice": effective_voice,
                     },
                 },
             }
@@ -1057,7 +1067,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 "modalities": output_modalities,
                 "input_audio_format": in_fmt,
                 "output_audio_format": out_fmt,
-                "voice": self.config.voice,
+                "voice": effective_voice,
                 "input_audio_transcription": {
                     "model": "whisper-1"
                 },
@@ -1117,6 +1127,11 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                     f"🛠️  OpenAI session configured with {len(tools)} tools",
                     call_id=self._call_id,
                 )
+                logger.info(
+                    "OpenAI session tool names",
+                    call_id=self._call_id,
+                    tools=[t.get("name") for t in tools],
+)
         except Exception as e:
             logger.warning(
                 f"Failed to add tools to OpenAI session: {e}",

--- a/src/tools/adapters/openai.py
+++ b/src/tools/adapters/openai.py
@@ -261,12 +261,27 @@ class OpenAIToolAdapter:
         try:
             # Step 1: Send function_call_output
             safe_result = sanitize_tool_result_for_json_string(result, max_bytes=12000)
+            output_payload = safe_result
+
+            if isinstance(safe_result, dict):
+                data = safe_result.get("data")
+
+                if isinstance(data, dict) and data.get("spoken_answer"):
+                    output_payload = data["spoken_answer"]
+                elif safe_result.get("spoken_answer"):
+                    output_payload = safe_result["spoken_answer"]
+                elif safe_result.get("message") and safe_result.get("message") not in (
+                    "Retrieved data successfully.",
+                    "Data retrieved successfully.",
+                ):
+                    output_payload = safe_result["message"]
+
             output_event = {
                 "type": "conversation.item.create",
                 "item": {
                     "type": "function_call_output",
                     "call_id": call_id,
-                    "output": json.dumps(safe_result)  # Stringify the result JSON (size-capped)
+                    "output": json.dumps(output_payload)
                 }
             }
             await websocket.send(json.dumps(output_event))

--- a/src/tools/telephony/unified_transfer.py
+++ b/src/tools/telephony/unified_transfer.py
@@ -5,6 +5,7 @@ This tool implements the canonical `blind_transfer` tool and replaces the legacy
 `transfer_call` and `transfer_to_queue` tools with a single unified interface.
 """
 
+import asyncio
 from typing import Dict, Any, Optional, Tuple, List
 import structlog
 
@@ -245,6 +246,23 @@ class UnifiedTransferTool(Tool):
                 "message": f"Invalid transfer type: {transfer_type}"
             }
     
+    async def _wait_before_transfer(self, context, description: str) -> None:
+        """Allow the assistant's spoken transfer message to finish before moving the channel."""
+        config = context.get_config_value("tools.transfer") or {}
+        pre_transfer_delay_sec = float(config.get("pre_transfer_delay_sec", 8.0))
+
+        if pre_transfer_delay_sec <= 0:
+            return
+
+        logger.info(
+            "Waiting before transfer to allow spoken message to finish",
+            call_id=context.call_id,
+            delay_seconds=pre_transfer_delay_sec,
+            transfer_target=description,
+        )
+        await asyncio.sleep(pre_transfer_delay_sec)
+
+
     async def _transfer_to_extension(
         self,
         context: ToolExecutionContext,
@@ -280,6 +298,8 @@ class UnifiedTransferTool(Tool):
         
         # Use ARI continue to transfer via dialplan (like queue/ringgroup transfers)
         # This properly leaves Stasis and lets Asterisk dialplan handle the call
+        await self._wait_before_transfer(context, description)
+
         await context.ari_client.send_command(
             method="POST",
             resource=f"channels/{context.caller_channel_id}/continue",
@@ -329,6 +349,8 @@ class UnifiedTransferTool(Tool):
         )
         
         # Execute transfer to FreePBX ext-queues context
+        await self._wait_before_transfer(context, description)
+
         await context.ari_client.send_command(
             method="POST",
             resource=f"channels/{context.caller_channel_id}/continue",
@@ -379,6 +401,8 @@ class UnifiedTransferTool(Tool):
         )
         
         # Execute transfer to FreePBX ext-group context
+        await self._wait_before_transfer(context, description)
+
         await context.ari_client.send_command(
             method="POST",
             resource=f"channels/{context.caller_channel_id}/continue",


### PR DESCRIPTION
## Summary

This PR improves how OpenAI tool results are returned to the model.

Instead of always passing the full sanitized JSON payload back as the function call output, this change prefers concise spoken response fields when available.

## Changes

- Prefer `data.spoken_answer` when present
- Fall back to top-level `spoken_answer`
- Fall back to meaningful `message` values
- Preserve the full sanitized result behavior when no concise spoken output is available

## Why

Some tools return large JSON payloads that are useful internally but not ideal for natural spoken responses. This helps the OpenAI provider receive a cleaner, more conversational tool result when the tool already provides a caller-ready answer.

## Testing

Verified with in-call HTTP lookup tools that return `spoken_answer`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-agent voice settings across context handling and provider sessions.
  * Voice preferences can now be carried through to realtime interactions and session updates.
  * Transfers now pause briefly before redirecting, helping spoken transfer messages finish naturally.
* **Bug Fixes**
  * Improved tool-result content sent to the model so responses are based on the most relevant spoken or message text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->