### PR TITLE
Fix targeted Codex review configuration

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -13,7 +13,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
@@ -77,21 +77,41 @@ jobs:
             "${BASE_REF}" \
             "+refs/pull/${PR_NUMBER}/head"
 
-      - name: Validate OpenAI API key
+      - name: Validate OpenAI API key and model access
+        id: openai
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_REVIEW_MODEL: ${{ vars.CODEX_REVIEW_MODEL }}
         run: |
           set -euo pipefail
+
           if [ -z "${OPENAI_API_KEY}" ]; then
             echo "OPENAI_API_KEY repository secret is required for Codex Targeted Review." >&2
             exit 1
           fi
 
+          if [ -z "${CODEX_REVIEW_MODEL}" ]; then
+            echo "CODEX_REVIEW_MODEL repository variable is required for Codex Targeted Review." >&2
+            exit 1
+          fi
+
+          status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${OPENAI_API_KEY}" \
+            "https://api.openai.com/v1/models/${CODEX_REVIEW_MODEL}")"
+          if [ "${status}" != "200" ]; then
+            echo "The configured Codex review model '${CODEX_REVIEW_MODEL}' is not available to the OPENAI_API_KEY project (HTTP ${status})." >&2
+            exit 1
+          fi
+
+          echo "model=${CODEX_REVIEW_MODEL}" >> "${GITHUB_OUTPUT}"
+
       - name: Run targeted Codex review
         id: run_codex
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1 observed 2026-07-22
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: ${{ steps.openai.outputs.model }}
+          codex-version: 0.145.0
           sandbox: read-only
           effort: medium
           prompt: |

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -97,9 +97,16 @@ jobs:
 
           models_file="$(mktemp)"
           trap 'rm -f "${models_file}"' EXIT
-          status="$(curl --silent --show-error --output "${models_file}" --write-out '%{http_code}' \
+          if ! status="$(curl --silent --show-error \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --output "${models_file}" \
+            --write-out '%{http_code}' \
             --header "Authorization: Bearer ${OPENAI_API_KEY}" \
-            "https://api.openai.com/v1/models")"
+            "https://api.openai.com/v1/models")"; then
+            echo "Unable to list models for the OPENAI_API_KEY project." >&2
+            exit 1
+          fi
           if [ "${status}" != "200" ]; then
             echo "Unable to list models for the OPENAI_API_KEY project (HTTP ${status})." >&2
             exit 1

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -95,11 +95,22 @@ jobs:
             exit 1
           fi
 
-          status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+          models_file="$(mktemp)"
+          trap 'rm -f "${models_file}"' EXIT
+          status="$(curl --silent --show-error --output "${models_file}" --write-out '%{http_code}' \
             --header "Authorization: Bearer ${OPENAI_API_KEY}" \
-            "https://api.openai.com/v1/models/${CODEX_REVIEW_MODEL}")"
+            "https://api.openai.com/v1/models")"
           if [ "${status}" != "200" ]; then
-            echo "The configured Codex review model '${CODEX_REVIEW_MODEL}' is not available to the OPENAI_API_KEY project (HTTP ${status})." >&2
+            echo "Unable to list models for the OPENAI_API_KEY project (HTTP ${status})." >&2
+            exit 1
+          fi
+
+          if ! jq --exit-status --arg model "${CODEX_REVIEW_MODEL}" \
+            '.data | any(.id == $model)' "${models_file}" >/dev/null; then
+            echo "The configured Codex review model '${CODEX_REVIEW_MODEL}' is not available to the OPENAI_API_KEY project." >&2
+            echo "Available GPT-5/Codex model IDs:" >&2
+            jq --raw-output '.data[].id | select(test("^gpt-5|codex"; "i"))' "${models_file}" \
+              | sort -u >&2
             exit 1
           fi
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  # PR conversation comments returned 403 with issues: write alone.
   pull-requests: write
 
 concurrency:

--- a/docs/contributing/PULL_REQUEST_WORKFLOW.md
+++ b/docs/contributing/PULL_REQUEST_WORKFLOW.md
@@ -30,6 +30,8 @@ Path-scoped security and image workflows continue to run when their files change
 - `@coderabbitai full review` — request a fresh CodeRabbit review of the frozen final diff.
 - `@coderabbitai pause` / `@coderabbitai resume` — override automatic CodeRabbit review behavior when needed.
 
+The optional targeted Codex workflow requires the `OPENAI_API_KEY` repository secret and a `CODEX_REVIEW_MODEL` repository variable naming a model available to that key's API project. The action and CLI versions are pinned so model defaults cannot change between review runs.
+
 CodeRabbit and Codex reviews are advisory. The protected branch requires the consolidated CI gate, CodeQL, a pull request, and resolved conversations. Maintainers retain an emergency administrator bypass; force pushes and branch deletion remain blocked.
 
 ## Maintainer checklist

--- a/tests/test_pr_workflow_policy.py
+++ b/tests/test_pr_workflow_policy.py
@@ -80,3 +80,18 @@ def test_coderabbit_reviews_one_draft_checkpoint_then_pauses() -> None:
     assert auto_review["drafts"] == "true"
     assert auto_review["auto_incremental_review"] == "true"
     assert auto_review["auto_pause_after_reviewed_commits"] == "1"
+
+
+def test_targeted_codex_review_pins_model_and_tooling() -> None:
+    workflow = _load_yaml(ROOT / ".github" / "workflows" / "codex-review.yml")
+    review_job = workflow["jobs"]["review"]
+    steps = {step["id"]: step for step in review_job["steps"] if "id" in step}
+
+    assert workflow["permissions"]["pull-requests"] == "write"
+    assert "vars.CODEX_REVIEW_MODEL" in steps["openai"]["env"]["CODEX_REVIEW_MODEL"]
+
+    codex_step = steps["run_codex"]
+    assert codex_step["uses"].startswith("openai/codex-action@")
+    assert not codex_step["uses"].endswith("@v1")
+    assert codex_step["with"]["model"] == "${{ steps.openai.outputs.model }}"
+    assert codex_step["with"]["codex-version"] == "0.145.0"

--- a/tests/test_pr_workflow_policy.py
+++ b/tests/test_pr_workflow_policy.py
@@ -88,10 +88,12 @@ def test_targeted_codex_review_pins_model_and_tooling() -> None:
     steps = {step["id"]: step for step in review_job["steps"] if "id" in step}
 
     assert workflow["permissions"]["pull-requests"] == "write"
-    assert "vars.CODEX_REVIEW_MODEL" in steps["openai"]["env"]["CODEX_REVIEW_MODEL"]
+    assert steps["openai"]["env"]["CODEX_REVIEW_MODEL"] == "${{ vars.CODEX_REVIEW_MODEL }}"
 
     codex_step = steps["run_codex"]
-    assert codex_step["uses"].startswith("openai/codex-action@")
-    assert not codex_step["uses"].endswith("@v1")
+    assert (
+        codex_step["uses"]
+        == "openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56"
+    )
     assert codex_step["with"]["model"] == "${{ steps.openai.outputs.model }}"
     assert codex_step["with"]["codex-version"] == "0.145.0"

--- a/tests/test_pr_workflow_policy.py
+++ b/tests/test_pr_workflow_policy.py
@@ -88,6 +88,7 @@ def test_targeted_codex_review_pins_model_and_tooling() -> None:
     steps = {step["id"]: step for step in review_job["steps"] if "id" in step}
 
     assert workflow["permissions"]["pull-requests"] == "write"
+    assert "issues" not in workflow["permissions"]
     assert steps["openai"]["env"]["CODEX_REVIEW_MODEL"] == "${{ vars.CODEX_REVIEW_MODEL }}"
 
     codex_step = steps["run_codex"]

--- a/tests/test_pr_workflow_policy.py
+++ b/tests/test_pr_workflow_policy.py
@@ -90,6 +90,10 @@ def test_targeted_codex_review_pins_model_and_tooling() -> None:
     assert workflow["permissions"]["pull-requests"] == "write"
     assert "issues" not in workflow["permissions"]
     assert steps["openai"]["env"]["CODEX_REVIEW_MODEL"] == "${{ vars.CODEX_REVIEW_MODEL }}"
+    preflight = steps["openai"]["run"]
+    assert 'if [ -z "${CODEX_REVIEW_MODEL}" ]; then' in preflight
+    assert '"https://api.openai.com/v1/models"' in preflight
+    assert ".data | any(.id == $model)" in preflight
 
     codex_step = steps["run_codex"]
     assert (


### PR DESCRIPTION
## Summary

Fix the optional targeted Codex review workflow after its first production run authenticated successfully but selected an API model unavailable to the configured project and could not post its result.

## Related Issue(s)

- GitHub issue(s): none; follow-up to the targeted review failure on #555

## Implementation Notes

- Key files touched:
  - `.github/workflows/codex-review.yml`
  - `tests/test_pr_workflow_policy.py`
  - `docs/contributing/PULL_REQUEST_WORKFLOW.md`
- Require and preflight the repository-level `CODEX_REVIEW_MODEL` against the configured API project, with bounded network timeouts.
- Pass the verified model explicitly and pin the observed working Codex action/CLI versions.
- Grant only `pull-requests: write` for publishing the advisory result; `issues: write` was removed after end-to-end verification.
- Repository configuration: `CODEX_REVIEW_MODEL=gpt-5`, the model verified as available to the API project.

## Testing

- [x] Unit tests: `python -m pytest -q tests/test_pr_workflow_policy.py tests/test_github_workflow_security.py` (7 passed)
- [x] Integration: targeted review run 29971735214 passed on `d425508f`; API preflight, Codex review, and PR result comment all succeeded with the final least-privilege token scope
- [x] Final CI: run 29971859608 passed on final head `c146fcdf`, including Docker image-size validation and `PR gate`
- [x] CodeQL passed on final head `c146fcdf`
- [ ] `agent check` (not applicable: CI-only change)
- [ ] `agent rca` (not applicable)
- [ ] `./scripts/rca_collect.sh` (not applicable)

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [x] Review fixes were pushed as cohesive batches
- [x] Final head is frozen, the PR is ready, and the final CI gate has passed
- [x] `@coderabbitai full review` completed; all actionable threads are resolved on the final head
- [x] Optional `codex-review` workflow completed after the final functional workflow change; the subsequent final-head commit only added its requested regression assertions
- [x] All actionable conversations are resolved

## Documentation

- [x] Other workflow documentation: `docs/contributing/PULL_REQUEST_WORKFLOW.md`
- [ ] `CHANGELOG.md` (not needed for an internal CI workflow correction)
