### PR TITLE
fix(cli): restore Windows build — platform-tag flock and self-update exec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,29 @@ jobs:
           echo "## 📋 Outdated Dependencies" >> $GITHUB_STEP_SUMMARY
           pip install pip-outdated || true
           pip list --outdated --format=columns | head -20 >> $GITHUB_STEP_SUMMARY || echo "Unable to check" >> $GITHUB_STEP_SUMMARY
+
+  # CLI cross-compile check: the release workflow builds all five platforms,
+  # but PR CI previously built none, so platform-only breakage (e.g. unix-only
+  # syscalls on Windows) surfaced only at tag time. Build-only, no artifacts.
+  cli-cross-compile:
+    name: CLI cross-compile (all release targets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: cli/go.sum
+
+      - name: Build all release platforms
+        working-directory: cli
+        run: |
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+            GOOS="${target%/*}" GOARCH="${target#*/}" go build ./...
+            echo "OK: $target"
+          done
+
+      - name: Run CLI tests
+        working-directory: cli
+        run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows CLI build restored** (`cli/cmd/agent/update.go`, `cli/cmd/agent/update_platform_unix.go`, `cli/cmd/agent/update_platform_windows.go`): the v7.2.1 `agent update` lock and self-update re-exec used unix-only `syscall.Flock`/`syscall.Exec`, which broke the Windows AMD64 cross-compile in the CLI release workflow (first failing build since the updater landed). File locking and process replacement now live behind build-tagged platform files — `flock(2)`/`execve(2)` on unix, `LockFileEx` and spawn-then-exit on Windows — with unchanged behavior on Linux/macOS. CI gains a `cli-cross-compile` job that builds all five release targets on every PR, closing the gap where no Go build ran at PR time and platform-only breakage surfaced only when tagging a release.
+
 ## [7.2.1] - 2026-07-02
 
 ### Added

--- a/cli/cmd/agent/update.go
+++ b/cli/cmd/agent/update.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/hkjarral/ava-ai-voice-agent-for-asterisk/cli/internal/check"
@@ -380,7 +379,7 @@ func acquireUpdateLock(repoRoot string) (func(), error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open update lock: %w", err)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+	if err := lockUpdateFile(f); err != nil {
 		_ = f.Close()
 		return nil, errors.New("another agent update or rollback is already running")
 	}
@@ -388,7 +387,7 @@ func acquireUpdateLock(repoRoot string) (func(), error) {
 	_, _ = f.Seek(0, 0)
 	_, _ = f.WriteString(fmt.Sprintf("pid=%d started_at=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339)))
 	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		unlockUpdateFile(f)
 		_ = f.Close()
 	}, nil
 }
@@ -600,7 +599,7 @@ func maybeSelfUpdateAndReexec() {
 	// Re-exec into the updated binary so the rest of `agent update` runs the newest logic.
 	env := append(os.Environ(), "AAVA_AGENT_SKIP_SELF_UPDATE=1")
 	args := append([]string{exePath}, os.Args[1:]...)
-	_ = syscall.Exec(exePath, args, env)
+	execReplace(exePath, args, env)
 }
 
 func releaseBinaryName(goos string, goarch string) (string, bool) {

--- a/cli/cmd/agent/update_platform_unix.go
+++ b/cli/cmd/agent/update_platform_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockUpdateFile takes a non-blocking exclusive lock on the update lock file.
+func lockUpdateFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockUpdateFile(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}
+
+// execReplace replaces the current process with the updated binary. On
+// failure it returns so the caller continues running the current binary,
+// matching the original syscall.Exec call-site behavior.
+func execReplace(exePath string, args []string, env []string) {
+	_ = syscall.Exec(exePath, args, env)
+}

--- a/cli/cmd/agent/update_platform_windows.go
+++ b/cli/cmd/agent/update_platform_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockUpdateFile takes a non-blocking exclusive lock on the update lock file.
+func lockUpdateFile(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, ol)
+}
+
+func unlockUpdateFile(f *os.File) {
+	ol := new(windows.Overlapped)
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ol)
+}
+
+// execReplace approximates Unix exec semantics on Windows, which has no
+// execve equivalent: run the updated binary as a child and exit with its
+// status. If the child cannot be started, return so the caller continues
+// running the current binary (same as a failed syscall.Exec).
+func execReplace(exePath string, args []string, env []string) {
+	cmd := exec.Command(exePath, args[1:]...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err == nil {
+		os.Exit(0)
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		os.Exit(exitErr.ExitCode())
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/fatih/color v1.16.0
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/sys v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -13,5 +14,4 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.14.0 // indirect
 )


### PR DESCRIPTION
## Summary

The v7.2.1 `Release CLI Binaries` workflow failed at the windows/amd64 cross-compile: the `agent update` lock uses `syscall.Flock` and the self-update re-exec uses `syscall.Exec`, both unix-only (introduced with the updater workflow in #483 — the first tag build since). Linux and macOS binaries built fine.

## Changes

- `cli/cmd/agent/update_platform_unix.go` (`//go:build !windows`): `flock(2)` lock + `execve(2)` re-exec — behavior unchanged
- `cli/cmd/agent/update_platform_windows.go` (`//go:build windows`): `LockFileEx` (exclusive, fail-immediately) + spawn-then-exit re-exec that preserves the original continue-on-failure semantics and propagates the child's exit code
- `update.go`: call sites switched to the platform helpers; `syscall` import removed; `golang.org/x/sys` promoted to a direct dependency (already in go.sum)
- **CI gap closed**: new `cli-cross-compile` job in `ci.yml` builds all five release targets (+ `go test`) on every PR — previously no Go build ran at PR time, so platform-only breakage could only surface at tag time

## Testing

- `go build ./...` for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 — all pass locally
- `go vet ./...` on host and `GOOS=windows` — clean
- `go test ./...` — pass
- ci.yml YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `agent update` so self-updates and update locking behave correctly on Windows and Unix.
  * Prevented cross-platform issues caused by platform-specific file locking and process handoff differences.
* **Tests**
  * Added CI coverage that cross-compiles the CLI for all supported release targets and runs the CLI test suite on every PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->