### PR TITLE
Run Trivy when its workflow changes

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,6 +20,7 @@ on:
       - 'requirements.txt'
       - 'local_ai_server/Dockerfile'
       - 'local_ai_server/requirements*.txt'
+      - '.github/workflows/trivy.yml'
   schedule:
     # Run weekly on Monday at 7am UTC (after CodeQL)
     - cron: '0 7 * * 1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Stale Admin UI provider links refreshed** (provider forms, Providers page, and setup wizard): corrected moved Telnyx, ElevenLabs, Kroko, and Asterisk documentation URLs. URL-check pipelines now use `pipefail`, so a checker failure cannot be masked by `tee`, and scheduled issue creation uses labels that exist in the repository.
 - **Local AI optional dependency pins now have one source of truth** (`local_ai_server/requirements.txt`, `local_ai_server/Dockerfile`, `local_ai_server/Dockerfile.gpu`): CPU and CUDA images install Sherpa-ONNX and llama-cpp-python from the shared requirements file instead of maintaining stale Dockerfile-specific versions. Sherpa-ONNX is updated to 1.13.4, and regression coverage prevents duplicate hard-coded pins from returning.
+- **Trivy action updates now self-test on pull requests** (`.github/workflows/trivy.yml`): changes to the scanner workflow itself trigger image builds and vulnerability scans, closing the path-filter gap that required a manual workflow dispatch for the 0.36.0 action update.
 
 ## [7.3.1] - 2026-07-09
 


### PR DESCRIPTION
## Summary

- include `.github/workflows/trivy.yml` in the Trivy workflow pull-request path filter
- document the self-test coverage fix in the changelog

## Related issues and PRs

- follow-up to #511, where Trivy 0.36.0 required manual workflow dispatch because the scanner workflow did not trigger for its own file
- dependency tracking: #220

## Root cause

Dependabot PR #511 changed only the Trivy workflow, but the workflow path was included for `push` and omitted for `pull_request`. As a result, its scanner update could not run the `Scan Docker Image` job automatically.

## Implementation notes

The pull-request path allowlist now includes `.github/workflows/trivy.yml`. No scanner inputs, permissions, schedules, image profiles, or SARIF behavior changed.

## Testing

- actionlint: passed
- workflow YAML parse: passed
- `git diff --check`: passed
- this PR automatically started `Scan Docker Image`: passed in 5m29s
- ai-engine and Local AI image builds/scans: passed
- SARIF and artifact handling: passed
- all general CI and CodeQL checks: passed

## Documentation

`CHANGELOG.md` documents that Trivy workflow updates now self-test on pull requests. No operator documentation is required because this changes CI behavior only.