### PR TITLE
fix: make Call History tool redaction configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -652,6 +652,13 @@ CALL_HISTORY_ENABLED=true
 # Retention period in days (0 = unlimited, keep forever)
 CALL_HISTORY_RETENTION_DAYS=0
 
+# Privacy policy for persisted in-call tool diagnostics (requires ai_engine restart):
+#   strict (default)  - redact credentials, caller PII/free text, and routing targets
+#   show_routing      - keep destinations/extensions/queues/mailboxes; redact secrets and PII
+#   off               - persist tool parameters and messages verbatim (trusted/private boxes only)
+# This affects future tool executions only. Existing REDACTED values cannot be recovered.
+CALL_HISTORY_TOOL_REDACTION_MODE=strict
+
 # Database file path. Use an ABSOLUTE path that lands on the mounted ./data volume
 # (container WORKDIR is /app). A relative path resolves against the current working
 # directory, so a process started elsewhere (e.g. a `docker exec python -` from /)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Call History redaction is operator-configurable** ([#589](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/589)): persisted in-call tool diagnostics now support fail-closed `strict`, `show_routing`, and explicit `off` modes. The middle mode keeps extension, queue, mailbox, and transfer destinations useful for troubleshooting while still masking credentials and caller data; strict mode also protects routing-derived `target_id` and messages that echo hidden values. System → Environment exposes the restart-required setting with an `off` warning, while Call History shows the configured policy, pending-restart state, per-call policy metadata, and any sanitized paths. Changes apply only to future tool executions; historical redactions remain unrecoverable.
+
 ## [7.5.3] - 2026-07-28
 
 ### Added

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -25,6 +25,8 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from zoneinfo import ZoneInfo
 
+import settings
+
 # Add project root to path for imports
 project_root = os.environ.get("PROJECT_ROOT", "/app/project")
 if project_root not in sys.path:
@@ -195,6 +197,15 @@ class FilterOptionsResponse(BaseModel):
     outcomes: List[str] = []
 
 
+class ToolRedactionPolicyResponse(BaseModel):
+    """Safe Call History privacy status; never returns arbitrary environment data."""
+
+    configured_mode: str = "strict"
+    configured_value_valid: bool = True
+    pending_restart: Optional[bool] = None
+    modes: Dict[str, str] = Field(default_factory=dict)
+
+
 class ProviderHealthStatus(BaseModel):
     """Health status for a single provider."""
     status: str
@@ -216,6 +227,29 @@ def _get_call_history_store():
     except ImportError as e:
         logger.error(f"Failed to import call_history module: {e}")
         raise HTTPException(status_code=500, detail="Call history module not available")
+
+
+def _configured_tool_redaction_policy() -> tuple[str, bool]:
+    """Read and validate only the Call History tool-redaction setting from .env."""
+    raw_value: Optional[str] = None
+    try:
+        from dotenv import dotenv_values
+
+        values = dotenv_values(settings.ENV_PATH) if os.path.exists(settings.ENV_PATH) else {}
+        value = (values or {}).get("CALL_HISTORY_TOOL_REDACTION_MODE")
+        raw_value = str(value) if value is not None else None
+    except Exception:
+        raw_value = None
+
+    from src.tools.execution_history import (
+        CALL_HISTORY_TOOL_REDACTION_MODES,
+        normalize_call_history_tool_redaction_mode,
+    )
+
+    normalized = normalize_call_history_tool_redaction_mode(raw_value)
+    candidate = str(raw_value or "").strip().lower()
+    valid = not candidate or candidate in CALL_HISTORY_TOOL_REDACTION_MODES
+    return normalized, valid
 
 
 def _normalize_tool_calls(tool_calls: list) -> list:
@@ -574,6 +608,34 @@ async def get_filter_options():
         pipelines=pipelines,
         contexts=contexts,
         outcomes=outcomes,
+    )
+
+
+@router.get("/calls/redaction-policy", response_model=ToolRedactionPolicyResponse)
+async def get_tool_redaction_policy():
+    """Return the configured tool-history privacy mode without exposing .env."""
+    configured_mode, configured_value_valid = _configured_tool_redaction_policy()
+    pending_restart: Optional[bool] = None
+    try:
+        from . import config as config_api
+
+        env_status = await config_api.get_env_status()
+        drift = (env_status.get("drift") or {}).get("ai_engine") or []
+        pending_restart = "CALL_HISTORY_TOOL_REDACTION_MODE" in drift
+    except Exception:
+        # Docker/env drift inspection is best-effort. The configured policy is
+        # still useful when container state cannot be inspected.
+        pending_restart = None
+
+    return ToolRedactionPolicyResponse(
+        configured_mode=configured_mode,
+        configured_value_valid=configured_value_valid,
+        pending_restart=pending_restart,
+        modes={
+            "strict": "Redact credentials, caller data, free text, and routing details.",
+            "show_routing": "Show destinations and extensions while redacting credentials and caller data.",
+            "off": "Persist in-call tool diagnostics verbatim.",
+        },
     )
 
 

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -24,19 +24,21 @@ from typing import Dict, Any, Optional, Union
 from urllib.parse import urlparse
 import settings
 
+PROJECT_SOURCE_ROOT = Path(settings.PROJECT_ROOT)
+if str(PROJECT_SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_SOURCE_ROOT))
+
 try:
     # The production Admin image copies the shared module into /app.
     from config_apply import classify_config_change
 except ModuleNotFoundError:
     # Source checkout/tests: import the same canonical module from root src/.
-    PROJECT_SOURCE_ROOT = Path(__file__).resolve().parents[3]
-    if str(PROJECT_SOURCE_ROOT) not in sys.path:
-        sys.path.insert(0, str(PROJECT_SOURCE_ROOT))
     from src.config_apply import classify_config_change
+
+from src.tools.execution_history import CALL_HISTORY_TOOL_REDACTION_MODES
 
 # A11: Maximum number of backups to keep
 MAX_BACKUPS = 5
-CALL_HISTORY_TOOL_REDACTION_MODES = frozenset({"strict", "show_routing", "off"})
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -1313,7 +1313,7 @@ async def update_env(env_data: Dict[str, Optional[str]]):
         redaction_mode = env_data.get("CALL_HISTORY_TOOL_REDACTION_MODE")
         if redaction_mode not in (None, "__DELETE__"):
             normalized_mode = str(redaction_mode).strip().lower()
-            if normalized_mode not in CALL_HISTORY_TOOL_REDACTION_MODES:
+            if normalized_mode and normalized_mode not in CALL_HISTORY_TOOL_REDACTION_MODES:
                 allowed = ", ".join(sorted(CALL_HISTORY_TOOL_REDACTION_MODES))
                 raise HTTPException(
                     status_code=400,

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -36,6 +36,7 @@ except ModuleNotFoundError:
 
 # A11: Maximum number of backups to keep
 MAX_BACKUPS = 5
+CALL_HISTORY_TOOL_REDACTION_MODES = frozenset({"strict", "show_routing", "off"})
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -1307,6 +1308,17 @@ async def update_env(env_data: Dict[str, Optional[str]]):
     - Already-quoted values from UI are stored as-is (no double-quoting)
     """
     try:
+        redaction_mode = env_data.get("CALL_HISTORY_TOOL_REDACTION_MODE")
+        if redaction_mode not in (None, "__DELETE__"):
+            normalized_mode = str(redaction_mode).strip().lower()
+            if normalized_mode not in CALL_HISTORY_TOOL_REDACTION_MODES:
+                allowed = ", ".join(sorted(CALL_HISTORY_TOOL_REDACTION_MODES))
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"CALL_HISTORY_TOOL_REDACTION_MODE must be one of: {allowed}",
+                )
+            env_data["CALL_HISTORY_TOOL_REDACTION_MODE"] = normalized_mode
+
         # If file logging is enabled but no path is provided, default to the shared media volume.
         # This matches the UI recommendation and prevents "log to file" from silently falling back
         # to a non-writable working directory inside the container.

--- a/admin_ui/backend/tests/test_call_history_redaction_policy.py
+++ b/admin_ui/backend/tests/test_call_history_redaction_policy.py
@@ -85,3 +85,21 @@ def test_env_update_rejects_unknown_policy_before_writing(tmp_path, monkeypatch)
     assert response.status_code == 400
     assert "must be one of" in response.json()["detail"]
     assert env_path.read_text(encoding="utf-8") == "CALL_HISTORY_TOOL_REDACTION_MODE=strict\n"
+
+
+def test_env_update_accepts_blank_policy_as_default_reset(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text("CALL_HISTORY_TOOL_REDACTION_MODE=show_routing\n", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+    monkeypatch.setattr(config, "_running_container_names", lambda: set())
+
+    app = FastAPI()
+    app.include_router(config.router, prefix="/api/config")
+    response = TestClient(app).post(
+        "/api/config/env",
+        json={"CALL_HISTORY_TOOL_REDACTION_MODE": "   "},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["changed_keys"] == ["CALL_HISTORY_TOOL_REDACTION_MODE"]
+    assert env_path.read_text(encoding="utf-8") == 'CALL_HISTORY_TOOL_REDACTION_MODE=""\n'

--- a/admin_ui/backend/tests/test_call_history_redaction_policy.py
+++ b/admin_ui/backend/tests/test_call_history_redaction_policy.py
@@ -10,12 +10,17 @@ sys.path.insert(0, str(BACKEND_ROOT))
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from api import calls, config  # noqa: E402
+from src.tools.execution_history import CALL_HISTORY_TOOL_REDACTION_MODES  # noqa: E402
 
 
 def _client() -> TestClient:
     app = FastAPI()
     app.include_router(calls.router, prefix="/api")
     return TestClient(app)
+
+
+def test_config_validation_uses_canonical_redaction_modes():
+    assert config.CALL_HISTORY_TOOL_REDACTION_MODES is CALL_HISTORY_TOOL_REDACTION_MODES
 
 
 def test_policy_endpoint_returns_only_normalized_policy_and_restart_state(tmp_path, monkeypatch):

--- a/admin_ui/backend/tests/test_call_history_redaction_policy.py
+++ b/admin_ui/backend/tests/test_call_history_redaction_policy.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = BACKEND_ROOT.parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from api import calls, config  # noqa: E402
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(calls.router, prefix="/api")
+    return TestClient(app)
+
+
+def test_policy_endpoint_returns_only_normalized_policy_and_restart_state(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        "CALL_HISTORY_TOOL_REDACTION_MODE=show_routing\nOPENAI_API_KEY=must-not-leak\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(calls.settings, "ENV_PATH", str(env_path))
+
+    async def fake_status():
+        return {"drift": {"ai_engine": ["CALL_HISTORY_TOOL_REDACTION_MODE"]}}
+
+    monkeypatch.setattr(config, "get_env_status", fake_status)
+
+    response = _client().get("/api/calls/redaction-policy")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["configured_mode"] == "show_routing"
+    assert payload["configured_value_valid"] is True
+    assert payload["pending_restart"] is True
+    assert set(payload) == {
+        "configured_mode",
+        "configured_value_valid",
+        "pending_restart",
+        "modes",
+    }
+    assert "must-not-leak" not in response.text
+
+
+def test_invalid_policy_fails_closed_and_is_reported(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text("CALL_HISTORY_TOOL_REDACTION_MODE=everything\n", encoding="utf-8")
+    monkeypatch.setattr(calls.settings, "ENV_PATH", str(env_path))
+
+    async def fake_status():
+        return {"drift": {"ai_engine": []}}
+
+    monkeypatch.setattr(config, "get_env_status", fake_status)
+
+    response = _client().get("/api/calls/redaction-policy")
+
+    assert response.status_code == 200
+    assert response.json()["configured_mode"] == "strict"
+    assert response.json()["configured_value_valid"] is False
+    assert response.json()["pending_restart"] is False
+
+
+def test_env_update_rejects_unknown_policy_before_writing(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    env_path.write_text("CALL_HISTORY_TOOL_REDACTION_MODE=strict\n", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+
+    app = FastAPI()
+    app.include_router(config.router, prefix="/api/config")
+    response = TestClient(app).post(
+        "/api/config/env",
+        json={"CALL_HISTORY_TOOL_REDACTION_MODE": "not-a-policy"},
+    )
+
+    assert response.status_code == 400
+    assert "must be one of" in response.json()["detail"]
+    assert env_path.read_text(encoding="utf-8") == "CALL_HISTORY_TOOL_REDACTION_MODE=strict\n"

--- a/admin_ui/frontend/src/components/calls/ToolExecutionGroups.test.tsx
+++ b/admin_ui/frontend/src/components/calls/ToolExecutionGroups.test.tsx
@@ -124,4 +124,37 @@ describe('InCallToolGroup', () => {
             '/env?section=call-history#system'
         );
     });
+
+    it('shows a mixed policy for strict and metadata-free legacy entries', () => {
+        render(
+            <InCallToolGroup
+                entries={[
+                    {
+                        type: 'tool_result',
+                        call_id: 'call-mixed',
+                        tool_call_id: 'tool-strict',
+                        name: 'blind_transfer',
+                        params: { destination: '***REDACTED***' },
+                        result: 'success',
+                        redaction_mode: 'strict',
+                        timestamp: '2026-07-29T04:00:00+00:00',
+                        duration_ms: 8,
+                    },
+                    {
+                        type: 'tool_result',
+                        call_id: 'call-mixed',
+                        tool_call_id: 'tool-legacy',
+                        name: 'hangup_call',
+                        params: {},
+                        result: 'success',
+                        timestamp: '2026-07-29T04:00:01+00:00',
+                        duration_ms: 3,
+                    },
+                ]}
+            />,
+        );
+
+        expect(screen.getByText('Mixed redaction policies')).toBeInTheDocument();
+        expect(screen.queryByText('Strict redaction')).not.toBeInTheDocument();
+    });
 });

--- a/admin_ui/frontend/src/components/calls/ToolExecutionGroups.test.tsx
+++ b/admin_ui/frontend/src/components/calls/ToolExecutionGroups.test.tsx
@@ -97,4 +97,31 @@ describe('InCallToolGroup', () => {
 
         expect(screen.getByText('call-fallback-1')).toBeInTheDocument();
     });
+
+    it('shows the recorded policy and irrecoverable sanitized paths', () => {
+        render(
+            <InCallToolGroup
+                entries={[{
+                    type: 'tool_result',
+                    call_id: 'call-redacted',
+                    name: 'blind_transfer',
+                    params: { destination: 'REDACTED' },
+                    target_id: 'REDACTED',
+                    result: 'success',
+                    redaction_mode: 'strict',
+                    redacted_fields: ['params.destination', 'target_id'],
+                    timestamp: '2026-07-29T04:00:00+00:00',
+                    duration_ms: 8,
+                }]}
+            />,
+        );
+
+        expect(screen.getByText('Strict redaction')).toBeInTheDocument();
+        expect(screen.getByText(/params\.destination, target_id/)).toBeInTheDocument();
+        expect(screen.getByText(/Original values cannot be recovered/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Configure future calls' })).toHaveAttribute(
+            'href',
+            '/env?section=call-history#system'
+        );
+    });
 });

--- a/admin_ui/frontend/src/components/calls/ToolExecutionGroups.tsx
+++ b/admin_ui/frontend/src/components/calls/ToolExecutionGroups.tsx
@@ -30,6 +30,8 @@ export interface InCallToolCall {
     params: unknown;
     result: string;
     message?: string;
+    redaction_mode?: 'strict' | 'show_routing' | 'off';
+    redacted_fields?: string[];
     timestamp: string;
     duration_ms: number;
 }
@@ -107,10 +109,26 @@ export const PhaseToolGroup = ({ phase, entries }: { phase: Exclude<ToolPhase, '
     </div>
 );
 
-export const InCallToolGroup = ({ entries }: { entries: InCallToolCall[] }) => (
+export const InCallToolGroup = ({ entries }: { entries: InCallToolCall[] }) => {
+    const recordedModes = Array.from(new Set(entries.map(entry => entry.redaction_mode).filter(Boolean)));
+    const recordedMode = recordedModes.length === 1 ? recordedModes[0] : recordedModes.length > 1 ? 'mixed' : 'legacy';
+    const modeLabels: Record<string, string> = {
+        strict: 'Strict redaction',
+        show_routing: 'Routing details visible',
+        off: 'Redaction off',
+        mixed: 'Mixed redaction policies',
+        legacy: 'Legacy record — policy not recorded',
+    };
+
+    return (
     <div>
         <div className="text-sm font-medium text-muted-foreground mb-1">
             {PHASE_LABELS.in_call} ({entries.length})
+        </div>
+        <div className="mb-2 rounded border border-blue-500/20 bg-blue-500/5 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">{modeLabels[recordedMode]}</span>
+            {' '}This reflects how the call was stored; changing the policy affects future tool executions only.
+            {' '}<a className="text-blue-500 hover:underline" href="/env?section=call-history#system">Configure future calls</a>.
         </div>
         <div className="space-y-2">
             {entries.map((tool, i) => {
@@ -149,9 +167,15 @@ export const InCallToolGroup = ({ entries }: { entries: InCallToolCall[] }) => (
                                 {JSON.stringify(tool.params, null, 2)}
                             </pre>
                         )}
+                        {tool.redacted_fields && tool.redacted_fields.length > 0 && (
+                            <div className="mt-2 text-xs text-muted-foreground break-words">
+                                Sanitized fields: <span className="font-mono">{tool.redacted_fields.join(', ')}</span>. Original values cannot be recovered.
+                            </div>
+                        )}
                     </div>
                 );
             })}
         </div>
     </div>
-);
+    );
+};

--- a/admin_ui/frontend/src/components/calls/ToolExecutionGroups.tsx
+++ b/admin_ui/frontend/src/components/calls/ToolExecutionGroups.tsx
@@ -110,7 +110,7 @@ export const PhaseToolGroup = ({ phase, entries }: { phase: Exclude<ToolPhase, '
 );
 
 export const InCallToolGroup = ({ entries }: { entries: InCallToolCall[] }) => {
-    const recordedModes = Array.from(new Set(entries.map(entry => entry.redaction_mode).filter(Boolean)));
+    const recordedModes = Array.from(new Set(entries.map(entry => entry.redaction_mode ?? 'legacy')));
     const recordedMode = recordedModes.length === 1 ? recordedModes[0] : recordedModes.length > 1 ? 'mixed' : 'legacy';
     const modeLabels: Record<string, string> = {
         strict: 'Strict redaction',

--- a/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
@@ -58,6 +58,11 @@ const LocationProbe = () => {
     return <div data-testid="location-search">{location.search}</div>;
 };
 
+const FullLocationProbe = () => {
+    const location = useLocation();
+    return <div data-testid="full-location">{`${location.pathname}${location.search}${location.hash}`}</div>;
+};
+
 describe('CallHistoryPage deep links', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -66,6 +71,20 @@ describe('CallHistoryPage deep links', () => {
                 return { data: { calls: [], total: 0, total_pages: 1 } };
             }
             if (url === '/api/calls/stats') return { data: null };
+            if (url === '/api/calls/redaction-policy') {
+                return {
+                    data: {
+                        configured_mode: 'show_routing',
+                        configured_value_valid: true,
+                        pending_restart: true,
+                        modes: {
+                            strict: 'Redact credentials, caller data, free text, and routing details.',
+                            show_routing: 'Show destinations and extensions while redacting credentials and caller data.',
+                            off: 'Persist in-call tool diagnostics verbatim.',
+                        },
+                    },
+                };
+            }
             if (url === '/api/calls/filters') {
                 return { data: { providers: [], pipelines: [], contexts: [], outcomes: [] } };
             }
@@ -147,5 +166,22 @@ describe('CallHistoryPage deep links', () => {
         fireEvent.keyDown(document, { key: 'Escape' });
         await waitFor(() => expect(dialog).not.toBeInTheDocument());
         expect(returnTarget).toHaveFocus();
+    });
+
+    it('surfaces the configured policy and links to its Environment setting', async () => {
+        render(
+            <MemoryRouter initialEntries={['/history']}>
+                <CallHistoryPage />
+                <FullLocationProbe />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByText('Tool history privacy: Show routing')).toBeInTheDocument();
+        expect(screen.getByText('AI Engine restart pending')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Configure redaction' }));
+
+        expect(screen.getByTestId('full-location')).toHaveTextContent(
+            '/env?section=call-history#system'
+        );
     });
 });

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -4,7 +4,7 @@ import {
     ChevronLeft, ChevronRight, RefreshCw, X, MessageSquare,
     Wrench, AlertCircle, CheckCircle, ArrowRightLeft, PhoneOff,
     BarChart3, Users, Timer, Activity, TrendingUp, Zap, PieChart,
-    Play, Pause, Volume2, FileAudio, Search
+    Play, Pause, Volume2, FileAudio, Search, ShieldCheck, SlidersHorizontal
 } from 'lucide-react';
 import axios from 'axios';
 import { toast } from 'sonner';
@@ -91,6 +91,19 @@ interface FilterOptions {
     outcomes: string[];
 }
 
+interface ToolRedactionPolicy {
+    configured_mode: 'strict' | 'show_routing' | 'off';
+    configured_value_valid: boolean;
+    pending_restart: boolean | null;
+    modes: Record<string, string>;
+}
+
+const REDACTION_MODE_LABELS: Record<string, string> = {
+    strict: 'Strict',
+    show_routing: 'Show routing',
+    off: 'Off',
+};
+
 const formatDuration = (seconds: number): string => {
     if (seconds < 60) return `${Math.round(seconds)}s`;
     const mins = Math.floor(seconds / 60);
@@ -176,6 +189,7 @@ const CallHistoryPage = () => {
     const [calls, setCalls] = useState<CallRecordSummary[]>([]);
     const [stats, setStats] = useState<CallStats | null>(null);
     const [filterOptions, setFilterOptions] = useState<FilterOptions | null>(null);
+    const [redactionPolicy, setRedactionPolicy] = useState<ToolRedactionPolicy | null>(null);
     // slug -> display_name, so the call's context_name (== agent slug) shows the friendly name.
     const [agentNames, setAgentNames] = useState<Record<string, string>>({});
     const [loading, setLoading] = useState(true);
@@ -314,6 +328,16 @@ const CallHistoryPage = () => {
         }
     }, []);
 
+    const fetchRedactionPolicy = useCallback(async () => {
+        try {
+            const res = await axios.get('/api/calls/redaction-policy');
+            setRedactionPolicy(res.data);
+        } catch (err) {
+            // Best-effort for compatibility with older Admin API versions.
+            console.error('Failed to fetch Call History redaction policy:', err);
+        }
+    }, []);
+
     useEffect(() => {
         fetchCalls();
     }, [fetchCalls]);
@@ -329,6 +353,10 @@ const CallHistoryPage = () => {
     useEffect(() => {
         fetchAgentNames();
     }, [fetchAgentNames]);
+
+    useEffect(() => {
+        fetchRedactionPolicy();
+    }, [fetchRedactionPolicy]);
 
     const cleanupAudio = useCallback(() => {
         if (audioRef.current) {
@@ -694,6 +722,41 @@ const CallHistoryPage = () => {
                     </button>
                 </div>
             </div>
+
+            {redactionPolicy && (
+                <div className="flex flex-col gap-3 rounded-lg border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex gap-3">
+                        <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-blue-500" />
+                        <div>
+                            <div className="flex flex-wrap items-center gap-2 text-sm font-medium">
+                                <span>Tool history privacy: {REDACTION_MODE_LABELS[redactionPolicy.configured_mode] || redactionPolicy.configured_mode}</span>
+                                {redactionPolicy.pending_restart === true && (
+                                    <span className="rounded bg-amber-500/15 px-2 py-0.5 text-xs text-amber-600 dark:text-amber-400">
+                                        AI Engine restart pending
+                                    </span>
+                                )}
+                                {!redactionPolicy.configured_value_valid && (
+                                    <span className="rounded bg-red-500/15 px-2 py-0.5 text-xs text-red-600 dark:text-red-400">
+                                        Invalid setting; strict fallback
+                                    </span>
+                                )}
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                                {redactionPolicy.modes[redactionPolicy.configured_mode]}
+                                {' '}Changes affect future tool executions only; historical redactions cannot be reversed.
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => navigate('/env?section=call-history#system')}
+                        className="inline-flex shrink-0 items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
+                    >
+                        <SlidersHorizontal className="h-4 w-4" />
+                        Configure redaction
+                    </button>
+                </div>
+            )}
 
             {/* Quick Troubleshoot */}
             {modalCall && (

--- a/admin_ui/frontend/src/pages/System/EnvPage.callHistoryPrivacy.test.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.callHistoryPrivacy.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import axios from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import EnvPage from './EnvPage';
+
+vi.mock('axios');
+vi.mock('../../auth/AuthContext', () => ({
+    useAuth: () => ({ token: 'test-token', loading: false }),
+}));
+
+const { confirmMock } = vi.hoisted(() => ({
+    confirmMock: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../hooks/useConfirmDialog', () => ({
+    useConfirmDialog: () => ({ confirm: confirmMock }),
+}));
+
+describe('EnvPage Call History privacy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        window.history.replaceState(null, '', '/env?section=call-history#system');
+        window.requestAnimationFrame = callback => {
+            callback(0);
+            return 1;
+        };
+        Element.prototype.scrollIntoView = vi.fn();
+        vi.mocked(axios.get).mockImplementation(async url => {
+            if (url === '/api/config/env') {
+                return {
+                    data: {
+                        CALL_HISTORY_ENABLED: 'true',
+                        CALL_HISTORY_RETENTION_DAYS: '0',
+                        CALL_HISTORY_DB_PATH: '/app/data/call_history.db',
+                        CALL_HISTORY_TOOL_REDACTION_MODE: 'show_routing',
+                    },
+                };
+            }
+            if (url === '/api/config/env/status') {
+                return { data: { apply_plan: [], pending_restart: false } };
+            }
+            if (url === '/api/config/yaml') return { data: { providers: {} } };
+            throw new Error(`Unexpected GET ${url}`);
+        });
+    });
+
+    it('shows all modes, warns for off, and requires confirmation before saving it', async () => {
+        render(
+            <MemoryRouter>
+                <EnvPage />
+            </MemoryRouter>
+        );
+
+        const select = await screen.findByLabelText('Tool Diagnostic Redaction');
+        expect(select).toHaveValue('show_routing');
+        expect(screen.getByRole('option', { name: /Strict/ })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /Show routing/ })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /Off/ })).toBeInTheDocument();
+        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+
+        fireEvent.change(select, { target: { value: 'off' } });
+        expect(screen.getByText(/Redaction is off/)).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+        await waitFor(() =>
+            expect(confirmMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    title: 'Disable Call History redaction?',
+                    variant: 'destructive',
+                })
+            )
+        );
+        expect(axios.post).not.toHaveBeenCalled();
+    });
+});

--- a/admin_ui/frontend/src/pages/System/EnvPage.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.tsx
@@ -92,6 +92,7 @@ const EnvPage = () => {
     const [smtpTestResult, setSmtpTestResult] = useState<{success: boolean; message?: string; error?: string} | null>(null);
     const [perInstanceRows, setPerInstanceRows] = useState<PerInstanceCredentialRow[]>([]);
     const [perInstanceLoading, setPerInstanceLoading] = useState(false);
+    const [savedCallHistoryRedactionMode, setSavedCallHistoryRedactionMode] = useState('strict');
 
     const [error, setError] = useState<string | null>(null);
 
@@ -120,6 +121,15 @@ const EnvPage = () => {
         window.addEventListener('hashchange', handleHashChange);
         return () => window.removeEventListener('hashchange', handleHashChange);
     }, []);
+
+    useEffect(() => {
+        if (activeTab !== 'system' || loading) return;
+        const section = new URLSearchParams(window.location.search).get('section');
+        if (section !== 'call-history') return;
+        window.requestAnimationFrame(() => {
+            document.getElementById('call-history-privacy')?.scrollIntoView({ block: 'start' });
+        });
+    }, [activeTab, loading]);
 
     // Load local AI server capabilities when on local-ai tab
     useEffect(() => {
@@ -267,6 +277,9 @@ const EnvPage = () => {
             });
             const loadedEnv = res.data || {};
             setEnv(loadedEnv);
+            setSavedCallHistoryRedactionMode(
+                (loadedEnv['CALL_HISTORY_TOOL_REDACTION_MODE'] || 'strict').trim().toLowerCase()
+            );
             if ((loadedEnv['KOKORO_MODE'] || '').toLowerCase() === 'hf') {
                 setShowAdvancedKokoro(true);
             }
@@ -300,6 +313,17 @@ const EnvPage = () => {
             return;
         }
 
+        const requestedRedactionMode = (env['CALL_HISTORY_TOOL_REDACTION_MODE'] || 'strict').trim().toLowerCase();
+        if (requestedRedactionMode === 'off' && savedCallHistoryRedactionMode !== 'off') {
+            const confirmed = await confirm({
+                title: 'Disable Call History redaction?',
+                description: 'Future in-call tool diagnostics may store credentials, caller information, free text, and routing data verbatim. These values can also appear in Call History exports and backups.',
+                confirmText: 'Disable redaction',
+                variant: 'destructive',
+            });
+            if (!confirmed) return;
+        }
+
         setSaving(true);
         try {
             const envToSave = { ...env };
@@ -318,6 +342,7 @@ const EnvPage = () => {
             });
             const keys = (response.data?.changed_keys || []) as string[];
             setChangedKeys(keys);
+            setSavedCallHistoryRedactionMode(requestedRedactionMode);
 
             // Prefer drift-based status (source of truth for whether containers need recreate),
             // but fall back to the immediate apply_plan from the save response.
@@ -584,7 +609,7 @@ const EnvPage = () => {
         // System - Container Permissions
         'ASTERISK_UID', 'ASTERISK_GID', 'DOCKER_GID',
         // System - Call History
-        'CALL_HISTORY_ENABLED', 'CALL_HISTORY_RETENTION_DAYS', 'CALL_HISTORY_DB_PATH',
+        'CALL_HISTORY_ENABLED', 'CALL_HISTORY_RETENTION_DAYS', 'CALL_HISTORY_DB_PATH', 'CALL_HISTORY_TOOL_REDACTION_MODE',
         // System - Outbound Campaign
         'AAVA_OUTBOUND_EXTENSION_IDENTITY', 'AAVA_OUTBOUND_AMD_CONTEXT', 'AAVA_MEDIA_DIR', 'AAVA_VM_UPLOAD_MAX_BYTES',
         'AAVA_OUTBOUND_PBX_TYPE', 'AAVA_OUTBOUND_DIAL_CONTEXT', 'AAVA_OUTBOUND_DIAL_PREFIX', 'AAVA_OUTBOUND_CHANNEL_TECH',
@@ -2081,34 +2106,56 @@ const EnvPage = () => {
                     </ConfigSection>
 
                     {/* Call History */}
-                    <ConfigSection title="Call History" description="Settings for call history persistence and retention.">
-                        <ConfigCard>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                                <FormSwitch
-                                    id="call-history-enabled"
-                                    label="Enable Call History"
-                                    description="Record call history for debugging and analytics."
-                                    checked={isTrue(env['CALL_HISTORY_ENABLED'])}
-                                    onChange={(e) => updateEnv('CALL_HISTORY_ENABLED', e.target.checked ? 'true' : 'false')}
-                                />
-                                <FormInput
-                                    label="Retention Days"
-                                    type="number"
-                                    value={env['CALL_HISTORY_RETENTION_DAYS'] || '0'}
-                                    onChange={(e) => updateEnv('CALL_HISTORY_RETENTION_DAYS', e.target.value)}
-                                    tooltip="0 = unlimited (keep forever)"
-                                />
-                                <div className="col-span-full">
-                                    <FormInput
-                                        label="Database Path"
-                                        value={env['CALL_HISTORY_DB_PATH'] || 'data/call_history.db'}
-                                        onChange={(e) => updateEnv('CALL_HISTORY_DB_PATH', e.target.value)}
-                                        placeholder="data/call_history.db"
+                    <div id="call-history-privacy" className="scroll-mt-6">
+                        <ConfigSection title="Call History" description="Settings for call history persistence, privacy, and retention.">
+                            <ConfigCard>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    <FormSwitch
+                                        id="call-history-enabled"
+                                        label="Enable Call History"
+                                        description="Record call history for debugging and analytics."
+                                        checked={isTrue(env['CALL_HISTORY_ENABLED'])}
+                                        onChange={(e) => updateEnv('CALL_HISTORY_ENABLED', e.target.checked ? 'true' : 'false')}
                                     />
+                                    <FormInput
+                                        label="Retention Days"
+                                        type="number"
+                                        value={env['CALL_HISTORY_RETENTION_DAYS'] || '0'}
+                                        onChange={(e) => updateEnv('CALL_HISTORY_RETENTION_DAYS', e.target.value)}
+                                        tooltip="0 = unlimited (keep forever)"
+                                    />
+                                    <FormSelect
+                                        label="Tool Diagnostic Redaction"
+                                        value={(env['CALL_HISTORY_TOOL_REDACTION_MODE'] || 'strict').trim().toLowerCase()}
+                                        onChange={(e) => updateEnv('CALL_HISTORY_TOOL_REDACTION_MODE', e.target.value)}
+                                        options={[
+                                            { value: 'strict', label: 'Strict — redact caller and routing data' },
+                                            { value: 'show_routing', label: 'Show routing — keep destinations and extensions' },
+                                            { value: 'off', label: 'Off — persist tool diagnostics verbatim' },
+                                        ]}
+                                        tooltip="Controls newly persisted in-call tool parameters, routing targets, and sensitive values echoed into tool messages. Existing records are unchanged."
+                                    />
+                                    <div className="col-span-full">
+                                        <FormInput
+                                            label="Database Path"
+                                            value={env['CALL_HISTORY_DB_PATH'] || 'data/call_history.db'}
+                                            onChange={(e) => updateEnv('CALL_HISTORY_DB_PATH', e.target.value)}
+                                            placeholder="data/call_history.db"
+                                        />
+                                    </div>
                                 </div>
-                            </div>
-                        </ConfigCard>
-                    </ConfigSection>
+                                {(env['CALL_HISTORY_TOOL_REDACTION_MODE'] || 'strict').trim().toLowerCase() === 'off' && (
+                                    <div className="mt-4 flex gap-2 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
+                                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                                        <span>Redaction is off. Future tool diagnostics may persist credentials and caller information in the database, API, exports, and backups.</span>
+                                    </div>
+                                )}
+                                <p className="text-xs text-muted-foreground mt-3">
+                                    Changes affect future tool executions after the AI Engine is recreated. Previously redacted values cannot be recovered.
+                                </p>
+                            </ConfigCard>
+                        </ConfigSection>
+                    </div>
 
                     {/* Outbound Campaign */}
                     <ConfigSection title="Outbound Campaign (Alpha)" description="Settings for outbound calling campaigns.">

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -109,6 +109,7 @@ If you’re not sure, start without these; use `agent check` and `docs/Transport
 
 - `CALL_HISTORY_DB_PATH`: SQLite path for Call History (default in `.env.example` is `data/call_history.db`).
 - `CALL_HISTORY_RETENTION_DAYS`: retention (0 = keep indefinitely).
+- `CALL_HISTORY_TOOL_REDACTION_MODE`: privacy policy for future persisted in-call tool diagnostics. `strict` (default) redacts credentials, caller PII/free text, and routing targets; `show_routing` keeps destinations, extensions, queues, and mailboxes while still redacting credentials and caller data; `off` persists tool diagnostics verbatim and is intended only for trusted/private systems. Invalid values fail closed to `strict`. Changing the value requires an `ai_engine` restart and cannot restore values already stored as `REDACTED`.
 
 ### Logging / diagnostics
 

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -73,13 +73,15 @@ append-only reduction contract:
   "type": "tool_result",
   "call_id": "1785299332.302",
   "tool_call_id": "provider-call-7",
-  "name": "google_calendar",
-  "action": "create_event",
+  "name": "blind_transfer",
+  "action": "blind_transfer",
   "status": "success",
-  "target_id": "calendar-event-42",
-  "params": {"action": "create_event"},
+  "target_id": "***REDACTED***",
+  "params": {"destination": "***REDACTED***"},
   "result": "success",
-  "message": "Event created",
+  "message": "Transfer accepted for ***REDACTED***",
+  "redaction_mode": "strict",
+  "redacted_fields": ["params.destination", "target_id", "message"],
   "timestamp": "2026-07-29T04:00:00+00:00",
   "duration_ms": 121.4
 }
@@ -107,7 +109,7 @@ append-only reduction contract:
   routing-derived top-level `target_id` is redacted along with its parameter;
   resource identifiers needed for reducers (for example, calendar event ids)
   remain available. Messages that echo a redacted parameter are sanitized too.
-  Policy changes affect future entries only, and historical `REDACTED` values
+  Policy changes affect future entries only, and historical `***REDACTED***` values
   cannot be recovered.
 - The event records the tool execution fact only. A successful voicemail route
   does not claim that a message was recorded, and a successful transfer does

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -96,10 +96,19 @@ append-only reduction contract:
   `create_event` followed by `delete_event` reconcile to zero net creations.
 - `status` is normalized to `success` or `failure`; `result` retains the legacy
   raw status for backward compatibility.
-- `params` is a diagnostic view, not an execution replay payload. Credentials,
-  caller PII/free text, and routing targets are recursively redacted before
-  persistence; the original parameters are used only for execution. The
-  explicit top-level `target_id` remains available for reducer reconciliation.
+- `params` is a diagnostic view, not an execution replay payload. Its persistence
+  policy is controlled by `CALL_HISTORY_TOOL_REDACTION_MODE`: `strict` (the
+  default) redacts credentials, caller PII/free text, and routing targets;
+  `show_routing` preserves destinations/extensions/queues/mailboxes while still
+  redacting credentials and caller data; `off` stores tool diagnostics verbatim.
+  Invalid values fail closed to `strict`. The original parameters are always used
+  for execution, regardless of the persistence policy.
+- New entries include `redaction_mode` and `redacted_fields`. Under `strict`, a
+  routing-derived top-level `target_id` is redacted along with its parameter;
+  resource identifiers needed for reducers (for example, calendar event ids)
+  remain available. Messages that echo a redacted parameter are sanitized too.
+  Policy changes affect future entries only, and historical `REDACTED` values
+  cannot be recovered.
 - The event records the tool execution fact only. A successful voicemail route
   does not claim that a message was recorded, and a successful transfer does
   not claim that a human answered.

--- a/src/tools/execution_history.py
+++ b/src/tools/execution_history.py
@@ -282,19 +282,14 @@ def _redact_message_echoes(message: Any, sensitive_values: list[str]) -> tuple[s
 
     changed = False
     for candidate in sorted(set(sensitive_values), key=len, reverse=True):
-        if len(candidate) < 3:
-            # Tiny values (for example, a one-digit extension) are replaced
-            # only as standalone tokens so ordinary words and larger numbers
-            # are not corrupted while exact echoes remain protected.
-            rendered, replacements = re.subn(
-                rf"(?<!\w){re.escape(candidate)}(?!\w)",
-                _REDACTED_PARAMETER_VALUE,
-                rendered,
-            )
-            changed = changed or replacements > 0
-        elif candidate in rendered:
-            rendered = rendered.replace(candidate, _REDACTED_PARAMETER_VALUE)
-            changed = True
+        # Replace exact token echoes without corrupting words or larger numbers
+        # that merely contain the sensitive value as a substring.
+        rendered, replacements = re.subn(
+            rf"(?<!\w){re.escape(candidate)}(?!\w)",
+            _REDACTED_PARAMETER_VALUE,
+            rendered,
+        )
+        changed = changed or replacements > 0
     return rendered, changed
 
 

--- a/src/tools/execution_history.py
+++ b/src/tools/execution_history.py
@@ -162,7 +162,7 @@ _ROUTING_PARAMETER_SUFFIXES = {
     "queue",
     "mailbox",
 }
-_ROUTING_TARGET_ID_KEYS = frozenset({"destination", "target", "extension", "queue", "mailbox"})
+_ROUTING_TARGET_ID_KEYS = frozenset(_ROUTING_PARAMETER_KEYS.intersection(_TARGET_ID_KEYS))
 
 
 def stable_tool_call_id(value: Any = None) -> str:

--- a/src/tools/execution_history.py
+++ b/src/tools/execution_history.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
@@ -39,7 +40,11 @@ _TARGET_ID_KEYS = (
     "mailbox",
 )
 _REDACTED_PARAMETER_VALUE = "***REDACTED***"
-_SENSITIVE_PARAMETER_KEYS = {
+CALL_HISTORY_TOOL_REDACTION_MODES = frozenset({"strict", "show_routing", "off"})
+_DEFAULT_TOOL_REDACTION_MODE = "strict"
+_warned_invalid_redaction_modes: set[str] = set()
+
+_SECRET_PARAMETER_KEYS = {
     # Credentials and authorization material. This follows the repository-wide
     # logging and HTTP-diagnostic redaction posture without substring matches
     # that would turn ordinary keys such as ``bypass`` into false positives.
@@ -67,8 +72,9 @@ _SENSITIVE_PARAMETER_KEYS = {
     "cookies",
     "header",
     "headers",
-    # Caller-supplied PII/free text and telephony routing targets accepted by
-    # the built-in in-call tools.
+}
+_PII_PARAMETER_KEYS = {
+    # Caller-supplied PII and free text accepted by built-in in-call tools.
     "name",
     "first_name",
     "last_name",
@@ -103,6 +109,10 @@ _SENSITIVE_PARAMETER_KEYS = {
     "body",
     "query",
     "prompt",
+}
+_ROUTING_PARAMETER_KEYS = {
+    # Telephony routing targets. Operators may expose these while retaining
+    # credential and caller-PII redaction via ``show_routing`` mode.
     "destination",
     "target",
     "extension",
@@ -110,7 +120,7 @@ _SENSITIVE_PARAMETER_KEYS = {
     "queue",
     "mailbox",
 }
-_SENSITIVE_PARAMETER_SUFFIXES = {
+_SECRET_PARAMETER_SUFFIXES = {
     "api_key",
     "token",
     "secret",
@@ -125,6 +135,8 @@ _SENSITIVE_PARAMETER_SUFFIXES = {
     "private_key",
     "client_secret",
     "cookie",
+}
+_PII_PARAMETER_SUFFIXES = {
     "name",
     "email",
     "phone",
@@ -142,12 +154,15 @@ _SENSITIVE_PARAMETER_SUFFIXES = {
     "body",
     "query",
     "prompt",
+}
+_ROUTING_PARAMETER_SUFFIXES = {
     "destination",
     "target",
     "extension",
     "queue",
     "mailbox",
 }
+_ROUTING_TARGET_ID_KEYS = frozenset({"destination", "target", "extension", "queue", "mailbox"})
 
 
 def stable_tool_call_id(value: Any = None) -> str:
@@ -187,11 +202,100 @@ def _scalar_identifier(value: Any) -> Optional[str]:
     return None
 
 
-def _is_sensitive_parameter_key(key: Any) -> bool:
-    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", str(key)).lower().replace("-", "_")
-    if normalized in _SENSITIVE_PARAMETER_KEYS:
+def normalize_call_history_tool_redaction_mode(value: Any, *, warn: bool = False) -> str:
+    """Return a supported mode, failing closed to ``strict`` when invalid."""
+    candidate = str(value or "").strip().lower()
+    if not candidate:
+        return _DEFAULT_TOOL_REDACTION_MODE
+    if candidate in CALL_HISTORY_TOOL_REDACTION_MODES:
+        return candidate
+    if warn and candidate not in _warned_invalid_redaction_modes:
+        _warned_invalid_redaction_modes.add(candidate)
+        logger.warning(
+            "Invalid call-history tool redaction mode; using strict",
+            configured_mode=candidate,
+            supported_modes=sorted(CALL_HISTORY_TOOL_REDACTION_MODES),
+        )
+    return _DEFAULT_TOOL_REDACTION_MODE
+
+
+def resolve_call_history_tool_redaction_mode() -> str:
+    """Resolve the effective runtime policy from the AI Engine environment."""
+    return normalize_call_history_tool_redaction_mode(
+        os.getenv("CALL_HISTORY_TOOL_REDACTION_MODE", _DEFAULT_TOOL_REDACTION_MODE),
+        warn=True,
+    )
+
+
+def _normalized_parameter_key(key: Any) -> str:
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", str(key)).lower().replace("-", "_")
+
+
+def _matches_key_family(normalized: str, keys: set[str], suffixes: set[str]) -> bool:
+    if normalized in keys:
         return True
-    return any(normalized.endswith(f"_{suffix}") for suffix in _SENSITIVE_PARAMETER_SUFFIXES)
+    return any(normalized.endswith(f"_{suffix}") for suffix in suffixes)
+
+
+def _parameter_key_family(key: Any) -> Optional[str]:
+    normalized = _normalized_parameter_key(key)
+    if _matches_key_family(normalized, _SECRET_PARAMETER_KEYS, _SECRET_PARAMETER_SUFFIXES):
+        return "secret"
+    if _matches_key_family(normalized, _PII_PARAMETER_KEYS, _PII_PARAMETER_SUFFIXES):
+        return "pii"
+    if _matches_key_family(normalized, _ROUTING_PARAMETER_KEYS, _ROUTING_PARAMETER_SUFFIXES):
+        return "routing"
+    return None
+
+
+def _is_sensitive_parameter_key(key: Any, mode: str = _DEFAULT_TOOL_REDACTION_MODE) -> bool:
+    if mode == "off":
+        return False
+    family = _parameter_key_family(key)
+    if family in {"secret", "pii"}:
+        return True
+    return family == "routing" and mode == "strict"
+
+
+def _sensitive_scalar_values(value: Any) -> list[str]:
+    """Collect scalar strings from a redacted value for message echo removal."""
+    if isinstance(value, dict):
+        values: list[str] = []
+        for item in value.values():
+            values.extend(_sensitive_scalar_values(item))
+        return values
+    if isinstance(value, (list, tuple)):
+        values = []
+        for item in value:
+            values.extend(_sensitive_scalar_values(item))
+        return values
+    if isinstance(value, bool) or value is None:
+        return []
+    candidate = str(value)
+    return [candidate] if candidate else []
+
+
+def _redact_message_echoes(message: Any, sensitive_values: list[str]) -> tuple[str, bool]:
+    rendered = str(message or "")
+    if not rendered or not sensitive_values:
+        return rendered, False
+
+    changed = False
+    for candidate in sorted(set(sensitive_values), key=len, reverse=True):
+        if len(candidate) < 3:
+            # Tiny values (for example, a one-digit extension) are replaced
+            # only as standalone tokens so ordinary words and larger numbers
+            # are not corrupted while exact echoes remain protected.
+            rendered, replacements = re.subn(
+                rf"(?<!\w){re.escape(candidate)}(?!\w)",
+                _REDACTED_PARAMETER_VALUE,
+                rendered,
+            )
+            changed = changed or replacements > 0
+        elif candidate in rendered:
+            rendered = rendered.replace(candidate, _REDACTED_PARAMETER_VALUE)
+            changed = True
+    return rendered, changed
 
 
 def _redact_parameter_value(value: Any) -> Any:
@@ -202,25 +306,59 @@ def _redact_parameter_value(value: Any) -> Any:
     return _REDACTED_PARAMETER_VALUE
 
 
-def _sanitize_persisted_parameters(value: Any) -> Any:
-    """Copy tool parameters while removing secrets, PII, and routing targets."""
+def _sanitize_persisted_parameters(
+    value: Any,
+    *,
+    mode: str = _DEFAULT_TOOL_REDACTION_MODE,
+    path: str = "params",
+) -> tuple[Any, list[str], list[str]]:
+    """Copy parameters and return sanitized data, redacted paths, and echo values."""
     if isinstance(value, dict):
-        return {
-            key: (
-                _redact_parameter_value(item)
-                if _is_sensitive_parameter_key(key)
-                else _sanitize_persisted_parameters(item)
+        sanitized: Dict[Any, Any] = {}
+        redacted_fields: list[str] = []
+        sensitive_values: list[str] = []
+        for key, item in value.items():
+            item_path = f"{path}.{key}"
+            if _is_sensitive_parameter_key(key, mode):
+                sanitized[key] = _redact_parameter_value(item)
+                if item not in (None, ""):
+                    redacted_fields.append(item_path)
+                    sensitive_values.extend(_sensitive_scalar_values(item))
+                continue
+            copied, nested_fields, nested_values = _sanitize_persisted_parameters(
+                item,
+                mode=mode,
+                path=item_path,
             )
-            for key, item in value.items()
-        }
+            sanitized[key] = copied
+            redacted_fields.extend(nested_fields)
+            sensitive_values.extend(nested_values)
+        return sanitized, redacted_fields, sensitive_values
     if isinstance(value, list):
-        return [_sanitize_persisted_parameters(item) for item in value]
+        sanitized_list = []
+        redacted_fields = []
+        sensitive_values = []
+        for index, item in enumerate(value):
+            copied, nested_fields, nested_values = _sanitize_persisted_parameters(
+                item,
+                mode=mode,
+                path=f"{path}[{index}]",
+            )
+            sanitized_list.append(copied)
+            redacted_fields.extend(nested_fields)
+            sensitive_values.extend(nested_values)
+        return sanitized_list, redacted_fields, sensitive_values
     if isinstance(value, tuple):
-        return tuple(_sanitize_persisted_parameters(item) for item in value)
-    return value
+        copied, redacted_fields, sensitive_values = _sanitize_persisted_parameters(
+            list(value),
+            mode=mode,
+            path=path,
+        )
+        return tuple(copied), redacted_fields, sensitive_values
+    return value, [], []
 
 
-def _target_id(parameters: Any, result: Any) -> Optional[str]:
+def _target_id(parameters: Any, result: Any) -> tuple[Optional[str], Optional[str]]:
     # A created resource id in the result is authoritative. For compensating
     # operations (for example calendar/delete_event), fall back to the same id
     # supplied as a parameter so reducers can reconcile create/delete pairs.
@@ -230,8 +368,8 @@ def _target_id(parameters: Any, result: Any) -> Optional[str]:
         for key in _TARGET_ID_KEYS:
             candidate = _scalar_identifier(source.get(key))
             if candidate:
-                return candidate
-    return None
+                return candidate, key
+    return None, None
 
 
 def build_in_call_tool_record(
@@ -243,6 +381,7 @@ def build_in_call_tool_record(
     result: Any,
     duration_ms: float = 0.0,
     canonical_name: Optional[str] = None,
+    redaction_mode: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build the additive v7.5.3 in-call tool-result contract.
 
@@ -251,8 +390,16 @@ def build_in_call_tool_record(
     make the append-only stream reducible without mixing telemetry into the
     transcript-only ``conversation_history``.
     """
+    mode = (
+        resolve_call_history_tool_redaction_mode()
+        if redaction_mode is None
+        else normalize_call_history_tool_redaction_mode(redaction_mode)
+    )
     execution_params = parameters if isinstance(parameters, dict) else {}
-    params = _sanitize_persisted_parameters(execution_params)
+    params, redacted_fields, sensitive_values = _sanitize_persisted_parameters(
+        execution_params,
+        mode=mode,
+    )
     result_dict = result if isinstance(result, dict) else {}
     raw_status = str(result_dict.get("status") or "").strip()
     terminal_status = normalize_tool_terminal_status(result)
@@ -263,9 +410,18 @@ def build_in_call_tool_record(
     if not action:
         action = name
 
+    target_id, target_key = _target_id(execution_params, result_dict)
+    if target_id and target_key in _ROUTING_TARGET_ID_KEYS and mode == "strict":
+        sensitive_values.append(target_id)
+        target_id = _REDACTED_PARAMETER_VALUE
+        redacted_fields.append("target_id")
+
     message = result_dict.get("message")
     if message is None and not isinstance(result, dict):
         message = str(result)
+    message, message_redacted = _redact_message_echoes(message, sensitive_values)
+    if message_redacted:
+        redacted_fields.append("message")
 
     return {
         "type": "tool_result",
@@ -274,10 +430,12 @@ def build_in_call_tool_record(
         "name": name,
         "action": action,
         "status": terminal_status,
-        "target_id": _target_id(execution_params, result_dict),
+        "target_id": target_id,
         "params": params,
         "result": raw_status or terminal_status,
-        "message": str(message or ""),
+        "message": message,
+        "redaction_mode": mode,
+        "redacted_fields": list(dict.fromkeys(redacted_fields)),
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "duration_ms": round(max(0.0, float(duration_ms or 0.0)), 2),
     }
@@ -293,6 +451,7 @@ async def record_in_call_tool_result(
     result: Any,
     duration_ms: float = 0.0,
     canonical_name: Optional[str] = None,
+    redaction_mode: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Append one terminal result to ``CallSession.tool_calls`` best-effort.
 
@@ -310,6 +469,7 @@ async def record_in_call_tool_result(
             result=result,
             duration_ms=duration_ms,
             canonical_name=canonical_name,
+            redaction_mode=redaction_mode,
         )
         if session_store is None:
             return None

--- a/tests/test_tool_execution_history.py
+++ b/tests/test_tool_execution_history.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.tools.execution_history import (
     build_in_call_tool_record,
+    normalize_call_history_tool_redaction_mode,
     normalize_tool_terminal_status,
     record_in_call_tool_result,
     stable_tool_call_id,
@@ -35,6 +36,8 @@ def test_calendar_create_record_has_stable_id_action_and_target():
         "params": {"action": "create_event", "summary": "***REDACTED***"},
         "result": "success",
         "message": "Created",
+        "redaction_mode": "strict",
+        "redacted_fields": ["params.summary"],
         "timestamp": record["timestamp"],
         "duration_ms": 12.35,
     }
@@ -167,18 +170,108 @@ def test_parameter_redaction_covers_common_pii_and_credential_shapes_without_suf
 
 
 @pytest.mark.parametrize("target_key", ["destination", "target", "extension", "queue", "mailbox"])
-def test_transfer_targets_are_not_persisted_verbatim(target_key):
+def test_strict_mode_redacts_transfer_targets_consistently(target_key):
     record = build_in_call_tool_record(
         call_id="call-transfer",
         tool_call_id="tool-transfer",
         tool_name="transfer_call",
         parameters={"action": "transfer", target_key: "private-destination"},
-        result={"status": "success"},
+        result={"status": "success", "message": "Using private-destination"},
+        redaction_mode="strict",
     )
 
     assert record["params"][target_key] == "***REDACTED***"
-    assert record["target_id"] == "private-destination"
+    assert record["target_id"] == "***REDACTED***"
+    assert record["message"] == "Using ***REDACTED***"
+    assert record["redacted_fields"] == [f"params.{target_key}", "target_id", "message"]
     assert record["action"] == "transfer"
+
+
+@pytest.mark.parametrize("target_key", ["destination", "target", "extension", "queue", "mailbox"])
+def test_show_routing_preserves_targets_but_redacts_pii_and_secrets(target_key):
+    parameters = {
+        "action": "transfer",
+        target_key: "support-6000",
+        "caller_email": "caller@example.com",
+        "authorization": "Bearer secret-token",
+    }
+    record = build_in_call_tool_record(
+        call_id="call-routing-visible",
+        tool_call_id="tool-routing-visible",
+        tool_name="blind_transfer",
+        parameters=parameters,
+        result={"status": "success", "message": "Routing support-6000 for caller@example.com"},
+        redaction_mode="show_routing",
+    )
+
+    assert record["params"][target_key] == "support-6000"
+    assert record["params"]["caller_email"] == "***REDACTED***"
+    assert record["params"]["authorization"] == "***REDACTED***"
+    assert record["target_id"] == "support-6000"
+    assert record["message"] == "Routing support-6000 for ***REDACTED***"
+    assert record["redaction_mode"] == "show_routing"
+    assert record["redacted_fields"] == ["params.caller_email", "params.authorization", "message"]
+    assert parameters["caller_email"] == "caller@example.com"
+
+
+def test_off_mode_persists_diagnostics_verbatim_without_mutating_input():
+    parameters = {
+        "destination": "Support",
+        "caller_email": "caller@example.com",
+        "metadata": {"authorization": "Bearer secret-token"},
+    }
+    record = build_in_call_tool_record(
+        call_id="call-off",
+        tool_call_id="tool-off",
+        tool_name="blind_transfer",
+        parameters=parameters,
+        result={"status": "success", "message": "Transfer Support for caller@example.com"},
+        redaction_mode="off",
+    )
+
+    assert record["params"] == parameters
+    assert record["params"] is not parameters
+    assert record["params"]["metadata"] is not parameters["metadata"]
+    assert record["target_id"] == "Support"
+    assert record["message"] == "Transfer Support for caller@example.com"
+    assert record["redaction_mode"] == "off"
+    assert record["redacted_fields"] == []
+
+
+def test_strict_mode_sanitizes_a_short_routing_value_only_as_a_token():
+    record = build_in_call_tool_record(
+        call_id="call-short-route",
+        tool_call_id="tool-short-route",
+        tool_name="blind_transfer",
+        parameters={"destination": "1"},
+        result={"status": "success", "message": "Transfer to 1; attempt 12 remains."},
+        redaction_mode="strict",
+    )
+
+    assert record["message"] == "Transfer to ***REDACTED***; attempt 12 remains."
+
+
+@pytest.mark.parametrize("configured", [None, "", "invalid", " STRICT "])
+def test_redaction_mode_normalization_fails_closed(configured):
+    expected = "strict"
+    assert normalize_call_history_tool_redaction_mode(configured) == expected
+
+
+def test_runtime_mode_is_resolved_from_environment(monkeypatch):
+    monkeypatch.setenv("CALL_HISTORY_TOOL_REDACTION_MODE", "show_routing")
+
+    record = build_in_call_tool_record(
+        call_id="call-env-policy",
+        tool_call_id="tool-env-policy",
+        tool_name="blind_transfer",
+        parameters={"destination": "support", "caller_email": "caller@example.com"},
+        result={"status": "success", "destination": "6000"},
+    )
+
+    assert record["redaction_mode"] == "show_routing"
+    assert record["params"]["destination"] == "support"
+    assert record["params"]["caller_email"] == "***REDACTED***"
+    assert record["target_id"] == "6000"
 
 
 def test_missing_ids_are_unique_per_invocation():

--- a/tests/test_tool_execution_history.py
+++ b/tests/test_tool_execution_history.py
@@ -251,6 +251,38 @@ def test_strict_mode_sanitizes_a_short_routing_value_only_as_a_token():
     assert record["message"] == "Transfer to ***REDACTED***; attempt 12 remains."
 
 
+@pytest.mark.parametrize(
+    ("sensitive_value", "message", "expected"),
+    [
+        (
+            "Sam",
+            "Samantha requested a callback; Sam confirmed.",
+            "Samantha requested a callback; ***REDACTED*** confirmed.",
+        ),
+        (
+            "6000",
+            "Transfer to 6000; reference 16000 remains.",
+            "Transfer to ***REDACTED***; reference 16000 remains.",
+        ),
+    ],
+)
+def test_strict_mode_sanitizes_longer_routing_values_only_as_tokens(
+    sensitive_value,
+    message,
+    expected,
+):
+    record = build_in_call_tool_record(
+        call_id="call-token-route",
+        tool_call_id="tool-token-route",
+        tool_name="blind_transfer",
+        parameters={"destination": sensitive_value},
+        result={"status": "success", "message": message},
+        redaction_mode="strict",
+    )
+
+    assert record["message"] == expected
+
+
 @pytest.mark.parametrize("configured", [None, "", "invalid", " STRICT "])
 def test_redaction_mode_normalization_fails_closed(configured):
     expected = "strict"


### PR DESCRIPTION
## Summary

Make persisted in-call tool diagnostics configurable instead of forcing routing details to remain redacted on every installation.

- Add `CALL_HISTORY_TOOL_REDACTION_MODE` with fail-closed `strict` (default), `show_routing`, and explicit `off` modes.
- Keep credentials and caller PII/free text protected in `show_routing`, while preserving resolved destinations, extensions, queues, and mailboxes for troubleshooting.
- Apply strict policy consistently to routing-derived `target_id` and sensitive values echoed in tool messages.
- Record `redaction_mode` and `redacted_fields` on new entries without a database migration.
- Surface the selector and destructive `off` warning under System → Environment → Call History.
- Surface configured/pending policy on Call History and the policy used for each stored call, with a direct link to the setting.

## Related Issue(s)

- Closes #589
- #341 is intentionally out of scope.

## Implementation Notes

- Key files touched (code/config/docs):
  - `src/tools/execution_history.py`
  - `admin_ui/backend/api/calls.py`
  - `admin_ui/backend/api/config.py`
  - `admin_ui/frontend/src/pages/System/EnvPage.tsx`
  - `admin_ui/frontend/src/pages/CallHistoryPage.tsx`
  - `admin_ui/frontend/src/components/calls/ToolExecutionGroups.tsx`
  - `.env.example`, `docs/ENVIRONMENT_VARIABLES.md`, `docs/TOOL_CALLING_GUIDE.md`, `CHANGELOG.md`
- High-level design decisions:
  - Missing or invalid values resolve to `strict`.
  - `show_routing` exposes routing identifiers only; secret and PII key families remain redacted.
  - `off` is explicit, warned, and confirmed in the UI for trusted/private deployments.
  - The Admin API exposes only the narrow policy/status response, never the complete `.env`.
  - Policy changes are forward-only and require `ai_engine` recreation; historical redactions cannot be recovered and exports continue to reflect stored values.
  - Pre-call/post-call tools, transcripts, support bundles, and ordinary logs are unchanged.

Agreed plan: introduce the three-mode persistence policy, keep strict compatibility/fail-closed behavior, add authenticated Admin API and both UI surfaces, preserve per-entry policy evidence, document the forward-only boundary, and verify the deployed images on voiprnd.

## Testing

- [x] Unit tests
  - `python -m pytest -q -k "not integration and not test_deepgram_stt_adapter_transcribes and not test_resolve_stream_targets and not test_output_rate_drift_adjusts_active_rate and not test_session_requests_g711_when_target_mulaw" --maxfail=10 --tb=short` — 2,011 passed, 6 skipped, 139 deselected
  - `cd admin_ui/backend && PYTHONPATH=. pytest tests -q` — 536 passed
  - `cd admin_ui/frontend && npm test` — 256 passed
  - Focused execution-history and policy checks — 46 Python tests passed; Call History component checks — 6 tests passed
  - `npm run lint`, `npm run build`, `python -m compileall -q .`, `scripts/check_release_docs.py`, and `scripts/check_no_committed_secrets.py` passed
- [x] Integration / manual tests
  - Built/recreated `ai_engine` from `debe6062` and `admin_ui` from final head `8de205e7` on voiprnd while idle (0 calls/sessions/channels).
  - Deployed synthetic transfer diagnostics confirmed:
    - `strict`: destination, resolved extension `6000`, caller email, and message echoes redacted.
    - `show_routing`: destination alias and resolved extension `6000` visible; caller email and its message echo redacted.
    - `off`: parameters, resolved extension, and message persisted verbatim.
  - Final review regression: blank/whitespace policy reset passed inside the final `admin_ui` container without modifying the deployed `.env`.
  - Auth boundary confirmed: `/api/calls/redaction-policy` returns 401 without a token.
  - Default deployed policy confirmed as valid implicit `strict`; Admin UI returned HTTP 200 and its compiled bundle contains the Call History privacy panel.
  - Post-deploy health: ARI connected, AudioSocket listening, all configured providers ready, all configured pipelines healthy, 0 calls/sessions.
- [x] `agent check` — PASS 19, WARN 0, FAIL 0, SKIP 0 on voiprnd
- [ ] `agent rca` — not applicable; no call-quality incident or real-call failure was investigated
- [ ] `./scripts/rca_collect.sh` — not applicable

For telephony changes:

- Test call IDs: none; this changes diagnostic persistence after tool execution, not routing or call ownership. The deployed execution-history contract was exercised directly with synthetic transfer results.
- Providers/pipelines involved: provider-independent shared tool execution history.
- Brief call behavior summary: no call-control behavior changes; voiprnd remained healthy and idle through deployment.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [x] Review fixes were pushed as cohesive batches
- [x] Final head is frozen, the PR is ready, and the final CI gate has passed
- [x] `@coderabbitai full review` completed; CodeRabbit follow-up passed on final head `8de205e7`
- [ ] Optional `codex-review` label/manual workflow completed on the frozen head, if requested
- [x] All actionable conversations are resolved

See the [pull-request workflow](../docs/contributing/PULL_REQUEST_WORKFLOW.md) for the expected review and CI sequence.

## Documentation

- [ ] `docs/contributing/architecture-deep-dive.md`
- [ ] `docs/ROADMAP.md` / `docs/milestones/*`
- [x] `docs/TOOL_CALLING_GUIDE.md`
- [x] Provider/tool-specific docs (`docs/ENVIRONMENT_VARIABLES.md` and `.env.example`)
- [ ] `docs/DEVELOPER_ONBOARDING.md` / other onboarding content
- [x] `CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-configurable Call History tool-diagnostic privacy modes: **Strict**, **Show routing**, and **Off**.
  * Call History now displays the active privacy policy, which fields were redacted, and whether a restart is pending.
  * Added an admin API to view the current redaction policy and updated the UI to navigate to the relevant setting.
* **Bug Fixes**
  * Invalid or unknown privacy settings now **fail closed to Strict**, keeping sensitive values protected in stored diagnostics and messages.
* **Documentation**
  * Updated environment-variable and tool-calling guidance, including restart behavior and irrecoverable redactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->