### PR TITLE
Unify Local AI dependency pins across CPU and GPU images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Stale Admin UI provider links refreshed** (provider forms, Providers page, and setup wizard): corrected moved Telnyx, ElevenLabs, Kroko, and Asterisk documentation URLs. URL-check pipelines now use `pipefail`, so a checker failure cannot be masked by `tee`, and scheduled issue creation uses labels that exist in the repository.
+- **Local AI optional dependency pins now have one source of truth** (`local_ai_server/requirements.txt`, `local_ai_server/Dockerfile`, `local_ai_server/Dockerfile.gpu`): CPU and CUDA images install Sherpa-ONNX and llama-cpp-python from the shared requirements file instead of maintaining stale Dockerfile-specific versions. Sherpa-ONNX is updated to 1.13.4, and regression coverage prevents duplicate hard-coded pins from returning.
 
 ## [7.3.1] - 2026-07-09
 

--- a/local_ai_server/Dockerfile
+++ b/local_ai_server/Dockerfile
@@ -53,7 +53,9 @@ RUN if [ "$INCLUDE_VOSK" = "true" ]; then \
 
 RUN if [ "$INCLUDE_SHERPA" = "true" ]; then \
         echo "📦 Installing Sherpa-ONNX STT..." && \
-        pip install --no-cache-dir sherpa-onnx==1.12.40; \
+        SHERPA_REQUIREMENT="$(grep -m 1 '^sherpa-onnx' requirements.txt)" && \
+        test -n "$SHERPA_REQUIREMENT" && \
+        pip install --no-cache-dir "$SHERPA_REQUIREMENT"; \
     fi
 
 RUN if [ "$INCLUDE_FASTER_WHISPER" = "true" ]; then \

--- a/local_ai_server/Dockerfile.gpu
+++ b/local_ai_server/Dockerfile.gpu
@@ -41,7 +41,8 @@ RUN if [ -f "${CUDA_HOME}/lib64/stubs/libcuda.so" ] && [ ! -e "${CUDA_HOME}/lib6
         ln -s "${CUDA_HOME}/lib64/stubs/libcuda.so" "${CUDA_HOME}/lib64/stubs/libcuda.so.1"; \
     fi
 
-# Copy requirements first for optimal caching
+# Copy requirements first for optimal caching and shared optional-backend pins
+COPY requirements.txt .
 COPY requirements-base.txt .
 
 # Install base dependencies (always required)
@@ -54,7 +55,9 @@ RUN if [ "$INCLUDE_VOSK" = "true" ]; then \
     fi
 
 RUN if [ "$INCLUDE_SHERPA" = "true" ]; then \
-        pip install --no-cache-dir sherpa-onnx==1.12.40; \
+        SHERPA_REQUIREMENT="$(grep -m 1 '^sherpa-onnx' requirements.txt)" && \
+        test -n "$SHERPA_REQUIREMENT" && \
+        pip install --no-cache-dir "$SHERPA_REQUIREMENT"; \
     fi
 
 RUN if [ "$INCLUDE_FASTER_WHISPER" = "true" ]; then \
@@ -110,9 +113,11 @@ RUN if [ "$INCLUDE_SILERO" = "true" ]; then \
     fi
 
 RUN if [ "$INCLUDE_LLAMA" = "true" ]; then \
+        LLAMA_CPP_REQUIREMENT="$(grep -m 1 '^llama-cpp-python' requirements.txt)" && \
+        test -n "$LLAMA_CPP_REQUIREMENT" && \
         CMAKE_ARGS="-DGGML_CUDA=on -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TOOLS=OFF" \
         FORCE_CMAKE=1 \
-        pip install --no-cache-dir llama-cpp-python==0.3.21; \
+        pip install --no-cache-dir "$LLAMA_CPP_REQUIREMENT"; \
     fi
 
 # Pre-install spacy model for Kokoro TTS (only if Kokoro included)

--- a/local_ai_server/requirements.txt
+++ b/local_ai_server/requirements.txt
@@ -3,7 +3,7 @@ vosk==0.3.45
 llama-cpp-python==0.3.31
 piper-tts==1.2.0
 numpy==1.26.4
-sherpa-onnx==1.12.40
+sherpa-onnx==1.13.4
 kokoro>=0.9.2
 # Note: numpy is used by both Piper TTS and Kroko/Sherpa STT (PCM16→float32 conversion)
 # sherpa-onnx provides local streaming ASR (Kroko is built on sherpa-onnx)

--- a/tests/test_local_ai_dockerfile_dependency_pins.py
+++ b/tests/test_local_ai_dockerfile_dependency_pins.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOCAL_AI_ROOT = REPO_ROOT / "local_ai_server"
+DOCKERFILES = (
+    LOCAL_AI_ROOT / "Dockerfile",
+    LOCAL_AI_ROOT / "Dockerfile.gpu",
+)
+
+
+def test_optional_native_dependency_pins_have_one_source_of_truth() -> None:
+    requirements = (LOCAL_AI_ROOT / "requirements.txt").read_text(encoding="utf-8")
+    assert re.search(r"^sherpa-onnx==\d+\.\d+\.\d+$", requirements, re.MULTILINE)
+    assert re.search(
+        r"^llama-cpp-python==\d+\.\d+\.\d+$", requirements, re.MULTILINE
+    )
+
+    for dockerfile in DOCKERFILES:
+        content = dockerfile.read_text(encoding="utf-8")
+        assert "COPY requirements.txt ." in content, dockerfile
+        assert "grep -m 1 '^sherpa-onnx' requirements.txt" in content, dockerfile
+        assert 'pip install --no-cache-dir "$SHERPA_REQUIREMENT"' in content, dockerfile
+        assert "grep -m 1 '^llama-cpp-python' requirements.txt" in content, dockerfile
+        assert 'pip install --no-cache-dir "$LLAMA_CPP_REQUIREMENT"' in content, dockerfile
+        assert not re.search(r"pip install[^\n]*sherpa-onnx==", content), dockerfile
+        assert not re.search(r"pip install[^\n]*llama-cpp-python==", content), dockerfile


### PR DESCRIPTION
## Summary

- update `sherpa-onnx` from 1.12.40 to 1.13.4
- make the CPU and CUDA Dockerfiles install Sherpa from `local_ai_server/requirements.txt`
- make the CUDA Dockerfile install llama-cpp-python from the same requirements source
- add regression coverage preventing Dockerfile-specific duplicate pins

## Root cause

Dependabot PR #488 changed `local_ai_server/requirements.txt`, but both Dockerfiles hard-coded Sherpa 1.12.40, so the deployed package did not change. A deeper audit found the CUDA Dockerfile also hard-coded llama-cpp-python 0.3.21, which would make #484 ineffective for GPU images.

This PR supersedes #488 and provides the prerequisite wiring for #484 to apply uniformly to CPU and GPU builds.

## Validation

- local Python suite: 1,380 passed, 6 skipped
- dependency-wiring regression test: passed
- `git diff --check`: passed
- PyPI current Sherpa release verified as 1.13.4 with Python >=3.7 metadata
- isolated CPU image build on 10.44.0.104: passed
- isolated CUDA image build on 10.44.0.104: passed
- CPU and CUDA native runtime: Sherpa 1.13.4 imported successfully
- CPU and CUDA real-model test: official Silero VAD ONNX loaded into `VoiceActivityDetector`
- active dev deployment: untouched; Local AI remains healthy

Silero model SHA-256: `9e2449e1087496d8d4caba907f23e0bd3f78d91fa552479bb9c23ac09cbb1fd6`.

## Impact

No provider configuration or model selection behavior changes. Optional Local AI native packages now resolve from one reviewed requirements file, eliminating CPU/GPU version drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Sherpa-ONNX to version 1.13.4.
  * Ensured CPU and CUDA images consistently install optional AI dependencies from shared requirements.
  * Improved dependency alignment across image builds, reducing version mismatch issues.

* **Tests**
  * Added regression coverage to prevent duplicate or conflicting dependency pins in Docker builds.

* **Documentation**
  * Documented the dependency and image build updates in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->