### PR TITLE
Fix v7.5.1 apply safety and realtime transcript integrity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,6 +68,9 @@ dev-debug.log
 # Environment files (SECURITY: Never include in image)
 .env
 .env.*
+.agent/
+data/
+secrets/
 .venv
 venv/
 ENV/
@@ -118,6 +121,8 @@ dist/
 
 # Package managers
 node_modules/
+**/node_modules/
+admin_ui/frontend/node_modules/
 pip-wheel-metadata/
 
 # Taskmaster-AI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Admin UI environment apply is recoverable** ([#552](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/552)): updater-image preparation now finishes before a running service is touched, and runtime data, secrets, and updater state are excluded from Docker build contexts. Compose replacements retain a rollback image and the previous container environment; a failed or unhealthy replacement restores the prior service when possible and returns its exact recovery state to the UI instead of leaving `ai_engine` absent.
+- **OpenAI and Grok call history retains complete assistant replies** ([#554](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/554)): assistant transcript accumulation is scoped by response/item and caller-final transcripts no longer clear it. Interleaved caller speech, consecutive replies, cancellations, and both supported realtime transcript event variants finalize independently. The fix is forward-only and does not rewrite existing call records.
+- **Tool changes distinguish Apply from Restart** ([#556](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/556)): managed-tool create, replace, patch, and delete responses now report `apply_required`, `restart_required`, `recommended_apply_method`, and an apply plan. Engine and Admin UI reconciliation share one classifier, pipeline STT/LLM/TTS adapters are no longer reported as newly added full-agent providers, and the Tools page offers hot reload for tool-only changes while preserving restarts for provider and process-level changes.
 - **Release documentation consistency:** corrected the v7.5.0 installation,
   migration, recovery, support-policy, roadmap, contributor, outbound-calling,
   CLI, and validation-matrix references. CI now derives the current release

--- a/README.md
+++ b/README.md
@@ -167,6 +167,27 @@ docker compose -p asterisk-ai-voice-agent logs -f ai_engine
 ## 🎉 What's New
 
 <details open>
+<summary><b>Upcoming v7.5.1 — Safer Admin apply and complete call history</b></summary>
+
+The v7.5.1 hotfix focuses on recovery and observability without changing audio
+profiles, provider transport, or fresh-install defaults.
+
+- **Recoverable Apply Changes** — the Admin UI prepares its updater runner
+  before touching a live service and restores the previous image and container
+  environment if a Compose replacement fails or does not become healthy.
+- **Complete realtime transcripts** — OpenAI and Grok keep assistant transcript
+  state separate from interleaved caller-final events, preventing clipped
+  prefixes in Call History and post-call consumers.
+- **Apply instead of unnecessary restart** — tool-only edits advertise and use
+  hot reload for new calls. Provider, environment, and process-level changes
+  remain on the restart/recreate path.
+
+No database migration or audio-profile reassignment is required. Existing
+stored transcripts are not rewritten.
+
+</details>
+
+<details>
 <summary><b>v7.5.0 — Enhanced telephony audio and VICIdial integration 🎧</b></summary>
 
 **v7.5.0 improves narrowband call audio without changing the established

--- a/admin_ui/Dockerfile
+++ b/admin_ui/Dockerfile
@@ -1,11 +1,11 @@
 # Stage 1: Build Frontend
 FROM node:20-bookworm-slim AS frontend-builder
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/package-lock.json* ./
+COPY admin_ui/frontend/package.json admin_ui/frontend/package-lock.json* ./
 # Install all deps including devDependencies for build (vite, typescript, etc.)
 RUN npm ci || npm install
 ARG CACHEBUST=1
-COPY frontend/ .
+COPY admin_ui/frontend/ .
 RUN npm run build
 # Note: devDependencies are only in builder stage, not in final image
 
@@ -45,17 +45,22 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 RUN useradd --create-home -u 1000 appuser
 
 # Install Python dependencies (bcrypt has manylinux wheels, no gcc needed)
-COPY backend/requirements.txt .
+COPY admin_ui/backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code
-COPY backend/ .
+COPY admin_ui/backend/ .
+
+# Keep config apply/restart classification identical to the AI Engine. The
+# Admin image has a separate runtime tree, so copy the dependency-free shared
+# policy into its import root from the same repository source file.
+COPY src/config_apply.py ./config_apply.py
 
 # Copy built frontend assets to backend's static directory
 COPY --from=frontend-builder /app/frontend/dist ./static
 
 # Entrypoint: ensure appuser can access the Docker socket regardless of host docker group GID.
-COPY entrypoint.sh /app/entrypoint.sh
+COPY admin_ui/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Expose default port (can be overridden by UVICORN_PORT)

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -809,6 +809,43 @@ def persist_config_content(content: str) -> dict:
     }
 
 
+async def _fetch_engine_config_state() -> Optional[Dict[str, Any]]:
+    """Read engine-owned apply state without making config saves depend on it."""
+    import httpx
+
+    engine_url = os.getenv("AI_ENGINE_HEALTH_URL", "http://localhost:15000")
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(engine_url.rstrip("/") + "/config/state")
+        if response.status_code != 200:
+            return None
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        logger.debug("Engine config state unavailable after config save", exc_info=True)
+        return None
+
+
+async def reconcile_apply_result_with_engine_state(result: dict) -> dict:
+    """Overlay a pre-existing deferred restart onto save-time diff metadata."""
+    state = await _fetch_engine_config_state()
+    if not state or state.get("restart_required") is not True:
+        return result
+
+    reconciled = dict(result)
+    reconciled["restart_required"] = True
+    reconciled["recommended_apply_method"] = "restart"
+    reconciled["apply_plan"] = [{
+        "service": "ai_engine",
+        "method": "restart",
+        "endpoint": "/api/system/containers/ai_engine/restart",
+    }]
+    reconciled["message"] = (
+        "Configuration saved. Restart AI Engine to finish applying pending changes."
+    )
+    return reconciled
+
+
 @router.get("")
 @router.get("/")
 async def get_config():
@@ -821,7 +858,8 @@ async def update_yaml_config(update: ConfigUpdate):
         # Persist via the shared helper (also used by the structured tools CRUD
         # API). MED-E1 email validation now lives inside persist_config_content
         # so every persistence path enforces it (not just this endpoint).
-        return persist_config_content(update.content)
+        result = persist_config_content(update.content)
+        return await reconcile_apply_result_with_engine_state(result)
     except HTTPException:
         raise
     except Exception as e:

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -20,6 +20,16 @@ from typing import Dict, Any, Optional, Union
 from urllib.parse import urlparse
 import settings
 
+try:
+    # The production Admin image copies the shared module into /app.
+    from config_apply import classify_config_change
+except ModuleNotFoundError:
+    # Source checkout/tests: import the same canonical module from root src/.
+    PROJECT_SOURCE_ROOT = Path(__file__).resolve().parents[3]
+    if str(PROJECT_SOURCE_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_SOURCE_ROOT))
+    from src.config_apply import classify_config_change
+
 # A11: Maximum number of backups to keep
 MAX_BACKUPS = 5
 
@@ -780,61 +790,21 @@ def persist_config_content(content: str) -> dict:
     # Write to LOCAL override file (keeps base ai-agent.yaml clean for git)
     _write_local_config(local_content)
 
-    # Determine recommended apply method based on what changed
-    # hot_reload: contexts, MCP servers, greetings/instructions only
-    # restart: most YAML changes (providers, pipelines, transport, VAD, etc.)
-    # recreate: .env changes (handled separately in /env endpoint)
-    recommended_method = "restart"  # Default for YAML changes
-
-    # Check if change is limited to hot-reloadable sections
-    try:
-        if old_merged:
-            # Keys that can be hot-reloaded.
-            # barge_in is read live from self.config per-call (every barge-in path
-            # does getattr(self.config, "barge_in", None)), so YAML tuning of it
-            # applies to new calls without dropping active ones (MED-R1).
-            # vad is NOT hot-reloadable: EnhancedVADManager, webrtcvad.Vad,
-            # self._vad_mode and AudioGatingManager are built once from config.vad
-            # in Engine.__init__, and _reload_handler does not rebuild them — so a
-            # vad-only save must use the restart path to actually apply.
-            # streaming is NOT hot-reloadable for the same reason
-            # (StreamingPlaybackManager reads its params once at construction).
-            # Both kept on the restart path (bot re-review, Finding 2).
-            # no_input is resolved into an immutable per-call policy when a new
-            # session starts, so it is safe to hot-reload without changing calls
-            # already in progress.
-            hot_reload_keys = {
-                'contexts', 'profiles', 'barge_in', 'no_input',
-                # v7.4 immutable tool generations: these apply atomically to new calls.
-                'tools', 'in_call_tools', 'farewell_hangup_delay_sec',
-                'on_provider_failure', 'provider_failure_prompt',
-                'provider_failure_redirect_context',
-                'provider_failure_redirect_extension',
-                'provider_failure_redirect_priority',
-            }
-
-            # Check if only hot-reloadable keys changed
-            all_keys = set(old_merged.keys()) | set(new_parsed.keys())
-            changed_keys = set()
-            for key in all_keys:
-                if old_merged.get(key) != new_parsed.get(key):
-                    changed_keys.add(key)
-
-            if changed_keys and changed_keys.issubset(hot_reload_keys):
-                recommended_method = "hot_reload"
-    except Exception:
-        pass  # Fall back to restart if comparison fails
-
-    apply_plan = ([{"service": "ai_engine", "method": "hot_reload", "endpoint": "/api/system/containers/ai_engine/reload"}]
-                 if recommended_method == "hot_reload"
-                 else [{"service": "ai_engine", "method": "restart", "endpoint": "/api/system/containers/ai_engine/restart"}])
+    decision = classify_config_change(old_merged, new_parsed)
+    recommended_method = decision.recommended_apply_method
+    apply_plan = decision.apply_plan()
 
     return {
         "status": "success",
-        "restart_required": recommended_method != "hot_reload",
+        "apply_required": decision.apply_required,
+        "restart_required": decision.restart_required,
         "recommended_apply_method": recommended_method,
         "apply_plan": apply_plan,
-        "message": f"Configuration saved. {'Hot reload' if recommended_method == 'hot_reload' else 'Restart'} AI Engine to apply changes.",
+        "message": (
+            "Configuration saved. No runtime changes detected."
+            if recommended_method == "none"
+            else f"Configuration saved. {'Hot reload' if recommended_method == 'hot_reload' else 'Restart'} AI Engine to apply changes."
+        ),
         "warnings": warnings,
     }
 

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -904,12 +904,26 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
         previous_environment = list(
             ((getattr(previous, "attrs", None) or {}).get("Config", {}).get("Env") or [])
         )
-        if previous_running and getattr(previous, "image", None) is not None:
+        if previous_running:
+            previous_image = getattr(previous, "image", None)
+            if (
+                previous_image is None
+                or not previous_image_ref
+                or previous_image_ref.startswith("sha256:")
+                or "@" in previous_image_ref
+            ):
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        "Cannot safely recreate the service because its current "
+                        "image has no restorable tag; service was not changed"
+                    ),
+                )
             rollback_ref = (
                 f"aava-recreate-rollback/{service_name}:"
                 f"{uuid.uuid4().hex[:12]}"
             )
-            if not previous.image.tag(rollback_ref):
+            if not previous_image.tag(rollback_ref):
                 raise HTTPException(
                     status_code=500,
                     detail="Failed to create a rollback image tag; service was not changed",
@@ -936,8 +950,10 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
         except Exception:
             logger.debug(
                 "Failed to remove recreate rollback tag",
-                service=safe_container_name,
-                rollback_ref=rollback_ref,
+                extra={
+                    "service": safe_container_name,
+                    "rollback_ref": rollback_ref,
+                },
                 exc_info=True,
             )
 
@@ -945,7 +961,7 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
         if not rollback_ref or not previous_image_ref:
             return
         image = client.images.get(rollback_ref)
-        if "@" in previous_image_ref:
+        if previous_image_ref.startswith("sha256:") or "@" in previous_image_ref:
             raise RuntimeError("Cannot restore a digest-only image reference")
         slash = previous_image_ref.rfind("/")
         colon = previous_image_ref.rfind(":")

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -153,6 +153,11 @@ def _compose_files_flags_for_recovery(
     return f"{flags} -f docker-compose.gpu.yml"
 
 
+def _escape_compose_environment(previous_environment: List[str]) -> List[str]:
+    """Preserve literal dollar signs when values pass through Compose YAML."""
+    return [entry.replace("$", "$$") for entry in previous_environment]
+
+
 def _sanitize_for_log(value: str) -> str:
     """Best-effort: prevent log injection via control characters."""
     try:
@@ -994,7 +999,9 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
                         {
                             "services": {
                                 service_name: {
-                                    "environment": previous_environment,
+                                    "environment": _escape_compose_environment(
+                                        previous_environment
+                                    ),
                                 }
                             }
                         },

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -10,6 +10,7 @@ import logging
 import re
 import subprocess
 import threading
+import tempfile
 import time
 import uuid
 import yaml
@@ -978,14 +979,16 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
                     os.chmod(recovery_dir, 0o700)
                 except OSError:
                     pass
-                recovery_override_path = os.path.join(
-                    recovery_dir, f"{service_name}-{uuid.uuid4().hex}.yml"
+                # Do not include request-derived service data in the path. The
+                # OS creates the file atomically under the fixed recovery
+                # directory, and the open descriptor is restricted before any
+                # captured environment is written.
+                fd, recovery_override_path = tempfile.mkstemp(
+                    prefix="recreate-",
+                    suffix=".yml",
+                    dir=recovery_dir,
                 )
-                fd = os.open(
-                    recovery_override_path,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                    0o600,
-                )
+                os.fchmod(fd, 0o600)
                 with os.fdopen(fd, "w", encoding="utf-8") as recovery_file:
                     yaml.safe_dump(
                         {

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -117,6 +117,41 @@ def _compose_files_flags_for_service(service_name: str) -> str:
     return "-f docker-compose.yml -f docker-compose.gpu.yml"
 
 
+def _compose_files_flags_for_recovery(
+    service_name: str,
+    previous_environment: List[str],
+    project_root: str,
+) -> str:
+    """Rebuild the prior service with the Compose topology it actually used."""
+    svc = {
+        "local-ai-server": "local_ai_server",
+        "ai-engine": "ai_engine",
+        "admin-ui": "admin_ui",
+    }.get(service_name, service_name)
+    if svc != "local_ai_server":
+        return "-f docker-compose.yml"
+
+    previous_values = {}
+    for entry in previous_environment:
+        key, separator, value = entry.partition("=")
+        if separator:
+            previous_values[key] = value
+
+    flags = "-f docker-compose.yml"
+    if not _is_truthy_env(previous_values.get("GPU_AVAILABLE")):
+        return flags
+
+    gpu_compose = os.path.join(project_root, "docker-compose.gpu.yml")
+    if not os.path.exists(gpu_compose):
+        logger.warning(
+            "Previously running local_ai_server used GPU_AVAILABLE=true but %s "
+            "is unavailable during recovery; falling back to base compose",
+            _sanitize_for_log(gpu_compose),
+        )
+        return flags
+    return f"{flags} -f docker-compose.gpu.yml"
+
+
 def _sanitize_for_log(value: str) -> str:
     """Best-effort: prevent log injection via control characters."""
     try:
@@ -789,7 +824,6 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
     Returns:
         Dict with status, method, and health_status fields
     """
-    import httpx
     host_root = _project_host_root_from_admin_ui_container()
 
     # Normalize legacy hyphenated service names to canonical underscored service names.
@@ -828,73 +862,248 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
     container_name = config["container"]
     safe_container_name = _sanitize_for_log(container_name)
 
-    try:
-        # First stop and remove the existing container to avoid name conflicts
+    compose_files = _compose_files_flags_for_service(service_name)
+    compose_prefix = f"{compose_files} " if compose_files else ""
+    timeout_sec = 600 if service_name == "local_ai_server" else 300
+
+    # Prepare the runner before inspecting or changing the service. Build, pull,
+    # permission, network, and disk failures therefore leave the current
+    # container completely untouched.
+    sha = _current_project_head_sha()
+    updater_tag = _ensure_updater_image_for_ref(
+        host_root,
+        _updater_image_tag_for_sha(sha),
+        prefer_pull_ref=None,
+        allow_build=True,
+    )
+
+    client = docker.from_env()
+    previous_running = False
+    previous_container_id: Optional[str] = None
+    previous_image_ref: Optional[str] = None
+    previous_environment: List[str] = []
+    rollback_ref: Optional[str] = None
+    previous = _find_compose_service_container(client, container_name)
+    if previous is not None:
         try:
-            client = docker.from_env()
-            container = client.containers.get(container_name)
-            logger.info("Stopping container %s before recreate", safe_container_name)
-            container.stop(timeout=10)
-            container.remove()
-            logger.info("Container %s stopped and removed", safe_container_name)
-        except docker.errors.NotFound:
-            logger.info("Container %s not found, will create fresh", safe_container_name)
-        except Exception as e:
-            logger.warning("Error stopping container %s", safe_container_name, exc_info=True)
-        
-        # Run compose in updater-runner so relative binds resolve on the host correctly.
-        compose_files = _compose_files_flags_for_service(service_name)
-        compose_prefix = f"{compose_files} " if compose_files else ""
-        cmd = (
-            "set -euo pipefail; "
-            "cd \"$PROJECT_ROOT\"; "
-            f"docker compose {compose_prefix}-p asterisk-ai-voice-agent up -d --force-recreate --no-build {service_name}"
+            previous.reload()
+        except Exception:
+            pass
+        previous_running = getattr(previous, "status", None) == "running"
+        previous_container_id = getattr(previous, "id", None)
+        previous_image_ref = (
+            (getattr(previous, "attrs", None) or {}).get("Config", {}).get("Image")
+            or getattr(getattr(previous, "image", None), "id", None)
         )
-        timeout_sec = 600 if service_name == "local_ai_server" else 300
-        code, out = _run_updater_ephemeral(
-            host_root,
-            env={"PROJECT_ROOT": host_root},
-            command=cmd,
-            timeout_sec=timeout_sec,
+        previous_environment = list(
+            ((getattr(previous, "attrs", None) or {}).get("Config", {}).get("Env") or [])
         )
-        if code != 0:
-            raise HTTPException(status_code=500, detail=f"Failed to recreate via compose: {(out or '').strip()[:800]}")
-        
-        # Health check polling after successful recreate
-        health_status = "skipped"
-        if health_check:
-            health_status = await _poll_health(
-                service_name,
-                timeout_seconds=config["health_timeout"],
+        if previous_running and getattr(previous, "image", None) is not None:
+            rollback_ref = (
+                f"aava-recreate-rollback/{service_name}:"
+                f"{uuid.uuid4().hex[:12]}"
             )
-        
-        # Return appropriate status based on health check result
-        # Don't claim success if health check timed out or failed
-        if health_status == "timeout":
-            return {
-                "status": "degraded",
-                "method": "docker-compose",
-                "output": (out or "").strip() or "Service recreated but health check timed out",
-                "health_status": health_status,
-            }
-        elif health_status == "unhealthy":
-            return {
-                "status": "degraded",
-                "method": "docker-compose",
-                "output": (out or "").strip() or "Service recreated but not healthy",
-                "health_status": health_status,
-            }
-        
-        return {
-            "status": "success", 
-            "method": "docker-compose", 
-            "output": (out or "").strip() or "Service recreated",
-            "health_status": health_status,
+            if not previous.image.tag(rollback_ref):
+                raise HTTPException(
+                    status_code=500,
+                    detail="Failed to create a rollback image tag; service was not changed",
+                )
+
+    def _service_state() -> tuple[bool, Optional[str]]:
+        current = _find_compose_service_container(client, container_name)
+        if current is None:
+            return False, None
+        try:
+            current.reload()
+        except Exception:
+            pass
+        return (
+            getattr(current, "status", None) == "running",
+            getattr(current, "id", None),
+        )
+
+    def _remove_rollback_tag() -> None:
+        if not rollback_ref:
+            return
+        try:
+            client.images.remove(rollback_ref, noprune=True)
+        except Exception:
+            logger.debug(
+                "Failed to remove recreate rollback tag",
+                service=safe_container_name,
+                rollback_ref=rollback_ref,
+                exc_info=True,
+            )
+
+    def _restore_previous_image_tag() -> None:
+        if not rollback_ref or not previous_image_ref:
+            return
+        image = client.images.get(rollback_ref)
+        if "@" in previous_image_ref:
+            raise RuntimeError("Cannot restore a digest-only image reference")
+        slash = previous_image_ref.rfind("/")
+        colon = previous_image_ref.rfind(":")
+        if colon > slash:
+            repository, tag = previous_image_ref[:colon], previous_image_ref[colon + 1:]
+        else:
+            repository, tag = previous_image_ref, "latest"
+        if not image.tag(repository, tag=tag, force=True):
+            raise RuntimeError("Docker refused the rollback image tag")
+
+    async def _raise_recreate_failure(
+        message: str,
+        *,
+        original_output: str,
+        health_status: Optional[str] = None,
+    ) -> None:
+        service_available, current_container_id = _service_state()
+        recovery_status = "not_needed" if service_available else "unavailable"
+        recovery_output = ""
+
+        if previous_running and rollback_ref and (
+            not service_available
+            or current_container_id != previous_container_id
+            or health_status in {"timeout", "unhealthy"}
+        ):
+            recovery_override_path: Optional[str] = None
+            try:
+                _restore_previous_image_tag()
+                # Compose must use the exact environment captured from the
+                # previously running container, not the newly saved .env values
+                # that may have caused the failed replacement.
+                project_root = os.getenv("PROJECT_ROOT", "/app/project")
+                recovery_dir = os.path.join(project_root, ".agent", "recreate-recovery")
+                os.makedirs(recovery_dir, mode=0o700, exist_ok=True)
+                try:
+                    os.chmod(recovery_dir, 0o700)
+                except OSError:
+                    pass
+                recovery_override_path = os.path.join(
+                    recovery_dir, f"{service_name}-{uuid.uuid4().hex}.yml"
+                )
+                fd = os.open(
+                    recovery_override_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                with os.fdopen(fd, "w", encoding="utf-8") as recovery_file:
+                    yaml.safe_dump(
+                        {
+                            "services": {
+                                service_name: {
+                                    "environment": previous_environment,
+                                }
+                            }
+                        },
+                        recovery_file,
+                        default_flow_style=False,
+                        sort_keys=False,
+                    )
+                override_rel = os.path.relpath(recovery_override_path, project_root)
+                recovery_files = _compose_files_flags_for_recovery(
+                    service_name,
+                    previous_environment,
+                    project_root,
+                )
+                recovery_files = f"{recovery_files} -f {override_rel}"
+                recovery_cmd = (
+                    "set -euo pipefail; "
+                    "cd \"$PROJECT_ROOT\"; "
+                    f"docker compose {recovery_files} -p asterisk-ai-voice-agent "
+                    f"up -d --force-recreate --no-build {service_name}"
+                )
+                recovery_code, recovery_output = _run_updater_ephemeral(
+                    host_root,
+                    env={"PROJECT_ROOT": host_root},
+                    command=recovery_cmd,
+                    timeout_sec=timeout_sec,
+                    prepared_image=updater_tag,
+                )
+                service_running, _ = _service_state()
+                service_available = recovery_code == 0 and service_running
+                recovery_status = "recovered" if service_available else "failed"
+            except Exception as recovery_error:
+                recovery_status = "failed"
+                recovery_output = str(recovery_error)
+            finally:
+                if recovery_override_path:
+                    try:
+                        os.remove(recovery_override_path)
+                    except OSError:
+                        logger.warning(
+                            "Failed to remove temporary recreate recovery file",
+                            extra={"service": safe_container_name},
+                            exc_info=True,
+                        )
+
+        if recovery_status in {"not_needed", "recovered"}:
+            _remove_rollback_tag()
+
+        detail = {
+            "message": message,
+            "service": service_name,
+            "service_available": service_available,
+            "recovery_status": recovery_status,
+            "error_output": (original_output or "").strip()[-1200:],
+            "recovery_output": (recovery_output or "").strip()[-1200:],
         }
-    except Exception as e:
-        if isinstance(e, HTTPException):
-            raise
-        raise HTTPException(status_code=500, detail="Failed to recreate service") from e
+        logger.error(
+            "Compose recreate failed",
+            extra={
+                "service": safe_container_name,
+                "service_available": service_available,
+                "recovery_status": recovery_status,
+            },
+        )
+        raise HTTPException(status_code=500, detail=detail)
+
+    cmd = (
+        "set -euo pipefail; "
+        "cd \"$PROJECT_ROOT\"; "
+        f"docker compose {compose_prefix}-p asterisk-ai-voice-agent "
+        f"up -d --force-recreate --no-build {service_name}"
+    )
+    code, out = _run_updater_ephemeral(
+        host_root,
+        env={"PROJECT_ROOT": host_root},
+        command=cmd,
+        timeout_sec=timeout_sec,
+        prepared_image=updater_tag,
+    )
+    if code != 0:
+        await _raise_recreate_failure(
+            "Failed to apply environment changes with Docker Compose",
+            original_output=out or "",
+        )
+
+    if not _service_state()[0]:
+        await _raise_recreate_failure(
+            "Docker Compose returned successfully but the replacement service is not running",
+            original_output=out or "",
+        )
+
+    health_status = "skipped"
+    if health_check:
+        health_status = await _poll_health(
+            service_name,
+            timeout_seconds=config["health_timeout"],
+        )
+    if health_status in {"timeout", "unhealthy"}:
+        await _raise_recreate_failure(
+            "Replacement service did not become healthy; the previous image was restored when possible",
+            original_output=out or "",
+            health_status=health_status,
+        )
+
+    _remove_rollback_tag()
+    return {
+        "status": "success",
+        "method": "docker-compose",
+        "output": (out or "").strip() or "Service recreated",
+        "health_status": health_status,
+        "recovery_status": "not_needed",
+        "service_available": _service_state()[0],
+    }
 
 
 async def _poll_health(service_name: str, timeout_seconds: int = 30) -> str:
@@ -1033,12 +1242,14 @@ async def reload_ai_engine():
         if resp.status_code == 200:
             data = resp.json()
             changes = data.get("changes", [])
-                
-            # Check if any change requires a restart (new providers, removed providers, deferred reload)
-            restart_required = any(
-                any(marker in str(c).lower() for marker in ("restart needed", "restart required", "reload deferred"))
-                for c in changes
-            )
+            # Prefer the engine's shared classification. Keep marker detection
+            # only as a compatibility fallback for older engine versions.
+            restart_required = data.get("restart_required")
+            if restart_required is None:
+                restart_required = any(
+                    any(marker in str(c).lower() for marker in ("restart needed", "restart required", "reload deferred"))
+                    for c in changes
+                )
                 
             if restart_required:
                 return {
@@ -1046,6 +1257,8 @@ async def reload_ai_engine():
                     "message": "Config updated but some changes require a restart to fully apply",
                     "changes": changes,
                     "restart_required": True,
+                    "apply_required": False,
+                    "recommended_apply_method": "restart",
                     "tool_generation": data.get("tool_generation"),
                     "tool_config_hash": data.get("tool_config_hash"),
                 }
@@ -1055,6 +1268,8 @@ async def reload_ai_engine():
                 "message": data.get("message", "Configuration reloaded"),
                 "changes": changes,
                 "restart_required": False,
+                "apply_required": False,
+                "recommended_apply_method": "none",
                 "tool_generation": data.get("tool_generation"),
                 "tool_config_hash": data.get("tool_config_hash"),
             }
@@ -4411,6 +4626,7 @@ def _run_updater_ephemeral(
     capture_stderr: bool = True,
     prefer_pull_ref: Optional[str] = None,
     allow_build: bool = True,
+    prepared_image: Optional[str] = None,
 ) -> tuple[int, str]:
     """
     Run the updater image as a short-lived container and return (exit_code, stdout/stderr).
@@ -4419,16 +4635,19 @@ def _run_updater_ephemeral(
     """
     import uuid
 
-    sha = _current_project_head_sha()
-    tag = _updater_image_tag_for_sha(sha)
-    source_ref = None if prefer_pull_ref else (env or {}).get("AAVA_UPDATE_REF")
-    tag = _ensure_updater_image_for_ref(
-        host_project_root,
-        tag,
-        prefer_pull_ref=prefer_pull_ref,
-        allow_build=allow_build,
-        source_ref=source_ref,
-    )
+    if prepared_image:
+        tag = _validate_docker_image_ref(prepared_image)
+    else:
+        sha = _current_project_head_sha()
+        tag = _updater_image_tag_for_sha(sha)
+        source_ref = None if prefer_pull_ref else (env or {}).get("AAVA_UPDATE_REF")
+        tag = _ensure_updater_image_for_ref(
+            host_project_root,
+            tag,
+            prefer_pull_ref=prefer_pull_ref,
+            allow_build=allow_build,
+            source_ref=source_ref,
+        )
 
     client = docker.from_env()
     name = f"aava-update-ephemeral-{uuid.uuid4().hex[:10]}"
@@ -5969,7 +6188,10 @@ async def asterisk_status():
 _CONFIG_STATE_SAFE_FALLBACK = {
     "running_config_hash": None,
     "disk_config_hash": None,
+    "apply_required": False,
     "restart_required": False,
+    "recommended_apply_method": "none",
+    "apply_plan": [],
     "disk_config_valid": True,
     "engine_reachable": False,
 }

--- a/admin_ui/backend/api/system.py
+++ b/admin_ui/backend/api/system.py
@@ -952,7 +952,7 @@ async def _recreate_via_compose(service_name: str, health_check: bool = True):
                 "Failed to remove recreate rollback tag",
                 extra={
                     "service": safe_container_name,
-                    "rollback_ref": rollback_ref,
+                    "rollback_ref": _sanitize_for_log(rollback_ref),
                 },
                 exc_info=True,
             )

--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -2,7 +2,7 @@
 Tools API endpoints for testing HTTP tools before saving.
 """
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Dict, Any, Optional, List, Literal
 import httpx
 import json
@@ -1094,6 +1094,19 @@ class ManagedToolOut(BaseModel):
     enabled: bool
     is_global: bool
     config: Dict[str, Any]
+    apply_required: Optional[bool] = None
+    restart_required: Optional[bool] = None
+    recommended_apply_method: Optional[str] = None
+    apply_plan: Optional[List[Dict[str, str]]] = None
+
+
+class ManagedToolDeleteOut(BaseModel):
+    name: str
+    deleted: bool = True
+    apply_required: bool
+    restart_required: bool
+    recommended_apply_method: str
+    apply_plan: List[Dict[str, str]] = Field(default_factory=list)
 
 
 def _kind_for_phase(phase: str) -> str:
@@ -1274,7 +1287,42 @@ def _persist_cfg(cfg: Dict[str, Any]) -> dict:
     return config_api.persist_config_content(content)
 
 
-def _to_out(block: str, name: str, doc: Dict[str, Any]) -> ManagedToolOut:
+def _apply_metadata(result: Optional[dict]) -> Dict[str, Any]:
+    result = result or {}
+    apply_required = bool(result.get("apply_required", True))
+    restart_required = bool(result.get("restart_required", False))
+    method = str(
+        result.get("recommended_apply_method")
+        or ("restart" if restart_required else "hot_reload" if apply_required else "none")
+    )
+    raw_plan = result.get("apply_plan")
+    if raw_plan is None:
+        if method == "none":
+            raw_plan = []
+        else:
+            raw_plan = [{
+                "service": "ai_engine",
+                "method": "restart" if method == "restart" else "hot_reload",
+                "endpoint": (
+                    "/api/system/containers/ai_engine/restart"
+                    if method == "restart"
+                    else "/api/system/containers/ai_engine/reload"
+                ),
+            }]
+    return {
+        "apply_required": apply_required,
+        "restart_required": restart_required,
+        "recommended_apply_method": method,
+        "apply_plan": list(raw_plan),
+    }
+
+
+def _to_out(
+    block: str,
+    name: str,
+    doc: Dict[str, Any],
+    apply_result: Optional[dict] = None,
+) -> ManagedToolOut:
     phase = _phase_for(block, doc)
     return ManagedToolOut(
         name=name,
@@ -1284,6 +1332,7 @@ def _to_out(block: str, name: str, doc: Dict[str, Any]) -> ManagedToolOut:
         enabled=bool(doc.get("enabled", True)),
         is_global=bool(doc.get("is_global", False)),
         config=_safe_jsonable(doc),
+        **(_apply_metadata(apply_result) if apply_result is not None else {}),
     )
 
 
@@ -1312,8 +1361,8 @@ async def create_managed_tool(body: ManagedToolWrite):
         raise HTTPException(status_code=500, detail=f"Config '{block}' block is not a mapping")
     section[name] = doc
 
-    _persist_cfg(cfg)
-    return _to_out(block, name, doc)
+    apply_result = _persist_cfg(cfg)
+    return _to_out(block, name, doc, apply_result)
 
 
 @router.get("/managed/{name}", response_model=ManagedToolOut)
@@ -1344,8 +1393,8 @@ async def replace_managed_tool(name: str, body: ManagedToolWrite):
         raise HTTPException(status_code=500, detail=f"Config '{target_block}' block is not a mapping")
     section[name] = doc
 
-    _persist_cfg(cfg)
-    return _to_out(target_block, name, doc)
+    apply_result = _persist_cfg(cfg)
+    return _to_out(target_block, name, doc, apply_result)
 
 
 @router.patch("/managed/{name}", response_model=ManagedToolOut)
@@ -1392,11 +1441,11 @@ async def patch_managed_tool(name: str, body: ManagedToolPatch):
         raise HTTPException(status_code=500, detail=f"Config '{target_block}' block is not a mapping")
     section[name] = merged
 
-    _persist_cfg(cfg)
-    return _to_out(target_block, name, merged)
+    apply_result = _persist_cfg(cfg)
+    return _to_out(target_block, name, merged, apply_result)
 
 
-@router.delete("/managed/{name}", status_code=204)
+@router.delete("/managed/{name}", response_model=ManagedToolDeleteOut)
 async def delete_managed_tool(name: str):
     """Delete a managed HTTP tool from the config."""
     cfg = _load_cfg()
@@ -1404,8 +1453,8 @@ async def delete_managed_tool(name: str):
     if block is None:
         raise HTTPException(status_code=404, detail=f"Tool '{name}' not found")
     _remove_tool_everywhere(cfg, name)
-    _persist_cfg(cfg)
-    return None
+    apply_result = _persist_cfg(cfg)
+    return ManagedToolDeleteOut(name=name, **_apply_metadata(apply_result))
 
 
 # ============================================================================

--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -1282,9 +1282,10 @@ def _load_cfg() -> Dict[str, Any]:
     return cfg
 
 
-def _persist_cfg(cfg: Dict[str, Any]) -> dict:
+async def _persist_cfg(cfg: Dict[str, Any]) -> dict:
     content = yaml.dump(cfg, default_flow_style=False, sort_keys=False)
-    return config_api.persist_config_content(content)
+    result = config_api.persist_config_content(content)
+    return await config_api.reconcile_apply_result_with_engine_state(result)
 
 
 def _apply_metadata(result: Optional[dict]) -> Dict[str, Any]:
@@ -1361,7 +1362,7 @@ async def create_managed_tool(body: ManagedToolWrite):
         raise HTTPException(status_code=500, detail=f"Config '{block}' block is not a mapping")
     section[name] = doc
 
-    apply_result = _persist_cfg(cfg)
+    apply_result = await _persist_cfg(cfg)
     return _to_out(block, name, doc, apply_result)
 
 
@@ -1393,7 +1394,7 @@ async def replace_managed_tool(name: str, body: ManagedToolWrite):
         raise HTTPException(status_code=500, detail=f"Config '{target_block}' block is not a mapping")
     section[name] = doc
 
-    apply_result = _persist_cfg(cfg)
+    apply_result = await _persist_cfg(cfg)
     return _to_out(target_block, name, doc, apply_result)
 
 
@@ -1441,7 +1442,7 @@ async def patch_managed_tool(name: str, body: ManagedToolPatch):
         raise HTTPException(status_code=500, detail=f"Config '{target_block}' block is not a mapping")
     section[name] = merged
 
-    apply_result = _persist_cfg(cfg)
+    apply_result = await _persist_cfg(cfg)
     return _to_out(target_block, name, merged, apply_result)
 
 
@@ -1453,7 +1454,7 @@ async def delete_managed_tool(name: str):
     if block is None:
         raise HTTPException(status_code=404, detail=f"Tool '{name}' not found")
     _remove_tool_everywhere(cfg, name)
-    apply_result = _persist_cfg(cfg)
+    apply_result = await _persist_cfg(cfg)
     return ManagedToolDeleteOut(name=name, **_apply_metadata(apply_result))
 
 
@@ -1592,7 +1593,7 @@ async def patch_builtin_tool(name: str, body: Dict[str, Any]):
         raise HTTPException(status_code=500, detail="Config 'tools' block is not a mapping")
     current = tools.get(name)
     tools[name] = _deep_merge(current if isinstance(current, dict) else {}, body)
-    _persist_cfg(cfg)
+    await _persist_cfg(cfg)
     return _builtin_to_out(name, cfg)
 
 
@@ -1607,7 +1608,7 @@ async def replace_builtin_tool(name: str, body: Dict[str, Any]):
     if not isinstance(tools, dict):
         raise HTTPException(status_code=500, detail="Config 'tools' block is not a mapping")
     tools[name] = dict(body)
-    _persist_cfg(cfg)
+    await _persist_cfg(cfg)
     return _builtin_to_out(name, cfg)
 
 
@@ -1686,7 +1687,7 @@ async def patch_tools_settings(body: Dict[str, Any]):
                 raise HTTPException(status_code=422, detail=f"'{k}' looks like a managed tool (has 'kind'); use POST/PUT /api/tools/managed/{k}")
         cfg["tools"] = _deep_merge(tools, patch)
 
-    _persist_cfg(cfg)
+    await _persist_cfg(cfg)
     delay = cfg.get(_FAREWELL_DELAY_KEY)
     return ToolsSettingsOut(
         farewell_hangup_delay_sec=delay if isinstance(delay, (int, float)) else None,

--- a/admin_ui/backend/tests/test_config_apply_method_v701.py
+++ b/admin_ui/backend/tests/test_config_apply_method_v701.py
@@ -22,6 +22,11 @@ def _patch_io(monkeypatch, old_merged, new_parsed):
     monkeypatch.setattr(config_api, "_compute_local_override", lambda base, parsed: parsed)
     monkeypatch.setattr(config_api, "_write_local_config", lambda content: None)
 
+    async def _no_engine_state():
+        return None
+
+    monkeypatch.setattr(config_api, "_fetch_engine_config_state", _no_engine_state)
+
 
 @pytest.mark.asyncio
 async def test_streaming_only_save_recommends_restart(monkeypatch):
@@ -61,3 +66,26 @@ async def test_streaming_plus_vad_save_recommends_restart(monkeypatch):
     _patch_io(monkeypatch, old, new)
     resp = await update_yaml_config(ConfigUpdate(content="x"))
     assert resp["recommended_apply_method"] == "restart"
+
+
+@pytest.mark.asyncio
+async def test_pending_engine_restart_overrides_hot_reload_save(monkeypatch):
+    old = {"tools": {}}
+    new = {"tools": {"lookup": {"kind": "generic_http_lookup"}}}
+    _patch_io(monkeypatch, old, new)
+
+    async def _pending_restart():
+        return {"restart_required": True}
+
+    monkeypatch.setattr(config_api, "_fetch_engine_config_state", _pending_restart)
+
+    resp = await update_yaml_config(ConfigUpdate(content="x"))
+
+    assert resp["apply_required"] is True
+    assert resp["restart_required"] is True
+    assert resp["recommended_apply_method"] == "restart"
+    assert resp["apply_plan"] == [{
+        "service": "ai_engine",
+        "method": "restart",
+        "endpoint": "/api/system/containers/ai_engine/restart",
+    }]

--- a/admin_ui/backend/tests/test_safe_recreate.py
+++ b/admin_ui/backend/tests/test_safe_recreate.py
@@ -56,6 +56,60 @@ async def test_compose_failure_keeps_still_running_service_available():
 
 
 @pytest.mark.asyncio
+async def test_digest_only_previous_image_aborts_before_compose():
+    previous = MagicMock()
+    previous.status = "running"
+    previous.attrs = {"Config": {}}
+    previous.image.id = "sha256:abcdef123456"
+    client = MagicMock()
+
+    with patch.object(
+        system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
+    ), patch.object(system, "_current_project_head_sha", return_value="abc123"), patch.object(
+        system, "_ensure_updater_image_for_ref", return_value="updater:test"
+    ), patch.object(system.docker, "from_env", return_value=client), patch.object(
+        system, "_find_compose_service_container", return_value=previous
+    ), patch.object(system, "_run_updater_ephemeral") as run_updater:
+        with pytest.raises(HTTPException) as exc:
+            await system._recreate_via_compose("ai_engine", health_check=False)
+
+    assert "no restorable tag" in exc.value.detail
+    previous.image.tag.assert_not_called()
+    run_updater.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rollback_tag_cleanup_failure_does_not_hide_success():
+    previous = MagicMock()
+    previous.status = "running"
+    previous.id = "old-container"
+    previous.attrs = {"Config": {"Image": "aava-ai-engine:latest"}}
+    previous.image.tag.return_value = True
+    replacement = MagicMock()
+    replacement.status = "running"
+    replacement.id = "new-container"
+    client = MagicMock()
+    client.images.remove.side_effect = RuntimeError("cleanup failed")
+
+    with patch.object(
+        system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
+    ), patch.object(system, "_current_project_head_sha", return_value="abc123"), patch.object(
+        system, "_ensure_updater_image_for_ref", return_value="updater:test"
+    ), patch.object(system.docker, "from_env", return_value=client), patch.object(
+        system,
+        "_find_compose_service_container",
+        side_effect=[previous, replacement, replacement],
+    ), patch.object(
+        system, "_run_updater_ephemeral", return_value=(0, "service recreated")
+    ):
+        result = await system._recreate_via_compose("ai_engine", health_check=False)
+
+    assert result["status"] == "success"
+    assert result["service_available"] is True
+    client.images.remove.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_compose_failure_restores_previous_image_when_service_disappears(
     monkeypatch, tmp_path
 ):

--- a/admin_ui/backend/tests/test_safe_recreate.py
+++ b/admin_ui/backend/tests/test_safe_recreate.py
@@ -63,7 +63,11 @@ async def test_compose_failure_restores_previous_image_when_service_disappears(
     previous = MagicMock()
     previous.status = "running"
     previous.attrs = {"Config": {"Image": "asterisk-ai-voice-agent-ai-engine:latest"}}
-    previous.attrs["Config"]["Env"] = ["OPENAI_API_KEY=old-secret", "TZ=UTC"]
+    previous.attrs["Config"]["Env"] = [
+        "OPENAI_API_KEY=old-secret",
+        "TOKEN=ab$cd",
+        "TZ=UTC",
+    ]
     previous.image.tag.return_value = True
     recovered = MagicMock()
     recovered.status = "running"
@@ -71,6 +75,26 @@ async def test_compose_failure_restores_previous_image_when_service_disappears(
     rollback_image.tag.return_value = True
     client = MagicMock()
     client.images.get.return_value = rollback_image
+
+    captured_recovery_environment = []
+    updater_calls = 0
+
+    def run_updater(*args, **kwargs):
+        nonlocal updater_calls
+        updater_calls += 1
+        if updater_calls == 1:
+            return 1, "replacement failed after stop"
+        override_paths = list(
+            (tmp_path / ".agent" / "recreate-recovery").glob("*.yml")
+        )
+        assert len(override_paths) == 1
+        override = system.yaml.safe_load(
+            override_paths[0].read_text(encoding="utf-8")
+        )
+        captured_recovery_environment.extend(
+            override["services"]["ai_engine"]["environment"]
+        )
+        return 0, "previous image restored"
 
     with patch.object(
         system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
@@ -83,7 +107,7 @@ async def test_compose_failure_restores_previous_image_when_service_disappears(
     ), patch.object(
         system,
         "_run_updater_ephemeral",
-        side_effect=[(1, "replacement failed after stop"), (0, "previous image restored")],
+        side_effect=run_updater,
     ) as run_updater:
         with pytest.raises(HTTPException) as exc:
             await system._recreate_via_compose("ai_engine", health_check=False)
@@ -94,6 +118,9 @@ async def test_compose_failure_restores_previous_image_when_service_disappears(
     rollback_image.tag.assert_called_once_with(
         "asterisk-ai-voice-agent-ai-engine", tag="latest", force=True
     )
+    # Compose reduces $$ to a literal $, so the restored container receives the
+    # original TOKEN=ab$cd rather than interpolating $cd from the host.
+    assert "TOKEN=ab$$cd" in captured_recovery_environment
     assert list((tmp_path / ".agent" / "recreate-recovery").glob("*.yml")) == []
     previous.stop.assert_not_called()
     previous.remove.assert_not_called()

--- a/admin_ui/backend/tests/test_safe_recreate.py
+++ b/admin_ui/backend/tests/test_safe_recreate.py
@@ -1,0 +1,143 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from api import system  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_updater_preparation_failure_does_not_touch_service():
+    with patch.object(
+        system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
+    ), patch.object(system, "_current_project_head_sha", return_value="abc123"), patch.object(
+        system,
+        "_ensure_updater_image_for_ref",
+        side_effect=HTTPException(status_code=500, detail="build context unreadable"),
+    ), patch.object(system.docker, "from_env") as docker_from_env:
+        with pytest.raises(HTTPException) as exc:
+            await system._recreate_via_compose("ai_engine", health_check=False)
+
+    assert exc.value.detail == "build context unreadable"
+    docker_from_env.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compose_failure_keeps_still_running_service_available():
+    previous = MagicMock()
+    previous.status = "running"
+    previous.attrs = {"Config": {"Image": "asterisk-ai-voice-agent-ai-engine:latest"}}
+    previous.image.tag.return_value = True
+    client = MagicMock()
+    client.images.remove.return_value = None
+
+    with patch.object(
+        system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
+    ), patch.object(system, "_current_project_head_sha", return_value="abc123"), patch.object(
+        system, "_ensure_updater_image_for_ref", return_value="updater:test"
+    ), patch.object(system.docker, "from_env", return_value=client), patch.object(
+        system, "_find_compose_service_container", return_value=previous
+    ), patch.object(
+        system, "_run_updater_ephemeral", return_value=(1, "compose rejected config")
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await system._recreate_via_compose("ai_engine", health_check=False)
+
+    assert exc.value.detail["service_available"] is True
+    assert exc.value.detail["recovery_status"] == "not_needed"
+    previous.stop.assert_not_called()
+    previous.remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compose_failure_restores_previous_image_when_service_disappears(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    previous = MagicMock()
+    previous.status = "running"
+    previous.attrs = {"Config": {"Image": "asterisk-ai-voice-agent-ai-engine:latest"}}
+    previous.attrs["Config"]["Env"] = ["OPENAI_API_KEY=old-secret", "TZ=UTC"]
+    previous.image.tag.return_value = True
+    recovered = MagicMock()
+    recovered.status = "running"
+    rollback_image = MagicMock()
+    rollback_image.tag.return_value = True
+    client = MagicMock()
+    client.images.get.return_value = rollback_image
+
+    with patch.object(
+        system, "_project_host_root_from_admin_ui_container", return_value="/srv/aava"
+    ), patch.object(system, "_current_project_head_sha", return_value="abc123"), patch.object(
+        system, "_ensure_updater_image_for_ref", return_value="updater:test"
+    ), patch.object(system.docker, "from_env", return_value=client), patch.object(
+        system,
+        "_find_compose_service_container",
+        side_effect=[previous, None, recovered],
+    ), patch.object(
+        system,
+        "_run_updater_ephemeral",
+        side_effect=[(1, "replacement failed after stop"), (0, "previous image restored")],
+    ) as run_updater:
+        with pytest.raises(HTTPException) as exc:
+            await system._recreate_via_compose("ai_engine", health_check=False)
+
+    assert exc.value.detail["service_available"] is True
+    assert exc.value.detail["recovery_status"] == "recovered"
+    assert run_updater.call_count == 2
+    rollback_image.tag.assert_called_once_with(
+        "asterisk-ai-voice-agent-ai-engine", tag="latest", force=True
+    )
+    assert list((tmp_path / ".agent" / "recreate-recovery").glob("*.yml")) == []
+    previous.stop.assert_not_called()
+    previous.remove.assert_not_called()
+
+
+def test_runtime_data_and_secrets_are_excluded_from_root_build_context():
+    dockerignore = (PROJECT_ROOT / ".dockerignore").read_text(encoding="utf-8")
+
+    assert "data/" in dockerignore.splitlines()
+    assert "secrets/" in dockerignore.splitlines()
+    assert ".agent/" in dockerignore.splitlines()
+    assert "**/node_modules/" in dockerignore.splitlines()
+
+
+def test_admin_image_packages_shared_config_apply_policy():
+    compose = (PROJECT_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    dockerfile = (PROJECT_ROOT / "admin_ui" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    assert "context: ." in compose
+    assert "dockerfile: admin_ui/Dockerfile" in compose
+    assert "COPY src/config_apply.py ./config_apply.py" in dockerfile
+
+
+def test_recovery_uses_previous_gpu_topology(tmp_path):
+    (tmp_path / "docker-compose.gpu.yml").touch()
+
+    flags = system._compose_files_flags_for_recovery(
+        "local_ai_server",
+        ["GPU_AVAILABLE=true", "TZ=UTC"],
+        str(tmp_path),
+    )
+
+    assert flags == "-f docker-compose.yml -f docker-compose.gpu.yml"
+
+
+def test_recovery_does_not_use_new_gpu_setting_for_previous_cpu_service(tmp_path):
+    (tmp_path / "docker-compose.gpu.yml").touch()
+
+    flags = system._compose_files_flags_for_recovery(
+        "local_ai_server",
+        ["GPU_AVAILABLE=false", "TZ=UTC"],
+        str(tmp_path),
+    )
+
+    assert flags == "-f docker-compose.yml"

--- a/admin_ui/backend/tests/test_tools_managed_api.py
+++ b/admin_ui/backend/tests/test_tools_managed_api.py
@@ -18,7 +18,7 @@ def client(monkeypatch):
     }
     monkeypatch.setattr(tools_api, "_load_cfg", lambda: copy.deepcopy(state["cfg"]))
 
-    def fake_persist(cfg):
+    async def fake_persist(cfg):
         state["cfg"] = copy.deepcopy(cfg)
         return {
             "status": "success",
@@ -568,6 +568,11 @@ def email_client(monkeypatch):
         state["cfg"] = yaml.safe_load(content) or {}
 
     monkeypatch.setattr(config_api, "_write_local_config", _record_write)
+
+    async def _no_engine_state():
+        return None
+
+    monkeypatch.setattr(config_api, "_fetch_engine_config_state", _no_engine_state)
 
     app = FastAPI()
     app.include_router(tools_api.router, prefix="/api/tools")

--- a/admin_ui/backend/tests/test_tools_managed_api.py
+++ b/admin_ui/backend/tests/test_tools_managed_api.py
@@ -20,7 +20,17 @@ def client(monkeypatch):
 
     def fake_persist(cfg):
         state["cfg"] = copy.deepcopy(cfg)
-        return {"status": "success", "restart_required": True}
+        return {
+            "status": "success",
+            "apply_required": True,
+            "restart_required": False,
+            "recommended_apply_method": "hot_reload",
+            "apply_plan": [{
+                "service": "ai_engine",
+                "method": "hot_reload",
+                "endpoint": "/api/system/containers/ai_engine/reload",
+            }],
+        }
 
     monkeypatch.setattr(tools_api, "_persist_cfg", fake_persist)
 
@@ -46,6 +56,9 @@ def test_crud_roundtrip_pre_call(client):
     assert body["block"] == "tools"
     assert body["config"]["method"] == "GET"  # pre_call default
     assert body["config"]["timeout_ms"] == 2000
+    assert body["apply_required"] is True
+    assert body["restart_required"] is False
+    assert body["recommended_apply_method"] == "hot_reload"
 
     # List excludes ai_identity but includes our tool
     names = {t["name"] for t in client.get("/api/tools/managed").json()}
@@ -63,7 +76,20 @@ def test_crud_roundtrip_pre_call(client):
     assert r.json()["config"]["url"] == "https://api.example.com/lookup"
 
     # Delete
-    assert client.delete("/api/tools/managed/crm_lookup").status_code == 204
+    deleted = client.delete("/api/tools/managed/crm_lookup")
+    assert deleted.status_code == 200
+    assert deleted.json() == {
+        "name": "crm_lookup",
+        "deleted": True,
+        "apply_required": True,
+        "restart_required": False,
+        "recommended_apply_method": "hot_reload",
+        "apply_plan": [{
+            "service": "ai_engine",
+            "method": "hot_reload",
+            "endpoint": "/api/system/containers/ai_engine/reload",
+        }],
+    }
     assert client.get("/api/tools/managed/crm_lookup").status_code == 404
 
 
@@ -491,8 +517,12 @@ def test_openapi_surfaces_managed_tool_schema():
     assert "/api/tools/managed/{name}" in spec["paths"]
     assert "ManagedToolOut" in spec["components"]["schemas"]
     out = spec["components"]["schemas"]["ManagedToolOut"]
-    for col in ("name", "phase", "kind", "block", "enabled", "is_global", "config"):
+    for col in (
+        "name", "phase", "kind", "block", "enabled", "is_global", "config",
+        "apply_required", "restart_required", "recommended_apply_method", "apply_plan",
+    ):
         assert col in out["properties"], col
+    assert "ManagedToolDeleteOut" in spec["components"]["schemas"]
     list_schema = spec["paths"]["/api/tools/managed"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
     assert list_schema.get("type") == "array"
     # Built-in + settings resources are present and typed too.

--- a/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
@@ -18,6 +18,18 @@ const configState = (restart_required: boolean) => ({
     },
 });
 
+const hotReloadState = {
+    data: {
+        running_config_hash: 'a',
+        disk_config_hash: 'b',
+        apply_required: true,
+        restart_required: false,
+        recommended_apply_method: 'hot_reload' as const,
+        disk_config_valid: true,
+        engine_reachable: true,
+    },
+};
+
 describe('useRestartRequired', () => {
     afterEach(() => {
         vi.useRealTimers();
@@ -42,6 +54,19 @@ describe('useRestartRequired', () => {
 
         await waitFor(() => expect(result.current.loading).toBe(false));
         expect(result.current.restartRequired).toBe(false);
+
+        unmount();
+    });
+
+    it('distinguishes a hot-reload apply from a restart', async () => {
+        mockedGet.mockResolvedValue(hotReloadState);
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.applyRequired).toBe(true);
+        expect(result.current.restartRequired).toBe(false);
+        expect(result.current.recommendedApplyMethod).toBe('hot_reload');
 
         unmount();
     });

--- a/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.test.ts
@@ -67,6 +67,7 @@ describe('useRestartRequired', () => {
         expect(result.current.applyRequired).toBe(true);
         expect(result.current.restartRequired).toBe(false);
         expect(result.current.recommendedApplyMethod).toBe('hot_reload');
+        expect(result.current.stateStale).toBe(false);
 
         unmount();
     });
@@ -88,13 +89,34 @@ describe('useRestartRequired', () => {
         unmount();
     });
 
-    it('treats request errors as no restart required', async () => {
+    it('keeps conservative defaults but reports stale state on an initial error', async () => {
         mockedGet.mockRejectedValue(new Error('network down'));
 
         const { result, unmount } = renderHook(() => useRestartRequired());
 
         await waitFor(() => expect(result.current.loading).toBe(false));
         expect(result.current.restartRequired).toBe(false);
+        expect(result.current.applyRequired).toBe(false);
+        expect(result.current.stateStale).toBe(true);
+
+        unmount();
+    });
+
+    it('preserves the last-known apply action when a later poll fails', async () => {
+        mockedGet.mockResolvedValueOnce(hotReloadState);
+
+        const { result, unmount } = renderHook(() => useRestartRequired());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        mockedGet.mockRejectedValueOnce(new Error('temporary outage'));
+        await act(async () => {
+            await result.current.refetch();
+        });
+
+        expect(result.current.applyRequired).toBe(true);
+        expect(result.current.restartRequired).toBe(false);
+        expect(result.current.recommendedApplyMethod).toBe('hot_reload');
+        expect(result.current.stateStale).toBe(true);
 
         unmount();
     });

--- a/admin_ui/frontend/src/hooks/useRestartRequired.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.ts
@@ -5,6 +5,8 @@ interface ConfigState {
     running_config_hash: string | null;
     disk_config_hash: string | null;
     restart_required: boolean;
+    apply_required?: boolean;
+    recommended_apply_method?: 'none' | 'hot_reload' | 'restart';
     disk_config_valid: boolean;
     engine_reachable: boolean;
 }
@@ -14,10 +16,14 @@ const POLL_INTERVAL_MS = 15000;
 
 export function useRestartRequired(): {
     restartRequired: boolean;
+    applyRequired: boolean;
+    recommendedApplyMethod: 'none' | 'hot_reload' | 'restart';
     refetch: () => Promise<void>;
     loading: boolean;
 } {
     const [restartRequired, setRestartRequired] = useState(false);
+    const [applyRequired, setApplyRequired] = useState(false);
+    const [recommendedApplyMethod, setRecommendedApplyMethod] = useState<'none' | 'hot_reload' | 'restart'>('none');
     const [loading, setLoading] = useState(true);
     // Latest-response-wins: a slower older request (e.g. the 15s poll) must not
     // overwrite a newer one (e.g. a post-save/restart refetch) with stale data.
@@ -28,12 +34,22 @@ export function useRestartRequired(): {
         try {
             const res = await axios.get<ConfigState>(CONFIG_STATE_URL);
             if (seq === requestSeq.current) {
-                setRestartRequired(res.data?.restart_required === true);
+                const needsRestart = res.data?.restart_required === true;
+                const needsApply = res.data?.apply_required === true;
+                setRestartRequired(needsRestart);
+                setApplyRequired(needsApply);
+                setRecommendedApplyMethod(
+                    needsRestart
+                        ? 'restart'
+                        : (res.data?.recommended_apply_method || (needsApply ? 'hot_reload' : 'none'))
+                );
             }
         } catch {
             // Never false-alarm: treat any error as "no restart required".
             if (seq === requestSeq.current) {
                 setRestartRequired(false);
+                setApplyRequired(false);
+                setRecommendedApplyMethod('none');
             }
         } finally {
             if (seq === requestSeq.current) {
@@ -57,5 +73,5 @@ export function useRestartRequired(): {
         };
     }, [refetch]);
 
-    return { restartRequired, refetch, loading };
+    return { restartRequired, applyRequired, recommendedApplyMethod, refetch, loading };
 }

--- a/admin_ui/frontend/src/hooks/useRestartRequired.ts
+++ b/admin_ui/frontend/src/hooks/useRestartRequired.ts
@@ -18,12 +18,14 @@ export function useRestartRequired(): {
     restartRequired: boolean;
     applyRequired: boolean;
     recommendedApplyMethod: 'none' | 'hot_reload' | 'restart';
+    stateStale: boolean;
     refetch: () => Promise<void>;
     loading: boolean;
 } {
     const [restartRequired, setRestartRequired] = useState(false);
     const [applyRequired, setApplyRequired] = useState(false);
     const [recommendedApplyMethod, setRecommendedApplyMethod] = useState<'none' | 'hot_reload' | 'restart'>('none');
+    const [stateStale, setStateStale] = useState(false);
     const [loading, setLoading] = useState(true);
     // Latest-response-wins: a slower older request (e.g. the 15s poll) must not
     // overwrite a newer one (e.g. a post-save/restart refetch) with stale data.
@@ -43,13 +45,13 @@ export function useRestartRequired(): {
                         ? 'restart'
                         : (res.data?.recommended_apply_method || (needsApply ? 'hot_reload' : 'none'))
                 );
+                setStateStale(false);
             }
         } catch {
-            // Never false-alarm: treat any error as "no restart required".
+            // Keep the last known action visible during transient failures.
+            // On an initial failure the conservative defaults remain false.
             if (seq === requestSeq.current) {
-                setRestartRequired(false);
-                setApplyRequired(false);
-                setRecommendedApplyMethod('none');
+                setStateStale(true);
             }
         } finally {
             if (seq === requestSeq.current) {
@@ -73,5 +75,5 @@ export function useRestartRequired(): {
         };
     }, [refetch]);
 
-    return { restartRequired, applyRequired, recommendedApplyMethod, refetch, loading };
+    return { restartRequired, applyRequired, recommendedApplyMethod, stateStale, refetch, loading };
 }

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -421,7 +421,22 @@ const EnvPage = () => {
             setApplyPlan([]);
             toast.success('Changes applied');
         } catch (error: any) {
-            toast.error('Failed to apply changes', { description: error.response?.data?.detail || error.message });
+            const detail = error.response?.data?.detail;
+            if (detail && typeof detail === 'object') {
+                const recovered = detail.recovery_status === 'recovered' || (
+                    detail.recovery_status === 'not_needed' && detail.service_available
+                );
+                const description = recovered
+                    ? `${detail.message || 'Changes were not applied.'} The previous service is running; you can correct the setting and retry.`
+                    : `${detail.message || 'Changes were not applied.'} Automatic recovery did not complete; check the container status before retrying.`;
+                if (recovered) {
+                    toast.warning('Changes not applied; service remains available', { description });
+                } else {
+                    toast.error('Failed to apply changes', { description });
+                }
+            } else {
+                toast.error('Failed to apply changes', { description: detail || error.message });
+            }
         } finally {
             setRestartingEngine(false);
         }

--- a/admin_ui/frontend/src/pages/ToolsPage.tsx
+++ b/admin_ui/frontend/src/pages/ToolsPage.tsx
@@ -42,7 +42,7 @@ const ToolsPage = () => {
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
     const [applyStatus, setApplyStatus] = useState<string | null>(null);
-    const { restartRequired, applyRequired, recommendedApplyMethod, refetch } = useRestartRequired();
+    const { restartRequired, applyRequired, recommendedApplyMethod, stateStale, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [activePhase, setActivePhase] = useState<ToolPhase>('in_call');
     const [toolCatalog, setToolCatalog] = useState<ToolDef[]>([]);
@@ -338,9 +338,12 @@ const ToolsPage = () => {
                 <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
                     <div className="flex items-center">
                         <AlertCircle className="w-5 h-5 mr-2" />
-                        {recommendedApplyMethod === 'hot_reload'
-                            ? 'Saved tool changes are ready to apply to new calls. Active calls will remain unchanged.'
-                            : 'Some saved configuration changes require an AI Engine restart to take effect.'}
+                        <span>
+                            {recommendedApplyMethod === 'hot_reload'
+                                ? 'Saved tool changes are ready to apply to new calls. Active calls will remain unchanged.'
+                                : 'Some saved configuration changes require an AI Engine restart to take effect.'}
+                            {stateStale && ' Status refresh failed; showing the last known action.'}
+                        </span>
                     </div>
                     <button
                         onClick={handleApplyAIEngine}
@@ -356,6 +359,12 @@ const ToolsPage = () => {
                             ? (recommendedApplyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
                             : (recommendedApplyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
                     </button>
+                </div>
+            )}
+            {stateStale && !applyRequired && !restartRequired && (
+                <div className="bg-yellow-500/10 border-yellow-500/30 border text-yellow-800 dark:text-yellow-500 p-3 rounded-md flex items-center">
+                    <AlertCircle className="w-5 h-5 mr-2" />
+                    Unable to refresh the AI Engine apply status. No pending action is known; retry after connectivity recovers.
                 </div>
             )}
             {applyStatus && (

--- a/admin_ui/frontend/src/pages/ToolsPage.tsx
+++ b/admin_ui/frontend/src/pages/ToolsPage.tsx
@@ -42,7 +42,7 @@ const ToolsPage = () => {
     const [yamlError, setYamlError] = useState<YamlErrorInfo | null>(() => getCachedConfig()?.yamlError ?? null);
     const [saving, setSaving] = useState(false);
     const [applyStatus, setApplyStatus] = useState<string | null>(null);
-    const { restartRequired, refetch } = useRestartRequired();
+    const { restartRequired, applyRequired, recommendedApplyMethod, refetch } = useRestartRequired();
     const [restartingEngine, setRestartingEngine] = useState(false);
     const [activePhase, setActivePhase] = useState<ToolPhase>('in_call');
     const [toolCatalog, setToolCatalog] = useState<ToolDef[]>([]);
@@ -215,6 +215,34 @@ const ToolsPage = () => {
         }
     };
 
+    const handleApplyAIEngine = async () => {
+        if (recommendedApplyMethod !== 'hot_reload') {
+            await handleRestartAIEngine(false);
+            return;
+        }
+        setRestartingEngine(true);
+        try {
+            const response = await axios.post('/api/system/containers/ai_engine/reload', {}, {
+                headers: { Authorization: `Bearer ${token}` },
+                timeout: 30000,
+            });
+            if (response.data?.restart_required) {
+                setApplyStatus('Hot reload applied partially. Restart the AI Engine to finish applying changes.');
+                toast.warning('Restart still required', { description: response.data?.message });
+            } else {
+                const generation = response.data?.tool_generation;
+                const message = `Applied${generation ? ` as tool generation ${generation}` : ''}. New calls use it; active calls remain unchanged.`;
+                setApplyStatus(message);
+                toast.success('Changes applied', { description: message });
+            }
+            await refetch();
+        } catch (error: any) {
+            toast.error('Failed to apply changes', { description: error.response?.data?.detail || error.message });
+        } finally {
+            setRestartingEngine(false);
+        }
+    };
+
     const mergeToolsConfig = (baseConfig: any, newToolsConfig: any) => {
         // Extract root-level settings that should not be nested under tools
         const {
@@ -306,14 +334,16 @@ const ToolsPage = () => {
 
     return (
         <div className="space-y-6">
-            {restartRequired && (
+            {(applyRequired || restartRequired) && (
                 <div className="bg-orange-500/15 border-orange-500/30 border text-yellow-800 dark:text-yellow-500 p-4 rounded-md flex items-center justify-between">
                     <div className="flex items-center">
                         <AlertCircle className="w-5 h-5 mr-2" />
-                        Some saved configuration changes require an AI Engine restart to take effect.
+                        {recommendedApplyMethod === 'hot_reload'
+                            ? 'Saved tool changes are ready to apply to new calls. Active calls will remain unchanged.'
+                            : 'Some saved configuration changes require an AI Engine restart to take effect.'}
                     </div>
                     <button
-                        onClick={() => handleRestartAIEngine(false)}
+                        onClick={handleApplyAIEngine}
                         disabled={restartingEngine}
                         className="flex items-center text-xs px-3 py-1.5 rounded transition-colors bg-orange-500 text-white hover:bg-orange-600 font-medium disabled:opacity-50"
                     >
@@ -322,7 +352,9 @@ const ToolsPage = () => {
                         ) : (
                             <RefreshCw className="w-3 h-3 mr-1.5" />
                         )}
-                        {restartingEngine ? 'Restarting...' : 'Restart AI Engine'}
+                        {restartingEngine
+                            ? (recommendedApplyMethod === 'hot_reload' ? 'Applying...' : 'Restarting...')
+                            : (recommendedApplyMethod === 'hot_reload' ? 'Apply Changes' : 'Restart AI Engine')}
                     </button>
                 </div>
             )}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,8 +153,8 @@ services:
     image: asterisk-ai-voice-agent-admin-ui:latest
     pull_policy: build
     build:
-      context: ./admin_ui
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: admin_ui/Dockerfile
       network: host
     container_name: admin_ui
     network_mode: host

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -2,6 +2,32 @@
 
 This guide covers upgrading between major versions of Asterisk AI Voice Agent.
 
+## v7.5.0 to v7.5.1
+
+v7.5.1 is an in-place hotfix with no database migration, audio-profile change,
+or provider-default change. Follow the normal tagged-release update procedure
+once the release is published.
+
+After upgrading:
+
+1. Recreate both `admin_ui` and `ai_engine` so the UI, API classification, and
+   runtime reconciliation use the same v7.5.1 code.
+2. Open **Tools & Capabilities**. Tool-only changes should show **Apply Changes**
+   and hot reload into a new immutable tool generation; they should not request
+   an AI Engine restart.
+3. Open **System → Environment**, save a harmless environment edit, and apply it
+   only when no calls are active. If replacement preparation or Compose fails,
+   the UI reports whether the previous service stayed available or was restored.
+4. Verify `ai_engine` health before returning the system to production traffic.
+
+Managed-tool `DELETE /api/tools/managed/{name}` now returns HTTP 200 with the
+deleted resource name and apply metadata instead of an empty HTTP 204 response.
+Clients that accepted any 2xx response remain compatible; clients pinned to 204
+must accept the structured 200 response.
+
+The transcript fix applies only to future OpenAI Realtime and Grok calls. It
+does not alter historical Call History records.
+
 ## v7.4.1 to v7.5.0
 
 Released 2026-07-22. Follow the

--- a/src/config_apply.py
+++ b/src/config_apply.py
@@ -8,7 +8,7 @@ hash mismatch from being presented as an unconditional restart requirement.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, FrozenSet, Mapping
+from typing import Any, Dict, FrozenSet, Mapping, Optional
 
 
 HOT_RELOADABLE_ROOT_KEYS: FrozenSet[str] = frozenset(
@@ -28,18 +28,29 @@ HOT_RELOADABLE_ROOT_KEYS: FrozenSet[str] = frozenset(
     }
 )
 
+_INVALID_CONFIG_CHANGE_KEY = "__invalid_config__"
 
-def _as_mapping(config: Any) -> Mapping[str, Any]:
+
+def _as_mapping(config: Any) -> Optional[Mapping[str, Any]]:
+    """Return a mapping representation, or ``None`` when conversion is unsafe."""
     if isinstance(config, Mapping):
         return config
     model_dump = getattr(config, "model_dump", None)
     if callable(model_dump):
-        return model_dump()
+        try:
+            dumped = model_dump()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, Mapping) else None
     legacy_dict = getattr(config, "dict", None)
     if callable(legacy_dict):
-        return legacy_dict()
+        try:
+            dumped = legacy_dict()
+        except Exception:
+            return None
+        return dumped if isinstance(dumped, Mapping) else None
     raw = getattr(config, "__dict__", None)
-    return raw if isinstance(raw, Mapping) else {}
+    return raw if isinstance(raw, Mapping) else None
 
 
 @dataclass(frozen=True)
@@ -71,6 +82,13 @@ def classify_config_change(old_config: Any, new_config: Any) -> ConfigApplyDecis
 
     old = _as_mapping(old_config)
     new = _as_mapping(new_config)
+    if old is None or new is None:
+        return ConfigApplyDecision(
+            changed_keys=frozenset({_INVALID_CONFIG_CHANGE_KEY}),
+            apply_required=True,
+            restart_required=True,
+            recommended_apply_method="restart",
+        )
     changed = frozenset(
         key
         for key in set(old) | set(new)

--- a/src/config_apply.py
+++ b/src/config_apply.py
@@ -1,0 +1,94 @@
+"""Shared classification for applying configuration changes.
+
+The Admin UI and AI Engine must agree on whether a saved YAML change can be
+hot-reloaded or needs a process restart.  Keeping this policy here prevents a
+hash mismatch from being presented as an unconditional restart requirement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, FrozenSet, Mapping
+
+
+HOT_RELOADABLE_ROOT_KEYS: FrozenSet[str] = frozenset(
+    {
+        "contexts",
+        "profiles",
+        "barge_in",
+        "no_input",
+        "tools",
+        "in_call_tools",
+        "farewell_hangup_delay_sec",
+        "on_provider_failure",
+        "provider_failure_prompt",
+        "provider_failure_redirect_context",
+        "provider_failure_redirect_extension",
+        "provider_failure_redirect_priority",
+    }
+)
+
+
+def _as_mapping(config: Any) -> Mapping[str, Any]:
+    if isinstance(config, Mapping):
+        return config
+    model_dump = getattr(config, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    legacy_dict = getattr(config, "dict", None)
+    if callable(legacy_dict):
+        return legacy_dict()
+    raw = getattr(config, "__dict__", None)
+    return raw if isinstance(raw, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class ConfigApplyDecision:
+    changed_keys: FrozenSet[str]
+    apply_required: bool
+    restart_required: bool
+    recommended_apply_method: str
+
+    def apply_plan(self) -> list[Dict[str, str]]:
+        if not self.apply_required:
+            return []
+        method = "restart" if self.restart_required else "hot_reload"
+        endpoint = (
+            "/api/system/containers/ai_engine/restart"
+            if self.restart_required
+            else "/api/system/containers/ai_engine/reload"
+        )
+        return [{"service": "ai_engine", "method": method, "endpoint": endpoint}]
+
+
+def classify_config_change(old_config: Any, new_config: Any) -> ConfigApplyDecision:
+    """Classify a root-level effective-config change.
+
+    Empty changes need no action. Changes limited to the immutable new-call
+    sections can be hot-reloaded; every other change remains fail-closed on the
+    restart path.
+    """
+
+    old = _as_mapping(old_config)
+    new = _as_mapping(new_config)
+    changed = frozenset(
+        key
+        for key in set(old) | set(new)
+        if old.get(key) != new.get(key)
+    )
+    apply_required = bool(changed)
+    restart_required = apply_required and not changed.issubset(
+        HOT_RELOADABLE_ROOT_KEYS
+    )
+    if not apply_required:
+        method = "none"
+    elif restart_required:
+        method = "restart"
+    else:
+        method = "hot_reload"
+    return ConfigApplyDecision(
+        changed_keys=changed,
+        apply_required=apply_required,
+        restart_required=restart_required,
+        recommended_apply_method=method,
+    )

--- a/src/config_apply.py
+++ b/src/config_apply.py
@@ -74,7 +74,7 @@ def classify_config_change(old_config: Any, new_config: Any) -> ConfigApplyDecis
     changed = frozenset(
         key
         for key in set(old) | set(new)
-        if old.get(key) != new.get(key)
+        if key not in old or key not in new or old[key] != new[key]
     )
     apply_required = bool(changed)
     restart_required = apply_required and not changed.issubset(

--- a/src/engine.py
+++ b/src/engine.py
@@ -46,6 +46,7 @@ from .config import (
     OpenAIRealtimeProviderConfig,
     GrokProviderConfig,
 )
+from .config_apply import classify_config_change
 from .config.provider_instances import (
     FULL_AGENT_KINDS,
     provider_kind,
@@ -316,6 +317,7 @@ class Engine:
         self._start_time = time.time()  # Track engine start time for uptime
         self._config_hash = self._compute_config_hash()
         self._config_loaded_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        self._restart_required_after_reload = False
         base_url = f"{config.asterisk.scheme}://{config.asterisk.host}:{config.asterisk.port}/ari"
         self.ari_client = ARIClient(
             username=config.asterisk.username,
@@ -16747,14 +16749,38 @@ class Engine:
             return {
                 "running_config_hash": running_hash,
                 "disk_config_hash": None,
+                "apply_required": False,
                 "restart_required": False,
+                "recommended_apply_method": "none",
+                "apply_plan": [],
                 "disk_config_valid": False,
             }
         disk_hash = self._compute_config_hash(disk_config)
+        decision = classify_config_change(self.config, disk_config)
+        deferred_restart = bool(
+            getattr(self, "_restart_required_after_reload", False)
+        )
+        restart_required = decision.restart_required or deferred_restart
+        apply_required = decision.apply_required
+        if restart_required:
+            recommended_method = "restart"
+        else:
+            recommended_method = decision.recommended_apply_method
         return {
             "running_config_hash": running_hash,
             "disk_config_hash": disk_hash,
-            "restart_required": running_hash != disk_hash,
+            "apply_required": apply_required,
+            "restart_required": restart_required,
+            "recommended_apply_method": recommended_method,
+            "apply_plan": (
+                [{
+                    "service": "ai_engine",
+                    "method": "restart",
+                    "endpoint": "/api/system/containers/ai_engine/restart",
+                }]
+                if restart_required
+                else decision.apply_plan()
+            ),
             "disk_config_valid": True,
             "tool_generation": getattr(getattr(self, "_tool_generation", None), "generation_id", None),
             "tool_config_hash": getattr(getattr(self, "_tool_generation", None), "config_hash", None),
@@ -19882,6 +19908,8 @@ class Engine:
                     "errors": errors
                 }, status=500)
 
+            apply_decision = classify_config_change(self.config, new_config)
+
             # Build every new-call runtime object off-side. Nothing running is
             # mutated unless both tool construction and orchestration validation
             # succeed completely.
@@ -19905,11 +19933,7 @@ class Engine:
                     status=500,
                 )
             
-            # Step 2: Compare and update provider configurations
-            old_providers = set(self.providers.keys()) if self.providers else set()
-            
             # Update config reference
-            old_config = self.config
             self.config = new_config
             self.transport_orchestrator = new_transport_orchestrator
             self._tool_generation = new_tool_generation
@@ -19919,6 +19943,10 @@ class Engine:
             # Recompute config hash after reload so health endpoint shows current state
             self._config_hash = self._compute_config_hash()
             self._config_loaded_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            self._restart_required_after_reload = bool(
+                getattr(self, "_restart_required_after_reload", False)
+                or apply_decision.restart_required
+            )
             changes.append("Configuration updated")
             changes.append(
                 f"Tool runtime generation {new_tool_generation.generation_id} applied "
@@ -19929,36 +19957,14 @@ class Engine:
             # It also refreshes legacy Context data retained strictly for migration diagnostics.
             changes.append("TransportOrchestrator rebuilt (profiles/agents refreshed)")
             
-            # Step 3: Reinitialize providers that have changed
-            try:
-                # Re-register providers with new config
-                new_providers_config = getattr(new_config, 'providers', {})
-                
-                for provider_name, provider_config in new_providers_config.items():
-                    if not getattr(provider_config, 'enabled', True):
-                        continue
-                    
-                    # Check if provider exists and needs update
-                    if provider_name in self.providers:
-                        # Provider exists - check if config changed
-                        old_prov_config = getattr(old_config, 'providers', {}).get(provider_name)
-                        if old_prov_config != provider_config:
-                            changes.append(f"Provider '{provider_name}' configuration updated")
-                    else:
-                        changes.append(f"Provider '{provider_name}' detected (restart needed to add)")
-                
-                # Check for removed providers
-                for old_name in old_providers:
-                    if old_name not in new_providers_config:
-                        changes.append(f"Provider '{old_name}' removed from config (restart needed)")
-                        
-            except Exception as e:
-                errors.append(f"Error updating providers: {str(e)}")
-            
-            # MCP process/credential replacement is intentionally outside the
-            # v7.4 new-call tool-generation contract.
-            if getattr(old_config, "mcp", None) != getattr(new_config, "mcp", None):
-                changes.append("MCP configuration changed (engine restart required)")
+            # Non-hot-reloadable sections are recorded once from the same policy
+            # used by the Admin UI. This avoids treating pipeline adapters such as
+            # local_stt/openai_llm as newly added full-agent providers.
+            if apply_decision.restart_required:
+                changed = ", ".join(sorted(apply_decision.changed_keys))
+                changes.append(
+                    f"Restart required to fully apply configuration sections: {changed}"
+                )
             
             # Step 5: Update prompts
             try:
@@ -19978,6 +19984,11 @@ class Engine:
                 "note": "Changes apply to new calls. Active calls use their captured generation.",
                 "tool_generation": new_tool_generation.generation_id,
                 "tool_config_hash": new_tool_generation.config_hash,
+                "apply_required": False,
+                "restart_required": self._restart_required_after_reload,
+                "recommended_apply_method": (
+                    "restart" if self._restart_required_after_reload else "none"
+                ),
             })
             
         except Exception as exc:

--- a/src/engine.py
+++ b/src/engine.py
@@ -16746,12 +16746,17 @@ class Engine:
             disk_config = load_config()
         except Exception as e:
             logger.warning("Failed to load disk config for state check", error=str(e))
+            deferred_restart = bool(
+                getattr(self, "_restart_required_after_reload", False)
+            )
             return {
                 "running_config_hash": running_hash,
                 "disk_config_hash": None,
                 "apply_required": False,
-                "restart_required": False,
-                "recommended_apply_method": "none",
+                "restart_required": deferred_restart,
+                "recommended_apply_method": (
+                    "restart" if deferred_restart else "none"
+                ),
                 "apply_plan": [],
                 "disk_config_valid": False,
             }

--- a/src/providers/grok.py
+++ b/src/providers/grok.py
@@ -188,7 +188,7 @@ class GrokProvider(AIProviderInterface):
         self._output_resampler_mode = configured_output_resampler
         self._output_resampler_source = output_resampler_source
         self._output_resampler_logged = False
-        self._transcript_buffer: str = ""
+        self._assistant_transcript_buffers: Dict[str, str] = {}
         self._input_info_logged: bool = False
         self._allowed_tools: Optional[List[str]] = None
         
@@ -422,7 +422,7 @@ class GrokProvider(AIProviderInterface):
         self._input_resample_state = None
         self._output_resample_state = None
         self._output_resampler_logged = False
-        self._transcript_buffer = ""
+        self._assistant_transcript_buffers.clear()
         self._closing = False
         self._closed = False
         self._session_started_ts = time.monotonic()
@@ -990,7 +990,7 @@ class GrokProvider(AIProviderInterface):
             self._in_audio_burst = False
             self._input_resample_state = None
             self._output_resample_state = None
-            self._transcript_buffer = ""
+            self._assistant_transcript_buffers.clear()
             logger.info("Grok session stopped")
             self._clear_metrics(previous_call_id)
 
@@ -1883,10 +1883,9 @@ class GrokProvider(AIProviderInterface):
             elif delta_type == "output_text.delta":
                 text = delta.get("text")
                 if text:
-                    await self._emit_transcript(text, is_final=False)
+                    await self._emit_assistant_transcript(event, text, is_final=False)
             elif delta_type == "output_text.done":
-                if self._transcript_buffer:
-                    await self._emit_transcript("", is_final=True)
+                await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # Modern event naming variants (top-level types)
@@ -1945,14 +1944,11 @@ class GrokProvider(AIProviderInterface):
                 elif isinstance(delta, str):
                     text = delta
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         if event_type == "response.audio_transcript.done":
-            if self._transcript_buffer:
-                # Track assistant conversation for email tools
-                await self._track_conversation("assistant", self._transcript_buffer)
-                await self._emit_transcript("", is_final=True)
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         if event_type in ("response.completed", "response.error", "response.cancelled", "response.done"):
@@ -2098,9 +2094,8 @@ class GrokProvider(AIProviderInterface):
                 pass
 
             self._pending_response = False
+            await self._emit_assistant_transcript(event, "", is_final=True)
             self._current_response_id = None  # Clear response ID after completion
-            if self._transcript_buffer:
-                await self._emit_transcript("", is_final=True)
             return
 
         if event_type == "conversation.item.input_audio_transcription.completed":
@@ -2134,7 +2129,7 @@ class GrokProvider(AIProviderInterface):
             delta = event.get("delta") or {}
             text = delta.get("text")
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         # xAI's native text-delta event name (vs OpenAI's response.output_text.delta).
@@ -2142,7 +2137,7 @@ class GrokProvider(AIProviderInterface):
         if event_type == "response.text.delta":
             text = event.get("text") or (event.get("delta") or {}).get("text")
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         # Optional acks/telemetry for audio buffer operations
@@ -2260,14 +2255,11 @@ class GrokProvider(AIProviderInterface):
             elif isinstance(delta, str):
                 text = delta
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         if event_type == "response.output_audio_transcript.done":
-            if self._transcript_buffer:
-                # Track assistant conversation for email tools
-                await self._track_conversation("assistant", self._transcript_buffer)
-                await self._emit_transcript("", is_final=True)
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # CRITICAL FIX #1: Handle session.updated ACK (following Deepgram pattern)
@@ -2592,13 +2584,10 @@ class GrokProvider(AIProviderInterface):
         if not self.on_event or not self._call_id:
             return
 
-        if text:
-            self._transcript_buffer += text
-
         payload = {
             "type": "Transcript",
             "call_id": self._call_id,
-            "text": text or self._transcript_buffer,
+            "text": text,
             "is_final": is_final,
         }
         try:
@@ -2606,8 +2595,50 @@ class GrokProvider(AIProviderInterface):
         except Exception:
             logger.error("Failed to emit transcript event", call_id=self._call_id, exc_info=True)
 
-        if is_final:
-            self._transcript_buffer = ""
+
+    def _assistant_transcript_key(self, event: Dict[str, Any]) -> str:
+        response = event.get("response") or {}
+        response_id = event.get("response_id") or response.get("id") or self._current_response_id
+        item_id = event.get("item_id")
+        if item_id:
+            return f"{response_id or 'response'}:{item_id}"
+        return str(response_id or "unscoped")
+
+    async def _emit_assistant_transcript(
+        self,
+        event: Dict[str, Any],
+        text: str,
+        *,
+        is_final: bool,
+    ) -> None:
+        """Accumulate/finalize only the matching assistant response item."""
+        key = self._assistant_transcript_key(event)
+        if text:
+            self._assistant_transcript_buffers[key] = (
+                self._assistant_transcript_buffers.get(key, "") + text
+            )
+            if not is_final:
+                await self._emit_transcript(text, is_final=False)
+                return
+
+        if not is_final:
+            return
+        keys = [key]
+        if not event.get("item_id"):
+            prefix = f"{key}:"
+            keys.extend(
+                candidate
+                for candidate in self._assistant_transcript_buffers
+                if candidate.startswith(prefix)
+            )
+        complete = "".join(
+            self._assistant_transcript_buffers.pop(candidate, "")
+            for candidate in dict.fromkeys(keys)
+        )
+        if not complete:
+            return
+        await self._track_conversation("assistant", complete)
+        await self._emit_transcript(complete, is_final=True)
 
     async def _track_conversation(self, role: str, text: str):
         """Track conversation turns for email tools (similar to Deepgram implementation)."""

--- a/src/providers/grok.py
+++ b/src/providers/grok.py
@@ -2126,10 +2126,14 @@ class GrokProvider(AIProviderInterface):
             return
 
         if event_type == "response.output_text.delta":
-            delta = event.get("delta") or {}
-            text = delta.get("text")
+            delta = event.get("delta")
+            text = delta.get("text") if isinstance(delta, dict) else delta
             if text:
                 await self._emit_assistant_transcript(event, text, is_final=False)
+            return
+
+        if event_type == "response.output_text.done":
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # xAI's native text-delta event name (vs OpenAI's response.output_text.delta).
@@ -2600,9 +2604,10 @@ class GrokProvider(AIProviderInterface):
         response = event.get("response") or {}
         response_id = event.get("response_id") or response.get("id") or self._current_response_id
         item_id = event.get("item_id")
+        response_key = response_id or "unscoped"
         if item_id:
-            return f"{response_id or 'response'}:{item_id}"
-        return str(response_id or "unscoped")
+            return f"{response_key}:{item_id}"
+        return str(response_key)
 
     async def _emit_assistant_transcript(
         self,
@@ -2631,10 +2636,16 @@ class GrokProvider(AIProviderInterface):
                 for candidate in self._assistant_transcript_buffers
                 if candidate.startswith(prefix)
             )
-        complete = "".join(
+        parts = [
             self._assistant_transcript_buffers.pop(candidate, "")
             for candidate in dict.fromkeys(keys)
-        )
+        ]
+        parts = [part for part in parts if part]
+        complete = ""
+        for part in parts:
+            if complete and not complete[-1].isspace() and not part[0].isspace():
+                complete += " "
+            complete += part
         if not complete:
             return
         await self._track_conversation("assistant", complete)

--- a/src/providers/openai_realtime.py
+++ b/src/providers/openai_realtime.py
@@ -172,7 +172,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         self._output_resampler_mode: str = configured_output_resampler
         self._output_resampler_source: str = output_resampler_source
         self._output_resampler_logged: bool = False
-        self._transcript_buffer: str = ""
+        self._assistant_transcript_buffers: Dict[str, str] = {}
         self._input_info_logged: bool = False
         self._allowed_tools: Optional[List[str]] = None
         
@@ -406,7 +406,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         self._input_resample_state = None
         self._output_resample_state = None
         self._output_resampler_logged = False
-        self._transcript_buffer = ""
+        self._assistant_transcript_buffers.clear()
         self._closing = False
         self._closed = False
         
@@ -958,7 +958,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             self._in_audio_burst = False
             self._input_resample_state = None
             self._output_resample_state = None
-            self._transcript_buffer = ""
+            self._assistant_transcript_buffers.clear()
             logger.info("OpenAI Realtime session stopped")
             self._clear_metrics(previous_call_id)
 
@@ -1826,10 +1826,9 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             elif delta_type == "output_text.delta":
                 text = delta.get("text")
                 if text:
-                    await self._emit_transcript(text, is_final=False)
+                    await self._emit_assistant_transcript(event, text, is_final=False)
             elif delta_type == "output_text.done":
-                if self._transcript_buffer:
-                    await self._emit_transcript("", is_final=True)
+                await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # Modern event naming variants (top-level types)
@@ -1888,14 +1887,11 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 elif isinstance(delta, str):
                     text = delta
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         if event_type == "response.audio_transcript.done":
-            if self._transcript_buffer:
-                # Track assistant conversation for email tools
-                await self._track_conversation("assistant", self._transcript_buffer)
-                await self._emit_transcript("", is_final=True)
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         if event_type in ("response.completed", "response.error", "response.cancelled", "response.done"):
@@ -2046,9 +2042,8 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 pass
 
             self._pending_response = False
+            await self._emit_assistant_transcript(event, "", is_final=True)
             self._current_response_id = None  # Clear response ID after completion
-            if self._transcript_buffer:
-                await self._emit_transcript("", is_final=True)
             return
 
         if event_type == "conversation.item.input_audio_transcription.completed":
@@ -2080,7 +2075,7 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             delta = event.get("delta") or {}
             text = delta.get("text")
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         # Optional acks/telemetry for audio buffer operations
@@ -2173,14 +2168,11 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             elif isinstance(delta, str):
                 text = delta
             if text:
-                await self._emit_transcript(text, is_final=False)
+                await self._emit_assistant_transcript(event, text, is_final=False)
             return
 
         if event_type == "response.output_audio_transcript.done":
-            if self._transcript_buffer:
-                # Track assistant conversation for email tools
-                await self._track_conversation("assistant", self._transcript_buffer)
-                await self._emit_transcript("", is_final=True)
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # CRITICAL FIX #1: Handle session.updated ACK (following Deepgram pattern)
@@ -2497,13 +2489,10 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         if not self.on_event or not self._call_id:
             return
 
-        if text:
-            self._transcript_buffer += text
-
         payload = {
             "type": "Transcript",
             "call_id": self._call_id,
-            "text": text or self._transcript_buffer,
+            "text": text,
             "is_final": is_final,
         }
         try:
@@ -2511,8 +2500,54 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         except Exception:
             logger.error("Failed to emit transcript event", call_id=self._call_id, exc_info=True)
 
-        if is_final:
-            self._transcript_buffer = ""
+
+    def _assistant_transcript_key(self, event: Dict[str, Any]) -> str:
+        response = event.get("response") or {}
+        response_id = event.get("response_id") or response.get("id") or self._current_response_id
+        item_id = event.get("item_id")
+        if item_id:
+            return f"{response_id or 'response'}:{item_id}"
+        return str(response_id or "unscoped")
+
+    async def _emit_assistant_transcript(
+        self,
+        event: Dict[str, Any],
+        text: str,
+        *,
+        is_final: bool,
+    ) -> None:
+        """Accumulate/finalize only the matching assistant response item.
+
+        Caller-final events bypass this state entirely, so an interleaved input
+        transcription cannot erase an assistant prefix.
+        """
+        key = self._assistant_transcript_key(event)
+        if text:
+            self._assistant_transcript_buffers[key] = (
+                self._assistant_transcript_buffers.get(key, "") + text
+            )
+            if not is_final:
+                await self._emit_transcript(text, is_final=False)
+                return
+
+        if not is_final:
+            return
+        keys = [key]
+        if not event.get("item_id"):
+            prefix = f"{key}:"
+            keys.extend(
+                candidate
+                for candidate in self._assistant_transcript_buffers
+                if candidate.startswith(prefix)
+            )
+        complete = "".join(
+            self._assistant_transcript_buffers.pop(candidate, "")
+            for candidate in dict.fromkeys(keys)
+        )
+        if not complete:
+            return
+        await self._track_conversation("assistant", complete)
+        await self._emit_transcript(complete, is_final=True)
 
     async def _track_conversation(self, role: str, text: str):
         """Track conversation turns for email tools (similar to Deepgram implementation)."""

--- a/src/providers/openai_realtime.py
+++ b/src/providers/openai_realtime.py
@@ -2072,10 +2072,14 @@ class OpenAIRealtimeProvider(AIProviderInterface):
             return
 
         if event_type == "response.output_text.delta":
-            delta = event.get("delta") or {}
-            text = delta.get("text")
+            delta = event.get("delta")
+            text = delta.get("text") if isinstance(delta, dict) else delta
             if text:
                 await self._emit_assistant_transcript(event, text, is_final=False)
+            return
+
+        if event_type == "response.output_text.done":
+            await self._emit_assistant_transcript(event, "", is_final=True)
             return
 
         # Optional acks/telemetry for audio buffer operations
@@ -2505,9 +2509,10 @@ class OpenAIRealtimeProvider(AIProviderInterface):
         response = event.get("response") or {}
         response_id = event.get("response_id") or response.get("id") or self._current_response_id
         item_id = event.get("item_id")
+        response_key = response_id or "unscoped"
         if item_id:
-            return f"{response_id or 'response'}:{item_id}"
-        return str(response_id or "unscoped")
+            return f"{response_key}:{item_id}"
+        return str(response_key)
 
     async def _emit_assistant_transcript(
         self,
@@ -2540,10 +2545,16 @@ class OpenAIRealtimeProvider(AIProviderInterface):
                 for candidate in self._assistant_transcript_buffers
                 if candidate.startswith(prefix)
             )
-        complete = "".join(
+        parts = [
             self._assistant_transcript_buffers.pop(candidate, "")
             for candidate in dict.fromkeys(keys)
-        )
+        ]
+        parts = [part for part in parts if part]
+        complete = ""
+        for part in parts:
+            if complete and not complete[-1].isspace() and not part[0].isspace():
+                complete += " "
+            complete += part
         if not complete:
             return
         await self._track_conversation("assistant", complete)

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -32,3 +32,12 @@ def test_provider_change_fails_closed_to_restart():
     assert decision.restart_required is True
     assert decision.recommended_apply_method == "restart"
     assert decision.apply_plan()[0]["endpoint"].endswith("/restart")
+
+
+def test_missing_key_differs_from_explicit_none():
+    decision = classify_config_change({"tools": None}, {})
+
+    assert decision.changed_keys == frozenset({"tools"})
+    assert decision.apply_required is True
+    assert decision.restart_required is False
+    assert decision.recommended_apply_method == "hot_reload"

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -1,0 +1,34 @@
+from src.config_apply import classify_config_change
+
+
+def test_no_change_requires_no_apply():
+    decision = classify_config_change({"tools": {}}, {"tools": {}})
+
+    assert decision.apply_required is False
+    assert decision.restart_required is False
+    assert decision.recommended_apply_method == "none"
+    assert decision.apply_plan() == []
+
+
+def test_tools_only_change_uses_hot_reload():
+    decision = classify_config_change(
+        {"tools": {}},
+        {"tools": {"lookup": {"kind": "generic_http_lookup"}}},
+    )
+
+    assert decision.apply_required is True
+    assert decision.restart_required is False
+    assert decision.recommended_apply_method == "hot_reload"
+    assert decision.apply_plan()[0]["endpoint"].endswith("/reload")
+
+
+def test_provider_change_fails_closed_to_restart():
+    decision = classify_config_change(
+        {"providers": {"openai_realtime": {"enabled": True}}},
+        {"providers": {"openai_realtime": {"enabled": False}}},
+    )
+
+    assert decision.apply_required is True
+    assert decision.restart_required is True
+    assert decision.recommended_apply_method == "restart"
+    assert decision.apply_plan()[0]["endpoint"].endswith("/restart")

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -41,3 +41,24 @@ def test_missing_key_differs_from_explicit_none():
     assert decision.apply_required is True
     assert decision.restart_required is False
     assert decision.recommended_apply_method == "hot_reload"
+
+
+def test_invalid_config_input_fails_closed_to_restart():
+    decision = classify_config_change({"tools": {}}, None)
+
+    assert decision.apply_required is True
+    assert decision.restart_required is True
+    assert decision.recommended_apply_method == "restart"
+    assert decision.apply_plan()[0]["endpoint"].endswith("/restart")
+
+
+def test_non_mapping_serializer_result_fails_closed_to_restart():
+    class InvalidConfig:
+        def model_dump(self):
+            return []
+
+    decision = classify_config_change({"tools": {}}, InvalidConfig())
+
+    assert decision.apply_required is True
+    assert decision.restart_required is True
+    assert decision.recommended_apply_method == "restart"

--- a/tests/test_engine_config_state.py
+++ b/tests/test_engine_config_state.py
@@ -58,6 +58,8 @@ def test_unchanged_config_reports_no_restart(monkeypatch):
         f"running={state['running_config_hash']} disk={state['disk_config_hash']}"
     )
     assert state["restart_required"] is False
+    assert state["apply_required"] is False
+    assert state["recommended_apply_method"] == "none"
 
 
 def test_changed_disk_config_requires_restart(monkeypatch):
@@ -75,6 +77,8 @@ def test_changed_disk_config_requires_restart(monkeypatch):
     assert state["disk_config_valid"] is True
     assert state["running_config_hash"] != state["disk_config_hash"]
     assert state["restart_required"] is True
+    assert state["apply_required"] is True
+    assert state["recommended_apply_method"] == "restart"
 
 
 def test_invalid_disk_config_is_safe(monkeypatch):
@@ -92,6 +96,41 @@ def test_invalid_disk_config_is_safe(monkeypatch):
     assert state["disk_config_valid"] is False
     assert state["disk_config_hash"] is None
     assert state["restart_required"] is False
+    assert state["apply_required"] is False
+
+
+def test_hot_reloadable_disk_change_reports_apply_not_restart(monkeypatch):
+    engine = _make_engine_from_disk()
+    mutated = load_config(_CONFIG_PATH)
+    mutated.tools = dict(mutated.tools or {})
+    mutated.tools["test_lookup"] = {
+        "kind": "generic_http_lookup",
+        "phase": "pre_call",
+        "url": "https://example.com",
+    }
+    monkeypatch.setattr(engine_mod, "load_config", lambda *a, **k: mutated)
+
+    state = engine._compute_config_state()
+
+    assert state["apply_required"] is True
+    assert state["restart_required"] is False
+    assert state["recommended_apply_method"] == "hot_reload"
+    assert state["apply_plan"][0]["endpoint"].endswith("/reload")
+
+
+def test_deferred_restart_survives_hash_reconciliation(monkeypatch):
+    engine = _make_engine_from_disk()
+    engine._restart_required_after_reload = True
+    monkeypatch.setattr(
+        engine_mod, "load_config", lambda *a, **k: load_config(_CONFIG_PATH)
+    )
+
+    state = engine._compute_config_state()
+
+    assert state["apply_required"] is False
+    assert state["restart_required"] is True
+    assert state["recommended_apply_method"] == "restart"
+    assert state["apply_plan"][0]["endpoint"].endswith("/restart")
 
 
 def test_compute_config_hash_accepts_arg():

--- a/tests/test_engine_config_state.py
+++ b/tests/test_engine_config_state.py
@@ -99,6 +99,24 @@ def test_invalid_disk_config_is_safe(monkeypatch):
     assert state["apply_required"] is False
 
 
+def test_invalid_disk_config_preserves_deferred_restart(monkeypatch):
+    engine = _make_engine_from_disk()
+    engine._restart_required_after_reload = True
+
+    def _raise(*a, **k):
+        raise ValueError("temporarily invalid YAML")
+
+    monkeypatch.setattr(engine_mod, "load_config", _raise)
+
+    state = engine._compute_config_state()
+
+    assert state["disk_config_valid"] is False
+    assert state["apply_required"] is False
+    assert state["restart_required"] is True
+    assert state["recommended_apply_method"] == "restart"
+    assert state["apply_plan"] == []
+
+
 def test_hot_reloadable_disk_change_reports_apply_not_restart(monkeypatch):
     engine = _make_engine_from_disk()
     mutated = load_config(_CONFIG_PATH)

--- a/tests/test_realtime_transcript_scoping.py
+++ b/tests/test_realtime_transcript_scoping.py
@@ -25,10 +25,65 @@ def _grok_provider(on_event):
     return provider
 
 
+def _assistant_events(shape, response_id, item_id, first, second):
+    common = {"response_id": response_id, "item_id": item_id}
+    if shape == "output_audio_transcript":
+        return [
+            {
+                **common,
+                "type": "response.output_audio_transcript.delta",
+                "delta": first,
+            },
+            {
+                **common,
+                "type": "response.output_audio_transcript.delta",
+                "delta": second,
+            },
+            {**common, "type": "response.output_audio_transcript.done"},
+        ]
+    if shape == "audio_transcript":
+        return [
+            {**common, "type": "response.audio_transcript.delta", "delta": first},
+            {**common, "type": "response.audio_transcript.delta", "delta": second},
+            {**common, "type": "response.audio_transcript.done"},
+        ]
+    if shape == "response_delta":
+        return [
+            {
+                **common,
+                "type": "response.delta",
+                "delta": {"type": "output_text.delta", "text": first},
+            },
+            {
+                **common,
+                "type": "response.delta",
+                "delta": {"type": "output_text.delta", "text": second},
+            },
+            {
+                **common,
+                "type": "response.delta",
+                "delta": {"type": "output_text.done"},
+            },
+        ]
+    if shape == "output_text":
+        return [
+            {**common, "type": "response.output_text.delta", "delta": first},
+            {**common, "type": "response.output_text.delta", "delta": second},
+            {**common, "type": "response.output_text.done"},
+        ]
+    raise AssertionError(f"unknown event shape: {shape}")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("factory", [_openai_provider, _grok_provider])
 @pytest.mark.parametrize("caller_position", ["before", "during", "after"])
-async def test_caller_final_never_clears_assistant_response(factory, caller_position):
+@pytest.mark.parametrize(
+    "assistant_shape",
+    ["output_audio_transcript", "audio_transcript", "response_delta", "output_text"],
+)
+async def test_caller_final_never_clears_assistant_response(
+    factory, caller_position, assistant_shape
+):
     emitted = []
     tracked = []
 
@@ -46,23 +101,13 @@ async def test_caller_final_never_clears_assistant_response(factory, caller_posi
         "item_id": "caller-item",
         "transcript": "Forget it. Count from six to seven.",
     }
-    first = {
-        "type": "response.output_audio_transcript.delta",
-        "response_id": "resp-1",
-        "item_id": "assistant-item",
-        "delta": "Let me think this through carefully for a moment.67",
-    }
-    second = {
-        "type": "response.output_audio_transcript.delta",
-        "response_id": "resp-1",
-        "item_id": "assistant-item",
-        "delta": " 68 69 70 71 72 73 74 75",
-    }
-    done = {
-        "type": "response.output_audio_transcript.done",
-        "response_id": "resp-1",
-        "item_id": "assistant-item",
-    }
+    first, second, done = _assistant_events(
+        assistant_shape,
+        "resp-1",
+        "assistant-item",
+        "Let me think this through carefully for a moment.67",
+        " 68 69 70 71 72 73 74 75",
+    )
 
     if caller_position == "before":
         sequence = [caller, first, second, done]
@@ -81,6 +126,69 @@ async def test_caller_final_never_clears_assistant_response(factory, caller_posi
         if caller_position != "after"
         else [assistant, caller["transcript"]]
     )
+    assert provider._assistant_transcript_buffers == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_openai_provider, _grok_provider])
+async def test_unscoped_terminal_event_finalizes_item_buffer(factory):
+    emitted = []
+    tracked = []
+
+    async def on_event(event):
+        emitted.append(event)
+
+    provider = factory(on_event)
+
+    async def track(role, text):
+        tracked.append((role, text))
+
+    provider._track_conversation = track
+    await provider._emit_assistant_transcript(
+        {"item_id": "assistant-item"}, "Complete response", is_final=False
+    )
+    await provider._emit_assistant_transcript({}, "", is_final=True)
+
+    assert tracked == [("assistant", "Complete response")]
+    assert [event["text"] for event in emitted if event["is_final"]] == [
+        "Complete response"
+    ]
+    assert provider._assistant_transcript_buffers == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_openai_provider, _grok_provider])
+async def test_terminal_response_separates_multiple_items(factory):
+    emitted = []
+    tracked = []
+
+    async def on_event(event):
+        emitted.append(event)
+
+    provider = factory(on_event)
+
+    async def track(role, text):
+        tracked.append((role, text))
+
+    provider._track_conversation = track
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-1", "item_id": "item-a"},
+        "First item.",
+        is_final=False,
+    )
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-1", "item_id": "item-b"},
+        "Second item.",
+        is_final=False,
+    )
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-1"}, "", is_final=True
+    )
+
+    assert tracked == [("assistant", "First item. Second item.")]
+    assert [event["text"] for event in emitted if event["is_final"]] == [
+        "First item. Second item."
+    ]
     assert provider._assistant_transcript_buffers == {}
 
 

--- a/tests/test_realtime_transcript_scoping.py
+++ b/tests/test_realtime_transcript_scoping.py
@@ -1,0 +1,127 @@
+import pytest
+
+from src.config import GrokProviderConfig, OpenAIRealtimeProviderConfig
+from src.providers.grok import GrokProvider
+from src.providers.openai_realtime import OpenAIRealtimeProvider
+
+
+def _openai_provider(on_event):
+    provider = OpenAIRealtimeProvider(
+        OpenAIRealtimeProviderConfig(api_key="test"), on_event=on_event
+    )
+    provider._call_id = "call-transcript"
+    provider._greeting_completed = True
+    return provider
+
+
+def _grok_provider(on_event):
+    provider = GrokProvider(
+        GrokProviderConfig(api_key="test"),
+        on_event=on_event,
+        provider_key="grok",
+    )
+    provider._call_id = "call-transcript"
+    provider._greeting_completed = True
+    return provider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_openai_provider, _grok_provider])
+@pytest.mark.parametrize("caller_position", ["before", "during", "after"])
+async def test_caller_final_never_clears_assistant_response(factory, caller_position):
+    emitted = []
+    tracked = []
+
+    async def on_event(event):
+        emitted.append(event)
+
+    provider = factory(on_event)
+
+    async def track(role, text):
+        tracked.append((role, text))
+
+    provider._track_conversation = track
+    caller = {
+        "type": "conversation.item.input_audio_transcription.completed",
+        "item_id": "caller-item",
+        "transcript": "Forget it. Count from six to seven.",
+    }
+    first = {
+        "type": "response.output_audio_transcript.delta",
+        "response_id": "resp-1",
+        "item_id": "assistant-item",
+        "delta": "Let me think this through carefully for a moment.67",
+    }
+    second = {
+        "type": "response.output_audio_transcript.delta",
+        "response_id": "resp-1",
+        "item_id": "assistant-item",
+        "delta": " 68 69 70 71 72 73 74 75",
+    }
+    done = {
+        "type": "response.output_audio_transcript.done",
+        "response_id": "resp-1",
+        "item_id": "assistant-item",
+    }
+
+    if caller_position == "before":
+        sequence = [caller, first, second, done]
+    elif caller_position == "during":
+        sequence = [first, caller, second, done]
+    else:
+        sequence = [first, second, done, caller]
+    for event in sequence:
+        await provider._handle_event(event)
+
+    assistant = "Let me think this through carefully for a moment.67 68 69 70 71 72 73 74 75"
+    assert ("assistant", assistant) in tracked
+    assert ("user", caller["transcript"]) in tracked
+    assert [e["text"] for e in emitted if e["is_final"]] == (
+        [caller["transcript"], assistant]
+        if caller_position != "after"
+        else [assistant, caller["transcript"]]
+    )
+    assert provider._assistant_transcript_buffers == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [_openai_provider, _grok_provider])
+async def test_terminal_response_finalizes_only_matching_response(factory):
+    emitted = []
+    tracked = []
+
+    async def on_event(event):
+        emitted.append(event)
+
+    provider = factory(on_event)
+
+    async def track(role, text):
+        tracked.append((role, text))
+
+    provider._track_conversation = track
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-cancelled", "item_id": "item-a"},
+        "Partial audible response",
+        is_final=False,
+    )
+    await provider._emit_assistant_transcript(
+        {"response": {"id": "resp-cancelled"}}, "", is_final=True
+    )
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-next", "item_id": "item-b"},
+        "Next complete response",
+        is_final=False,
+    )
+    await provider._emit_assistant_transcript(
+        {"response_id": "resp-next", "item_id": "item-b"}, "", is_final=True
+    )
+
+    assert tracked == [
+        ("assistant", "Partial audible response"),
+        ("assistant", "Next complete response"),
+    ]
+    assert [e["text"] for e in emitted if e["is_final"]] == [
+        "Partial audible response",
+        "Next complete response",
+    ]
+    assert provider._assistant_transcript_buffers == {}

--- a/tests/test_tool_reload_v740.py
+++ b/tests/test_tool_reload_v740.py
@@ -97,6 +97,8 @@ async def test_reload_does_not_misclassify_pipeline_adapters_as_new_providers():
     }
     old_config.providers = adapters
     new_config.providers = adapters
+    old_config.dict()["providers"] = adapters
+    new_config.dict()["providers"] = adapters
     engine.config = old_config
     engine._build_tool_generation = lambda _config: new
 

--- a/tests/test_tool_reload_v740.py
+++ b/tests/test_tool_reload_v740.py
@@ -70,6 +70,8 @@ async def test_reload_publishes_new_generation_without_mutating_active_call():
     payload = json.loads(response.text)
     assert response.status == 200
     assert payload["tool_generation"] == 2
+    assert payload["restart_required"] is False
+    assert payload["recommended_apply_method"] == "none"
     assert engine._tool_generation is new
     assert engine._next_tool_generation_id == 3
     assert Engine._tool_registry_for_session(engine, active_call) is old.registry
@@ -79,6 +81,34 @@ async def test_reload_publishes_new_generation_without_mutating_active_call():
     assert Engine._tool_registry_for_session(engine, None) is new.registry
     assert offloaded == [engine._build_tool_generation]
     assert not engine._tool_reload_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_reload_does_not_misclassify_pipeline_adapters_as_new_providers():
+    old = ToolRuntimeGeneration.build(generation_id=1, config=_config("old").dict())
+    new = ToolRuntimeGeneration.build(generation_id=2, config=_config("new").dict())
+    engine = _engine(old)
+    old_config = _config("old")
+    new_config = _config("new")
+    adapters = {
+        "local_stt": {"enabled": True},
+        "openai_llm": {"enabled": True},
+        "local_tts": {"enabled": True},
+    }
+    old_config.providers = adapters
+    new_config.providers = adapters
+    engine.config = old_config
+    engine._build_tool_generation = lambda _config: new
+
+    with patch("src.config.load_config", return_value=new_config), patch(
+        "src.engine.TransportOrchestrator", return_value=SimpleNamespace()
+    ):
+        response = await Engine._reload_handler(engine, SimpleNamespace())
+
+    payload = json.loads(response.text)
+    assert response.status == 200
+    assert payload["restart_required"] is False
+    assert not any("detected" in change.lower() for change in payload["changes"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Prepare the v7.5.1 hotfix by fixing three production regressions without changing audio profiles, provider transports, resampling, or fresh-install defaults:

- make Admin UI environment recreates fail safely and restore the prior service when replacement fails;
- preserve complete OpenAI Realtime and Grok assistant transcripts when caller-final events interleave;
- distinguish pending hot reloads from true AI Engine restart requirements after tool API changes.

Diagnostic-only tap configuration and capture behavior are explicitly excluded. The remaining development diagnostic work is tracked separately in #558.

## Related Issue(s)

- Closes #552
- Closes #554
- Closes #556
- Follow-up only: #558

## Implementation Notes

- Key files touched (code/config/docs):
  - `admin_ui/backend/api/system.py`, `admin_ui/frontend/src/pages/System/EnvPage.tsx`, `.dockerignore`, `admin_ui/Dockerfile`, `docker-compose.yml`
  - `src/providers/openai_realtime.py`, `src/providers/grok.py`
  - `src/config_apply.py`, `src/engine.py`, Admin managed-tool APIs and Tools UI
  - `README.md`, `CHANGELOG.md`, `docs/MIGRATION.md`
- High-level design decisions:
  - Prepare the updater image before inspecting or mutating the target service; let Compose own replacement rather than explicitly stopping/removing the current container.
  - Retain a temporary rollback image plus the exact prior container environment and CPU/GPU Compose topology. On replacement or health failure, recreate the previous service and return structured availability/recovery state.
  - Use one dependency-free configuration classifier in both runtime images. Tool-only changes hot reload into immutable new-call generations; non-hot sections remain fail-closed on restart.
  - Scope assistant transcript buffers by provider response/item. Caller-final transcripts bypass assistant state, and only the matching assistant terminal event finalizes that response.
  - Managed-tool DELETE now returns structured HTTP 200 apply metadata instead of an empty HTTP 204 response; this compatibility note is documented.

Agreed plan: fix #552, #554, and #556 as a narrow v7.5.1 hotfix; validate locally and on voiprnd; preserve existing defaults; keep development diagnostics out of production scope.

## Testing

- [x] Unit tests:
  - Core suite: `1815 passed, 6 skipped, 139 deselected`
  - Admin backend: `494 passed`
  - Admin frontend: `31 files / 221 tests passed`
  - Frontend lint: `0 errors` (`867` existing warnings, below the configured limit)
  - Frontend production build passed
  - Release-doc consistency, committed-secret guard, Python compileall, shell syntax, and `git diff --check` passed
- [x] Integration / manual tests:
  - Admin image built from the production Dockerfile; standalone import smoke test returned `hot_reload`
  - Root Admin build context reduced from about 259 MB locally to about 460 KB after nested package/runtime exclusions
  - voiprnd deployed exact final commit `aa952f60`; rebuilt/recreated only `ai_engine` and `admin_ui`, while untouched `local_ai_server` remained healthy
  - Reversible managed-tool create → reload → delete → reload returned correct metadata, advanced immutable generations, preserved the AI Engine container ID, removed the probe, and restored exact baseline YAML
  - Live `recreate=true` API path prepared the updater, recreated `ai_engine`, returned `health_status=healthy`, left no rollback artifact, and ended with matching config hashes/no apply drift
  - voiprnd remained at zero active calls/channels during runtime validation; 67 GB disk remained free, so no pruning was necessary
  - Deployed-image smoke checks confirmed invalid config inputs fail closed to restart and pending engine restart state overrides hot-reload save metadata; no error-level startup logs were emitted
- [x] `agent check` — exact-head CI, thread audit, local regression suites, and voiprnd runtime checks passed
- [ ] `agent rca` — no new telephony call was originated for the draft checkpoint
- [ ] `./scripts/rca_collect.sh` — not applicable to the API/recreate validation

For telephony changes:

- Test call IDs:
  - Historical reproduction pinned in tests: `1784679445.962`
  - Candidate provider calls: not repeated for the final config-only fix batch; media transport is unchanged
- Providers/pipelines involved:
  - OpenAI Realtime and Grok transcript persistence only
- Brief call behavior summary:
  - The original call audio was complete while Call History clipped assistant prefixes. Regression tests replay caller-final events before, during, and after assistant deltas, plus consecutive/cancelled responses and modern/legacy transcript events for both providers.
  - No media transport, VAD, resampler, audio-profile, or provider-default behavior changes in this PR.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [x] Review fixes were pushed as a cohesive batch
- [x] Final head is frozen, the PR is ready, and the final CI gate has passed
- [x] `@coderabbitai full review` completed on the frozen head
- [x] Optional `codex-review` label/manual workflow completed on the frozen head, if requested
- [x] All actionable conversations are resolved

See the [pull-request workflow](../docs/contributing/PULL_REQUEST_WORKFLOW.md) for the expected review and CI sequence.

## Documentation

- [ ] `docs/contributing/architecture-deep-dive.md`
- [ ] `docs/ROADMAP.md` / `docs/milestones/*`
- [ ] `docs/TOOL_CALLING_GUIDE.md`
- [x] Provider/tool-specific docs — managed-tool API compatibility and runtime behavior in `docs/MIGRATION.md`
- [x] `docs/DEVELOPER_ONBOARDING.md` / other onboarding content — operator upgrade/verification guidance in `README.md` and `docs/MIGRATION.md`
- [x] `CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI now distinguishes **Apply** vs **Restart** with a recommended method and an explicit apply plan; tool-only updates can hot-reload while broader changes trigger restart.
* **Bug Fixes**
  * Call history/transcripts now retain complete assistant replies without truncation (scoped correctly across realtime events).
  * Admin environment apply/recreate is more recoverable: when replacements fail or aren’t healthy, the previous setup is restored.
  * Managed tool **DELETE** now returns apply/restart recommendation metadata (instead of empty 204).
* **Documentation**
  * Added v7.5.1 upgrade guidance covering safer Admin apply and transcript behavior.
* **Chores**
  * Improved Docker build context exclusions for faster, smaller builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


