### PR TITLE
Support legacy Git in update recovery

### DIFF
--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -4603,8 +4603,8 @@ def _update_plan_failure_detail(
             "trap 'exit 129' HUP\n"
             "trap 'exit 130' INT\n"
             "trap 'exit 143' TERM\n"
-            'AAVA_CLI_REMOTE="$(sudo git -c safe.directory="$AAVA_REPO" '
-            '-C "$AAVA_REPO" remote get-url origin)" || { echo "Failed to resolve '
+            'AAVA_CLI_REMOTE="$(aava_git config --get remote.origin.url)" || { '
+            'echo "Failed to resolve '
             'checkout origin for CLI source; update not attempted" >&2; exit 2; }\n'
             'git clone --quiet --depth 1 --single-branch --branch "$AAVA_CLI_REF" '
             '-- "$AAVA_CLI_REMOTE" '
@@ -4636,17 +4636,23 @@ def _update_plan_failure_detail(
         "Recovery (run these commands in a host SSH shell):\n"
         f"AAVA_REPO={quoted_root}\n"
         'AAVA_RECOVERY_PATCH="$(dirname "$AAVA_REPO")/aava-update-recovery.patch"\n'
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" status --short '
+        # RHEL/CentOS 7 ships Git 1.8.3, before `git -C`, `remote get-url`,
+        # `--absolute-git-dir`, and `--path-format=absolute` existed.
+        'aava_git() {\n'
+        '  sudo git -c safe.directory="$AAVA_REPO" --git-dir="$AAVA_REPO/.git" '
+        '--work-tree="$AAVA_REPO" "$@"\n'
+        '}\n'
+        'aava_git status --short '
         '|| { echo "Failed to inspect checkout changes; update not attempted" >&2; exit 2; }\n'
         "(\n"
         "  set -o pipefail\n"
-        '  sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" diff --binary --cached '
+        '  aava_git diff --binary --cached '
         '| sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null\n'
         ') || { echo "Failed to preserve staged tracked edits; update not attempted" '
         ">&2; exit 2; }\n"
         "(\n"
         "  set -o pipefail\n"
-        '  sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" diff --binary '
+        '  aava_git diff --binary '
         '| sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null\n'
         ') || { echo "Failed to preserve unstaged tracked edits; update not attempted" '
         ">&2; exit 2; }\n"
@@ -4663,14 +4669,17 @@ def _update_plan_failure_detail(
         "  exit 2\n"
         "fi\n"
         'AAVA_EXPECTED_GIT_DIR="$(sudo realpath -e "$AAVA_REPO/.git")" || exit 2\n'
-        'AAVA_GIT_DIR="$(sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'rev-parse --absolute-git-dir)" || exit 2\n'
-        'AAVA_GIT_COMMON_DIR="$(sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'rev-parse --path-format=absolute --git-common-dir)" || exit 2\n'
-        'if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ] || '
-        '[ "$AAVA_GIT_COMMON_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then\n'
-        '  printf \'Refusing Git metadata repair outside %s (gitdir=%s common=%s)\\n\' '
-        '"$AAVA_EXPECTED_GIT_DIR" "$AAVA_GIT_DIR" "$AAVA_GIT_COMMON_DIR" >&2\n'
+        'aava_resolve_git_path() {\n'
+        '  case "$1" in\n'
+        '    /*) sudo realpath -e -- "$1" ;;\n'
+        '    *) sudo realpath -e -- "$AAVA_REPO/$1" ;;\n'
+        '  esac\n'
+        '}\n'
+        'AAVA_GIT_DIR_RAW="$(aava_git rev-parse --git-dir)" || exit 2\n'
+        'AAVA_GIT_DIR="$(aava_resolve_git_path "$AAVA_GIT_DIR_RAW")" || exit 2\n'
+        'if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then\n'
+        '  printf \'Refusing Git metadata repair outside %s (gitdir=%s)\\n\' '
+        '"$AAVA_EXPECTED_GIT_DIR" "$AAVA_GIT_DIR" >&2\n'
         "  exit 2\n"
         "fi\n"
         'sudo chown -R --no-dereference "$AAVA_UID:$AAVA_GID" '

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -4603,7 +4603,7 @@ def _update_plan_failure_detail(
             "trap 'exit 129' HUP\n"
             "trap 'exit 130' INT\n"
             "trap 'exit 143' TERM\n"
-            'AAVA_CLI_REMOTE="$(aava_git config --get remote.origin.url)" || { '
+            'AAVA_CLI_REMOTE="$(aava_git ls-remote --get-url origin)" || { '
             'echo "Failed to resolve '
             'checkout origin for CLI source; update not attempted" >&2; exit 2; }\n'
             'git clone --quiet --depth 1 --single-branch --branch "$AAVA_CLI_REF" '

--- a/admin_ui/backend/tests/test_updates_api.py
+++ b/admin_ui/backend/tests/test_updates_api.py
@@ -301,8 +301,9 @@ def test_update_plan_branch_recovery_builds_cli_from_exact_selected_ref(tmp_path
 
     assert "AAVA_CLI_REF=codex/upgrade-improvements" in detail
     assert (
-        'AAVA_CLI_REMOTE="$(aava_git config --get remote.origin.url)"'
+        'AAVA_CLI_REMOTE="$(aava_git ls-remote --get-url origin)"'
     ) in detail
+    assert "config --get remote.origin.url" not in detail
     assert '--branch "$AAVA_CLI_REF"' in detail
     assert '-- "$AAVA_CLI_REMOTE" "$AAVA_CLI_SRC/repo"' in detail
     assert '-e AAVA_CLI_VERSION="$AAVA_CLI_REF" golang:1.22-bookworm' in detail
@@ -314,7 +315,7 @@ def test_update_plan_branch_recovery_builds_cli_from_exact_selected_ref(tmp_path
     assert "AGENT_VERSION=latest" not in detail
     assert "scripts/install-cli.sh" not in detail
     assert "https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk.git" not in detail
-    assert detail.index("config --get remote.origin.url") < detail.index("git clone --quiet")
+    assert detail.index("ls-remote --get-url origin") < detail.index("git clone --quiet")
 
 
 def test_update_plan_recovery_fails_closed_on_owner_or_agent_repair_errors(tmp_path) -> None:

--- a/admin_ui/backend/tests/test_updates_api.py
+++ b/admin_ui/backend/tests/test_updates_api.py
@@ -119,17 +119,16 @@ async def test_updates_plan_failure_returns_exact_error_and_cli_recovery(monkeyp
     assert f"AAVA_REPO={tmp_path}" in detail
     assert "AGENT_VERSION=v7.4.0" in detail
     assert (
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" status --short '
+        'aava_git status --short '
         '|| { echo "Failed to inspect checkout changes; update not attempted" '
         '>&2; exit 2; }'
     ) in detail
     assert (
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'diff --binary --cached | sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null'
+        'aava_git diff --binary --cached '
+        '| sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null'
     ) in detail
     assert (
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'diff --binary | sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null'
+        'aava_git diff --binary | sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null'
     ) in detail
     assert detail.count("set -o pipefail") == 3
     assert (
@@ -162,8 +161,15 @@ async def test_updates_plan_failure_returns_exact_error_and_cli_recovery(monkeyp
     assert 'if sudo test -L "$AAVA_REPO/.agent"; then' in detail
     assert 'if sudo test -L "$AAVA_REPO/.git" || ! sudo test -d "$AAVA_REPO/.git"; then' in detail
     assert 'AAVA_EXPECTED_GIT_DIR="$(sudo realpath -e "$AAVA_REPO/.git")" || exit 2' in detail
-    assert 'rev-parse --absolute-git-dir' in detail
-    assert 'rev-parse --path-format=absolute --git-common-dir' in detail
+    assert 'rev-parse --git-dir' in detail
+    assert 'rev-parse --git-common-dir' not in detail
+    assert 'rev-parse --absolute-git-dir' not in detail
+    assert 'rev-parse --path-format=absolute' not in detail
+    assert 'aava_resolve_git_path() {' in detail
+    assert 'aava_git() {' in detail
+    assert ' --git-dir="$AAVA_REPO/.git" ' in detail
+    assert '--work-tree="$AAVA_REPO" "$@"' in detail
+    assert ' -C "$AAVA_REPO"' not in detail
     assert (
         'sudo chown -R --no-dereference "$AAVA_UID:$AAVA_GID" '
         '"$AAVA_EXPECTED_GIT_DIR" || exit 2'
@@ -197,13 +203,12 @@ def test_update_plan_recovery_stops_before_update_if_patch_capture_fails(tmp_pat
 
     inspection = 'status --short || { echo "Failed to inspect checkout changes; update not attempted"'
     staged_capture = (
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'diff --binary --cached | sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null'
+        'aava_git diff --binary --cached '
+        '| sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null'
     )
     staged_failure = "Failed to preserve staged tracked edits; update not attempted"
     unstaged_capture = (
-        'sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" '
-        'diff --binary | sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null'
+        'aava_git diff --binary | sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null'
     )
     unstaged_failure = "Failed to preserve unstaged tracked edits; update not attempted"
     installer = "AAVA_CLI_REF=main"
@@ -246,11 +251,8 @@ def test_update_plan_recovery_bounds_git_metadata_repair(tmp_path) -> None:
         'if sudo test -L "$AAVA_REPO/.git" || ! sudo test -d "$AAVA_REPO/.git"; then'
     )
     expected = 'AAVA_EXPECTED_GIT_DIR="$(sudo realpath -e "$AAVA_REPO/.git")" || exit 2'
-    resolved = 'AAVA_GIT_DIR="$(sudo git'
-    boundary = (
-        'if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ] || '
-        '[ "$AAVA_GIT_COMMON_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then'
-    )
+    resolved = 'AAVA_GIT_DIR_RAW="$(aava_git rev-parse --git-dir)"'
+    boundary = 'if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then'
     refusal = "Refusing Git metadata repair outside %s"
     repair = (
         'sudo chown -R --no-dereference "$AAVA_UID:$AAVA_GID" '
@@ -261,7 +263,7 @@ def test_update_plan_recovery_bounds_git_metadata_repair(tmp_path) -> None:
     assert boundary in detail
     assert refusal in detail
     assert repair in detail
-    assert '"$AAVA_GIT_COMMON_DIR"\n' not in detail
+    assert "AAVA_GIT_COMMON_DIR" not in detail
     assert detail.index(metadata_guard) < detail.index(expected) < detail.index(resolved)
     assert detail.index(resolved) < detail.index(boundary) < detail.index(repair)
 
@@ -299,8 +301,7 @@ def test_update_plan_branch_recovery_builds_cli_from_exact_selected_ref(tmp_path
 
     assert "AAVA_CLI_REF=codex/upgrade-improvements" in detail
     assert (
-        'AAVA_CLI_REMOTE="$(sudo git -c safe.directory="$AAVA_REPO" '
-        '-C "$AAVA_REPO" remote get-url origin)"'
+        'AAVA_CLI_REMOTE="$(aava_git config --get remote.origin.url)"'
     ) in detail
     assert '--branch "$AAVA_CLI_REF"' in detail
     assert '-- "$AAVA_CLI_REMOTE" "$AAVA_CLI_SRC/repo"' in detail
@@ -313,7 +314,7 @@ def test_update_plan_branch_recovery_builds_cli_from_exact_selected_ref(tmp_path
     assert "AGENT_VERSION=latest" not in detail
     assert "scripts/install-cli.sh" not in detail
     assert "https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk.git" not in detail
-    assert detail.index("remote get-url origin") < detail.index("git clone --quiet")
+    assert detail.index("config --get remote.origin.url") < detail.index("git clone --quiet")
 
 
 def test_update_plan_recovery_fails_closed_on_owner_or_agent_repair_errors(tmp_path) -> None:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -131,23 +131,29 @@ error: cannot open '.git/FETCH_HEAD': Permission denied
 run the recovery from an SSH shell on the host. The privileged steps repair only the
 bounded Git/updater metadata, then the update runs as the checkout owner. This bypasses
 the short-lived updater container's `/root` traversal problem without recursively
-changing checkout ownership:
+changing checkout ownership. The `aava_git` wrapper also avoids newer Git-only `-C`,
+`remote get-url`, and absolute-path flags, so recovery works with Git 1.8.3 on
+RHEL/CentOS 7 hosts:
 
 ```bash
 AAVA_REPO=/path/to/AVA-AI-Voice-Agent-for-Asterisk
 AAVA_RECOVERY_PATCH="$(dirname "$AAVA_REPO")/aava-update-recovery.patch"
-sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" status --short || {
+aava_git() {
+  sudo git -c safe.directory="$AAVA_REPO" --git-dir="$AAVA_REPO/.git" \
+    --work-tree="$AAVA_REPO" "$@"
+}
+aava_git status --short || {
   echo "Failed to inspect checkout changes; update not attempted" >&2
   exit 2
 }
 (
   set -o pipefail
-  sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" diff --binary --cached \
+  aava_git diff --binary --cached \
     | sudo tee "$AAVA_RECOVERY_PATCH" >/dev/null
 ) || { echo "Failed to preserve staged tracked edits; update not attempted" >&2; exit 2; }
 (
   set -o pipefail
-  sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" diff --binary \
+  aava_git diff --binary \
     | sudo tee -a "$AAVA_RECOVERY_PATCH" >/dev/null
 ) || { echo "Failed to preserve unstaged tracked edits; update not attempted" >&2; exit 2; }
 
@@ -174,11 +180,17 @@ if sudo test -L "$AAVA_REPO/.git" || ! sudo test -d "$AAVA_REPO/.git"; then
   exit 2
 fi
 AAVA_EXPECTED_GIT_DIR="$(sudo realpath -e "$AAVA_REPO/.git")" || exit 2
-AAVA_GIT_DIR="$(sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" rev-parse --absolute-git-dir)" || exit 2
-AAVA_GIT_COMMON_DIR="$(sudo git -c safe.directory="$AAVA_REPO" -C "$AAVA_REPO" rev-parse --path-format=absolute --git-common-dir)" || exit 2
-if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ] || [ "$AAVA_GIT_COMMON_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then
-  printf 'Refusing Git metadata repair outside %s (gitdir=%s common=%s)\n' \
-    "$AAVA_EXPECTED_GIT_DIR" "$AAVA_GIT_DIR" "$AAVA_GIT_COMMON_DIR" >&2
+aava_resolve_git_path() {
+  case "$1" in
+    /*) sudo realpath -e -- "$1" ;;
+    *) sudo realpath -e -- "$AAVA_REPO/$1" ;;
+  esac
+}
+AAVA_GIT_DIR_RAW="$(aava_git rev-parse --git-dir)" || exit 2
+AAVA_GIT_DIR="$(aava_resolve_git_path "$AAVA_GIT_DIR_RAW")" || exit 2
+if [ "$AAVA_GIT_DIR" != "$AAVA_EXPECTED_GIT_DIR" ]; then
+  printf 'Refusing Git metadata repair outside %s (gitdir=%s)\n' \
+    "$AAVA_EXPECTED_GIT_DIR" "$AAVA_GIT_DIR" >&2
   exit 2
 fi
 sudo chown -R --no-dereference "$AAVA_UID:$AAVA_GID" "$AAVA_EXPECTED_GIT_DIR" || exit 2

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -119,7 +119,9 @@ container, install that binary at `/usr/local/bin/agent`, and fail closed if ori
 resolution, fetch, build, installation, or cleanup fails. This supports branches hosted
 on the operator's fork or private origin instead of assuming the public upstream. If
 Docker or Git cannot perform that exact-ref bootstrap, select a published release tag
-or repair the host prerequisites; do not continue with an older CLI.
+or repair the host prerequisites; do not continue with an older CLI. Origin resolution
+uses `git ls-remote --get-url` so `url.*.insteadOf` rewrites are expanded even on Git
+1.8.3, which predates `git remote get-url`.
 
 If the exact UI error contains either of these messages:
 
@@ -131,9 +133,8 @@ error: cannot open '.git/FETCH_HEAD': Permission denied
 run the recovery from an SSH shell on the host. The privileged steps repair only the
 bounded Git/updater metadata, then the update runs as the checkout owner. This bypasses
 the short-lived updater container's `/root` traversal problem without recursively
-changing checkout ownership. The `aava_git` wrapper also avoids newer Git-only `-C`,
-`remote get-url`, and absolute-path flags, so recovery works with Git 1.8.3 on
-RHEL/CentOS 7 hosts:
+changing checkout ownership. The `aava_git` wrapper also avoids newer Git-only `-C`
+and absolute-path flags, so recovery works with Git 1.8.3 on RHEL/CentOS 7 hosts:
 
 ```bash
 AAVA_REPO=/path/to/AVA-AI-Voice-Agent-for-Asterisk


### PR DESCRIPTION
## What changed

- generate host recovery commands that work with Git 1.8.3
- replace newer `git -C`, `remote get-url`, and absolute-path-only invocations with a bounded `--git-dir`/`--work-tree` wrapper
- keep the metadata repair constrained to the checkout `.git` directory
- document legacy RHEL/CentOS 7 compatibility

## Why

Live verification on voiprnd showed that the exact recovery introduced by #533 still stopped on its stock Git 1.8.3.1 before it could repair the mixed-owned updater metadata.

## Validation

- 441 Admin backend tests passed
- 52 focused updater/recovery tests passed
- generated branch and release recovery scripts pass `bash -n`
- exact helper primitives passed against Git 1.8.3.1 on voiprnd

No reviewer was manually requested or triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update-plan recovery compatibility with older Git versions (including RHEL/CentOS 7).
  * Refined recovery behavior to correctly preserve both staged and unstaged changes.
  * Strengthened validation and safety checks when repairing Git metadata to prevent incorrect repairs.
* **Tests**
  * Updated recovery and failure-detail command expectations to match the revised recovery logic.
* **Documentation**
  * Refreshed installation/update planner recovery guidance, including stricter stop conditions and clearer origin resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->