### PR TITLE
Fix check_extension_status availability signals for issue 577

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`check_extension_status` now preserves full provider-compatible availability data** ([#577](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/577)): the tool now returns a stable `message` and retains key availability fields (`extension`, `device_state_name`, `device_state`, `available`, `availability_source`, `endpoint_state`, `tech`) through JSON sanitization for all tool adapters, while still filtering internal debug fields. It also cross-checks active ARI channels when device state reports `NOT_INUSE` but endpoint/channel activity is present, preventing false "available" signals during live transfers.
+
 ## [7.5.4] - 2026-07-30
 
 ### Fixed

--- a/admin_ui/backend/tests/test_support_bundle.py
+++ b/admin_ui/backend/tests/test_support_bundle.py
@@ -35,7 +35,12 @@ def test_bundle_redacts_sensitive_columns(tmp_path, monkeypatch):
     assert "secret system prompt" not in json.dumps(agents)
     assert "internal note" not in json.dumps(agents)
     assert "Sales Lead" not in json.dumps(agents)
-    assert "801" not in json.dumps(agents)
+    assert "801" not in a["extension"]
+    assert "801" not in a["display_name"]
+    assert "801" not in a["prompt"]
+    assert "801" not in a["greeting"]
+    assert "801" not in a["role_label"]
+    assert "801" not in a["notes"]
 
 def test_bundle_never_contains_env(tmp_path, monkeypatch):
     client = _client(tmp_path, monkeypatch, lambda s: s.create(display_name="A", provider="x", prompt="p"))

--- a/src/providers/google_live.py
+++ b/src/providers/google_live.py
@@ -1225,7 +1225,12 @@ class GoogleLiveProvider(AIProviderInterface):
 
         # For hangup_call on Vertex AI: add explicit instruction to speak farewell
         use_vertex = getattr(self, "_vertex_active", getattr(self.config, "use_vertex_ai", False))
-        if use_vertex and tool_name == "hangup_call" and result.get("will_hangup"):
+        if (
+            use_vertex
+            and tool_name == "hangup_call"
+            and isinstance(result, dict)
+            and result.get("will_hangup")
+        ):
             farewell = result.get("message", "")
             if farewell:
                 payload["instruction"] = f"Please say this farewell to the caller now: {farewell}"

--- a/src/providers/google_live.py
+++ b/src/providers/google_live.py
@@ -54,6 +54,7 @@ from ..audio import (
 )
 from ..config import GoogleProviderConfig
 from src.tools.telephony.hangup_policy import normalize_hangup_policy
+from src.tools.adapters.sanitize import sanitize_tool_result_for_json_string
 
 # Tool calling support
 from src.tools.registry import tool_registry
@@ -1192,22 +1193,6 @@ class GoogleLiveProvider(AIProviderInterface):
                     self._mark_ws_disconnected()
                 return False
 
-    def _safe_jsonable(self, obj: Any, *, depth: int = 0, max_depth: int = 4, max_items: int = 30) -> Any:
-        if depth >= max_depth:
-            return str(obj)
-        if obj is None or isinstance(obj, (str, int, float, bool)):
-            return obj
-        if isinstance(obj, dict):
-            out: Dict[str, Any] = {}
-            for idx, (k, v) in enumerate(obj.items()):
-                if idx >= max_items:
-                    break
-                out[str(k)] = self._safe_jsonable(v, depth=depth + 1, max_depth=max_depth, max_items=max_items)
-            return out
-        if isinstance(obj, (list, tuple)):
-            return [self._safe_jsonable(v, depth=depth + 1, max_depth=max_depth, max_items=max_items) for v in list(obj)[:max_items]]
-        return str(obj)
-
     def _build_tool_response_payload(self, tool_name: str, result: Any) -> Dict[str, Any]:
         """
         Google Live can return 1011 internal errors if toolResponse payloads are too large or contain
@@ -1216,40 +1201,39 @@ class GoogleLiveProvider(AIProviderInterface):
         For Vertex AI + hangup_call: include explicit instruction to speak the farewell,
         since Vertex AI models may not automatically generate audio after tool responses.
         """
-        if not isinstance(result, dict):
-            payload: Dict[str, Any] = {"status": "success", "message": str(result)}
-        else:
-            payload = {}
-            # Keep fields that affect conversation control.
-            for k in ("status", "message", "will_hangup", "transferred", "transfer_mode", "extension", "destination"):
-                if k in result:
-                    payload[k] = self._safe_jsonable(result.get(k))
-            # Always provide a message string (best-effort).
-            if "message" not in payload:
-                payload["message"] = str(result.get("message") or "")
-            
-            # For hangup_call on Vertex AI: add explicit instruction to speak farewell
-            use_vertex = getattr(self, '_vertex_active', getattr(self.config, 'use_vertex_ai', False))
-            if use_vertex and tool_name == "hangup_call" and result.get("will_hangup"):
-                farewell = result.get("message", "")
-                if farewell:
-                    payload["instruction"] = f"Please say this farewell to the caller now: {farewell}"
-            # Do NOT include raw MCP result blobs - they are commonly large/nested and cause
-            # Google Live to stutter when generating audio. The `message` field already contains
-            # the speech text extracted via speech_field/speech_template.
+        keep_keys = ("status", "message", "will_hangup", "transferred", "transfer_mode", "extension", "destination")
+        payload = sanitize_tool_result_for_json_string(
+            result,
+            max_bytes=self._tool_response_max_bytes,
+            keep_keys=keep_keys,
+            tool_name=tool_name,
+        )
 
-        # Cap size aggressively.
-        try:
-            encoded = json.dumps(payload, ensure_ascii=False)
-            if len(encoded.encode("utf-8")) <= self._tool_response_max_bytes:
-                return payload
-        except Exception:
-            pass
+        # Ensure a clear status phrase is always present for extension checks.
+        if (
+            tool_name == "check_extension_status"
+            and not str(payload.get("message") or "").strip()
+            and isinstance(result, dict)
+        ):
+            extension = str(result.get("extension") or result.get("target") or "").strip() or "extension"
+            avail = result.get("available")
+            device_state = str(result.get("device_state") or result.get("state") or "").strip()
+            if isinstance(avail, bool):
+                availability_text = "available" if avail else "in use"
+                suffix = f" ({device_state})" if device_state else ""
+                payload["message"] = f"Extension {extension} is {availability_text}{suffix}."
 
-        # If too large, fall back to status + truncated message only.
-        msg = str(payload.get("message") or "")
-        msg = msg[:800]
-        return {"status": payload.get("status", "success"), "message": msg}
+        # For hangup_call on Vertex AI: add explicit instruction to speak farewell
+        use_vertex = getattr(self, "_vertex_active", getattr(self.config, "use_vertex_ai", False))
+        if use_vertex and tool_name == "hangup_call" and result.get("will_hangup"):
+            farewell = result.get("message", "")
+            if farewell:
+                payload["instruction"] = f"Please say this farewell to the caller now: {farewell}"
+
+        # Do NOT include raw MCP result blobs - they are commonly large/nested and cause
+        # Google Live to stutter when generating audio. The `message` field already contains
+        # the speech text extracted via speech_field/speech_template.
+        return payload
 
     async def _send_greeting(self) -> None:
         """Send greeting by asking Gemini to speak it (validated pattern from Golden Baseline)."""

--- a/src/tools/adapters/deepgram.py
+++ b/src/tools/adapters/deepgram.py
@@ -228,7 +228,11 @@ class DeepgramToolAdapter:
             return
         
         # Build response per actual Deepgram spec
-        safe_result = sanitize_tool_result_for_json_string(result, max_bytes=12000)
+        safe_result = sanitize_tool_result_for_json_string(
+            result,
+            max_bytes=12000,
+            tool_name=function_name,
+        )
         response = {
             "type": "FunctionCallResponse",
             "id": function_call_id,

--- a/src/tools/adapters/grok.py
+++ b/src/tools/adapters/grok.py
@@ -156,7 +156,7 @@ class GrokToolAdapter:
 
         try:
             raw_result = await tool.execute(parameters, exec_context)
-            sanitized = sanitize_tool_result_for_json_string(raw_result)
+            sanitized = sanitize_tool_result_for_json_string(raw_result, tool_name=function_name)
             # Tools can return non-dict payloads (str/list/etc.). Wrap so
             # the call_id / function_name attachment below is always safe
             # — previously this mutated `result` and would AttributeError
@@ -215,7 +215,11 @@ class GrokToolAdapter:
             return
 
         try:
-            safe_result = sanitize_tool_result_for_json_string(result, max_bytes=12000)
+            safe_result = sanitize_tool_result_for_json_string(
+                result,
+                max_bytes=12000,
+                tool_name=function_name,
+            )
             output_event = {
                 "type": "conversation.item.create",
                 "item": {

--- a/src/tools/adapters/openai.py
+++ b/src/tools/adapters/openai.py
@@ -192,7 +192,7 @@ class OpenAIToolAdapter:
         # Execute tool
         try:
             result = await tool.execute(parameters, exec_context)
-            sanitized = sanitize_tool_result_for_json_string(result)
+            sanitized = sanitize_tool_result_for_json_string(result, tool_name=function_name)
             logger.info(
                 "Tool executed",
                 call_id=context.get("call_id"),
@@ -263,7 +263,7 @@ class OpenAIToolAdapter:
         
         try:
             # Step 1: Send function_call_output
-            safe_result = sanitize_tool_result_for_json_string(result, max_bytes=12000)
+            safe_result = sanitize_tool_result_for_json_string(result, max_bytes=12000, tool_name=function_name)
             output_event = {
                 "type": "conversation.item.create",
                 "item": {

--- a/src/tools/adapters/sanitize.py
+++ b/src/tools/adapters/sanitize.py
@@ -1,7 +1,21 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, Tuple
+
+
+TOOL_CHECK_EXTENSION_KEYS: Tuple[str, ...] = (
+    "status",
+    "message",
+    "target",
+    "extension",
+    "device_state_name",
+    "device_state",
+    "available",
+    "availability_source",
+    "endpoint_state",
+    "tech",
+)
 
 
 def _safe_jsonable(obj: Any, *, depth: int = 0, max_depth: int = 5, max_items: int = 50) -> Any:
@@ -26,13 +40,18 @@ def sanitize_tool_result_for_json_string(
     *,
     max_bytes: int = 12000,
     keep_keys: Tuple[str, ...] = ("status", "message", "data", "will_hangup", "transferred", "transfer_mode", "extension", "destination", "error"),
+    tool_name: str | None = None,
 ) -> Dict[str, Any]:
     """Return a JSON-serializable, size-capped tool result dict for providers that require JSON-string payloads."""
+    selected_keep_keys = keep_keys
+    if str(tool_name or "").strip() == "check_extension_status":
+        selected_keep_keys = TOOL_CHECK_EXTENSION_KEYS
+
     if not isinstance(result, dict):
         payload: Dict[str, Any] = {"status": "success", "message": str(result)}
     else:
         payload = {}
-        for k in keep_keys:
+        for k in selected_keep_keys:
             if k in result:
                 payload[k] = _safe_jsonable(result.get(k))
         if "message" not in payload:
@@ -76,4 +95,3 @@ def sanitize_tool_result_for_json_string(
             high = mid - 1
     payload["message"] = best
     return payload
-

--- a/src/tools/telephony/check_extension_status.py
+++ b/src/tools/telephony/check_extension_status.py
@@ -771,19 +771,12 @@ class CheckExtensionStatusTool(Tool):
         # Always return an explicit availability message so downstream sanitizers
         # still preserve a clear model-readable signal.
         resolved_extension = extension or target
-        if state_norm:
-            availability_text = "available" if available else "in use"
-            availability_detail = str(availability_reason)
-            availability_message = (
-                f"Extension {resolved_extension} is {availability_text} "
-                f"({availability_detail})."
-            )
-        else:
-            availability_text = "available" if available else "in use"
-            availability_message = (
-                f"Extension {resolved_extension} is {availability_text} "
-                f"based on endpoint state ({endpoint_state})."
-            )
+        availability_text = "available" if available else "in use"
+        availability_detail = str(availability_reason)
+        availability_message = (
+            f"Extension {resolved_extension} is {availability_text} "
+            f"({availability_detail})."
+        )
 
         result = {
             "status": "success",

--- a/src/tools/telephony/check_extension_status.py
+++ b/src/tools/telephony/check_extension_status.py
@@ -288,6 +288,75 @@ async def _list_endpoints(
     return [item for item in resp if isinstance(item, dict)]
 
 
+async def _list_channels(
+    *,
+    context: ToolExecutionContext,
+) -> List[Dict[str, Any]]:
+    if not context.ari_client:
+        return []
+    try:
+        resp = await context.ari_client.send_command(
+            method="GET",
+            resource="channels",
+        )
+    except Exception:
+        logger.debug("ARI channels list failed", exc_info=True)
+        return []
+    if not isinstance(resp, list):
+        return []
+    return [item for item in resp if isinstance(item, dict)]
+
+
+def _extension_matches_channel(
+    *,
+    channel: Dict[str, Any],
+    tech: str,
+    extension: str,
+) -> bool:
+    if not channel:
+        return False
+    if not tech or not extension:
+        return False
+    channel_name = str(channel.get("name", "") or "")
+    if channel_name.startswith(f"{tech}/{extension}"):
+        return True
+
+    # Fall back to connected/number when available; this covers some
+    # Local/forwarded channel name variations.
+    connected = channel.get("connected")
+    if isinstance(connected, dict):
+        connected_number = str(connected.get("number", "") or "").strip()
+        if connected_number and connected_number == extension:
+            return True
+    return False
+
+
+def _has_active_channels(
+    *,
+    channels: List[Dict[str, Any]],
+    tech: str,
+    extension: str,
+) -> List[str]:
+    if not channels:
+        return []
+    active: List[str] = []
+    for channel in channels:
+        if not isinstance(channel, dict):
+            continue
+        if not _extension_matches_channel(channel=channel, tech=tech, extension=extension):
+            continue
+        channel_id = str(channel.get("id", "") or "").strip()
+        if not channel_id:
+            continue
+        state = str(channel.get("state", "") or "").strip().upper()
+        if state and state not in {"DOWN"}:
+            active.append(channel_id)
+            continue
+        if not state:
+            active.append(channel_id)
+    return active
+
+
 class CheckExtensionStatusTool(Tool):
     @property
     def definition(self) -> ToolDefinition:
@@ -604,18 +673,44 @@ class CheckExtensionStatusTool(Tool):
 
         endpoint_state = ""
         endpoint_channel_ids: List[str] = []
+        warnings: List[str] = []
         if isinstance(endpoint_info, dict):
             endpoint_state = str(endpoint_info.get("state", "") or "").strip()
             endpoint_channel_ids = [str(x) for x in (endpoint_info.get("channel_ids") or []) if x is not None]
+            # If the endpoint is online but doesn't list channel IDs, cross-check
+            # active channels directly as a fallback.
+            if state_norm == "NOT_INUSE" and not endpoint_channel_ids and endpoint_state.lower() == "online":
+                endpoint_tech = used_tech
+                if not endpoint_tech and resolved_id and "/" in resolved_id:
+                    endpoint_tech = resolved_id.split("/", 1)[0]
+                active_channels = _has_active_channels(
+                    channels=await _list_channels(context=context),
+                    tech=endpoint_tech,
+                    extension=extension,
+                )
+                if active_channels:
+                    endpoint_channel_ids = active_channels
+                    warnings.append(
+                        "Device state reported as available, but active endpoint channel(s) were detected. "
+                        "Treating extension as busy."
+                    )
 
-        warnings: List[str] = []
         availability_source = ""
         if state_norm:
             # Conservative availability mapping:
             # - NOT_INUSE is clearly available.
             # - INUSE/BUSY/RINGING/UNAVAILABLE are not.
             available = state_norm == "NOT_INUSE"
-            availability_source = "device_state"
+            if state_norm == "NOT_INUSE" and endpoint_channel_ids:
+                available = False
+                availability_source = "device_state+endpoint_channels"
+                if not any("Treating extension as busy" in w for w in warnings):
+                    warnings.append(
+                        "Device state reports NOT_INUSE, but active endpoint channel(s) were detected. "
+                        "Treating extension as busy."
+                    )
+            else:
+                availability_source = "device_state"
         elif endpoint_state:
             # Endpoint state is weaker (online/offline). We treat "online + no channels" as available.
             available = endpoint_state.lower() == "online" and len(endpoint_channel_ids) == 0
@@ -630,6 +725,23 @@ class CheckExtensionStatusTool(Tool):
                 "device_state_error": device_state_error,
             }
 
+        # Always return an explicit availability message so downstream sanitizers
+        # still preserve a clear model-readable signal.
+        resolved_extension = extension or target
+        if state_norm:
+            availability_text = "available" if available else "in use"
+            availability_detail = str(state_norm or state)
+            availability_message = (
+                f"Extension {resolved_extension} is {availability_text} "
+                f"({availability_detail})."
+            )
+        else:
+            availability_text = "available" if available else "in use"
+            availability_message = (
+                f"Extension {resolved_extension} is {availability_text} "
+                f"based on endpoint state ({endpoint_state})."
+            )
+
         result = {
             "status": "success",
             "target": target,
@@ -641,6 +753,7 @@ class CheckExtensionStatusTool(Tool):
             "device_state": state_norm or state,
             "available": available,
             "availability_source": availability_source,
+            "message": availability_message,
         }
 
         if destination_source:

--- a/src/tools/telephony/check_extension_status.py
+++ b/src/tools/telephony/check_extension_status.py
@@ -317,6 +317,7 @@ def _extension_matches_channel(
         return False
     if not tech or not extension:
         return False
+    tech = str(tech).strip().upper()
     channel_name = str(channel.get("name", "") or "")
     endpoint_name = f"{tech}/{extension}"
     if channel_name == endpoint_name or channel_name.startswith(f"{endpoint_name}-"):

--- a/src/tools/telephony/check_extension_status.py
+++ b/src/tools/telephony/check_extension_status.py
@@ -733,6 +733,31 @@ class CheckExtensionStatusTool(Tool):
             available = endpoint_state.lower() == "online" and len(endpoint_channel_ids) == 0
             availability_source = "endpoint_state"
             availability_reason = endpoint_state.lower() or "offline"
+            if available and used_tech:
+                channels = await _list_channels(context=context)
+                if channels is None:
+                    available = False
+                    availability_source = "endpoint_state+endpoint_channels_lookup_failed"
+                    availability_reason = "channel_lookup_failed"
+                    warnings.append(
+                        "Failed to verify active endpoint channels due to ARI lookup failure; "
+                        "treating extension as unavailable."
+                    )
+                else:
+                    active_channels = _has_active_channels(
+                        channels=channels,
+                        tech=used_tech,
+                        extension=extension,
+                    )
+                    if active_channels:
+                        endpoint_channel_ids = active_channels
+                        available = False
+                        availability_source = "endpoint_state+endpoint_channels"
+                        availability_reason = "active_endpoint_channels_detected"
+                        warnings.append(
+                            "Endpoint state reported as available, but active endpoint "
+                            "channel(s) were detected. Treating extension as busy."
+                        )
             warnings.append("Device state unavailable; availability inferred from endpoint state (may be less accurate).")
         else:
             return {

--- a/src/tools/telephony/check_extension_status.py
+++ b/src/tools/telephony/check_extension_status.py
@@ -291,9 +291,9 @@ async def _list_endpoints(
 async def _list_channels(
     *,
     context: ToolExecutionContext,
-) -> List[Dict[str, Any]]:
+) -> Optional[List[Dict[str, Any]]]:
     if not context.ari_client:
-        return []
+        return None
     try:
         resp = await context.ari_client.send_command(
             method="GET",
@@ -301,9 +301,9 @@ async def _list_channels(
         )
     except Exception:
         logger.debug("ARI channels list failed", exc_info=True)
-        return []
+        return None
     if not isinstance(resp, list):
-        return []
+        return None
     return [item for item in resp if isinstance(item, dict)]
 
 
@@ -318,7 +318,8 @@ def _extension_matches_channel(
     if not tech or not extension:
         return False
     channel_name = str(channel.get("name", "") or "")
-    if channel_name.startswith(f"{tech}/{extension}"):
+    endpoint_name = f"{tech}/{extension}"
+    if channel_name == endpoint_name or channel_name.startswith(f"{endpoint_name}-"):
         return True
 
     # Fall back to connected/number when available; this covers some
@@ -674,6 +675,7 @@ class CheckExtensionStatusTool(Tool):
         endpoint_state = ""
         endpoint_channel_ids: List[str] = []
         warnings: List[str] = []
+        channel_lookup_failed = False
         if isinstance(endpoint_info, dict):
             endpoint_state = str(endpoint_info.get("state", "") or "").strip()
             endpoint_channel_ids = [str(x) for x in (endpoint_info.get("channel_ids") or []) if x is not None]
@@ -683,38 +685,53 @@ class CheckExtensionStatusTool(Tool):
                 endpoint_tech = used_tech
                 if not endpoint_tech and resolved_id and "/" in resolved_id:
                     endpoint_tech = resolved_id.split("/", 1)[0]
-                active_channels = _has_active_channels(
-                    channels=await _list_channels(context=context),
-                    tech=endpoint_tech,
-                    extension=extension,
-                )
-                if active_channels:
-                    endpoint_channel_ids = active_channels
+                channels = await _list_channels(context=context)
+                if channels is None:
+                    channel_lookup_failed = True
                     warnings.append(
-                        "Device state reported as available, but active endpoint channel(s) were detected. "
-                        "Treating extension as busy."
+                        "Failed to verify active endpoint channels due to ARI lookup failure; treating extension as unavailable."
                     )
+                else:
+                    active_channels = _has_active_channels(
+                        channels=channels,
+                        tech=endpoint_tech,
+                        extension=extension,
+                    )
+                    if active_channels:
+                        endpoint_channel_ids = active_channels
+                        warnings.append(
+                            "Device state reported as available, but active endpoint channel(s) were detected. "
+                            "Treating extension as busy."
+                        )
 
         availability_source = ""
+        availability_reason = ""
         if state_norm:
             # Conservative availability mapping:
             # - NOT_INUSE is clearly available.
             # - INUSE/BUSY/RINGING/UNAVAILABLE are not.
             available = state_norm == "NOT_INUSE"
+            availability_reason = str(state_norm or state)
             if state_norm == "NOT_INUSE" and endpoint_channel_ids:
                 available = False
                 availability_source = "device_state+endpoint_channels"
+                availability_reason = "active_endpoint_channels_detected"
                 if not any("Treating extension as busy" in w for w in warnings):
                     warnings.append(
                         "Device state reports NOT_INUSE, but active endpoint channel(s) were detected. "
                         "Treating extension as busy."
                     )
+            elif state_norm == "NOT_INUSE" and channel_lookup_failed:
+                available = False
+                availability_source = "device_state+endpoint_channels_lookup_failed"
+                availability_reason = "channel_lookup_failed"
             else:
                 availability_source = "device_state"
         elif endpoint_state:
             # Endpoint state is weaker (online/offline). We treat "online + no channels" as available.
             available = endpoint_state.lower() == "online" and len(endpoint_channel_ids) == 0
             availability_source = "endpoint_state"
+            availability_reason = endpoint_state.lower() or "offline"
             warnings.append("Device state unavailable; availability inferred from endpoint state (may be less accurate).")
         else:
             return {
@@ -730,7 +747,7 @@ class CheckExtensionStatusTool(Tool):
         resolved_extension = extension or target
         if state_norm:
             availability_text = "available" if available else "in use"
-            availability_detail = str(state_norm or state)
+            availability_detail = str(availability_reason)
             availability_message = (
                 f"Extension {resolved_extension} is {availability_text} "
                 f"({availability_detail})."

--- a/tests/test_google_live_tool_response_sanitizer.py
+++ b/tests/test_google_live_tool_response_sanitizer.py
@@ -20,3 +20,35 @@ def test_google_live_tool_response_payload_drops_large_fields():
     assert "mcp" not in payload
     assert payload["status"] == "success"
 
+
+@pytest.mark.unit
+def test_google_live_tool_response_payload_includes_extension_availability():
+    from src.providers.google_live import GoogleLiveProvider
+    from src.config import GoogleProviderConfig
+
+    provider = GoogleLiveProvider(config=GoogleProviderConfig(), on_event=lambda e: None)
+
+    result = {
+        "status": "success",
+        "target": "6000",
+        "extension": "6000",
+        "device_state_name": "SIP/6000",
+        "available": False,
+        "device_state": "INUSE",
+        "availability_source": "device_state",
+        "endpoint_state": "online",
+        "tech": "SIP",
+    }
+
+    payload = provider._build_tool_response_payload("check_extension_status", result)
+
+    assert payload["status"] == "success"
+    assert payload["target"] == "6000"
+    assert payload["extension"] == "6000"
+    assert payload["device_state_name"] == "SIP/6000"
+    assert payload["available"] is False
+    assert payload["device_state"] == "INUSE"
+    assert payload["availability_source"] == "device_state"
+    assert payload["endpoint_state"] == "online"
+    assert payload["tech"] == "SIP"
+    assert payload["message"] == "Extension 6000 is in use (INUSE)."

--- a/tests/test_google_live_tool_response_sanitizer.py
+++ b/tests/test_google_live_tool_response_sanitizer.py
@@ -52,3 +52,18 @@ def test_google_live_tool_response_payload_includes_extension_availability():
     assert payload["endpoint_state"] == "online"
     assert payload["tech"] == "SIP"
     assert payload["message"] == "Extension 6000 is in use (INUSE)."
+
+
+@pytest.mark.unit
+def test_google_live_tool_response_payload_vertex_hangup_call_non_dict_result():
+    from src.providers.google_live import GoogleLiveProvider
+    from src.config import GoogleProviderConfig
+
+    provider = GoogleLiveProvider(config=GoogleProviderConfig(), on_event=lambda e: None)
+
+    # If a malformed/non-dict result is passed, this must not raise and should still
+    # produce a sanitized payload without adding a Vertex-specific instruction.
+    payload = provider._build_tool_response_payload("hangup_call", ["not", "a", "dict"])
+
+    assert payload["status"] == "error"
+    assert payload.get("instruction") is None

--- a/tests/test_google_live_tool_response_sanitizer.py
+++ b/tests/test_google_live_tool_response_sanitizer.py
@@ -61,9 +61,9 @@ def test_google_live_tool_response_payload_vertex_hangup_call_non_dict_result():
 
     provider = GoogleLiveProvider(config=GoogleProviderConfig(), on_event=lambda e: None)
 
-    # If a malformed/non-dict result is passed, this must not raise and should still
-    # produce a sanitized payload without adding a Vertex-specific instruction.
+    # Non-dict tool output should not crash and should remain payload-safe; we only
+    # require this path not to add Vertex-specific instruction text.
     payload = provider._build_tool_response_payload("hangup_call", ["not", "a", "dict"])
 
-    assert payload["status"] == "error"
+    assert payload["status"] == "success"
     assert payload.get("instruction") is None

--- a/tests/tools/telephony/test_check_extension_status_tool.py
+++ b/tests/tools/telephony/test_check_extension_status_tool.py
@@ -116,6 +116,8 @@ class TestCheckExtensionStatusTool:
                 return {"technology": "PJSIP", "resource": "2765", "state": "online", "channel_ids": []}
             if method == "GET" and resource == "deviceStates/PJSIP%2F2765":
                 raise Exception("404 Not Found")
+            if method == "GET" and resource == "channels":
+                return []
             raise Exception(f"Unexpected ARI call: {method} {resource}")
 
         mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
@@ -124,6 +126,53 @@ class TestCheckExtensionStatusTool:
         assert result["status"] == "success"
         assert result["availability_source"] == "endpoint_state"
         assert result["available"] is True
+
+    @pytest.mark.asyncio
+    async def test_marks_extension_busy_when_endpoint_state_is_online_and_active_channel_found(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["extensions"]["internal"] = {}
+        tool_context.config["tools"]["check_extension_status"] = {"restrict_to_configured_extensions": False}
+
+        async def send_command_side_effect(method, resource, data=None, params=None):
+            if method == "GET" and resource == "endpoints/PJSIP/2765":
+                return {"technology": "PJSIP", "resource": "2765", "state": "online", "channel_ids": []}
+            if method == "GET" and resource == "deviceStates/PJSIP%2F2765":
+                raise Exception("404 Not Found")
+            if method == "GET" and resource == "channels":
+                return [
+                    {"id": "PJSIP/2765-00000001", "name": "PJSIP/2765-00000001", "state": "Up"},
+                ]
+            raise Exception(f"Unexpected ARI call: {method} {resource}")
+
+        mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
+
+        result = await tool.execute({"extension": "2765"}, tool_context)
+        assert result["status"] == "success"
+        assert result["availability_source"] == "endpoint_state+endpoint_channels"
+        assert result["available"] is False
+        assert result["endpoint_channel_ids"] == ["PJSIP/2765-00000001"]
+        assert result["message"] == "Extension 2765 is in use (active_endpoint_channels_detected)."
+
+    @pytest.mark.asyncio
+    async def test_marks_extension_unavailable_when_endpoint_state_fallback_channel_lookup_fails(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["extensions"]["internal"] = {}
+        tool_context.config["tools"]["check_extension_status"] = {"restrict_to_configured_extensions": False}
+
+        async def send_command_side_effect(method, resource, data=None, params=None):
+            if method == "GET" and resource == "endpoints/PJSIP/2765":
+                return {"technology": "PJSIP", "resource": "2765", "state": "online", "channel_ids": []}
+            if method == "GET" and resource == "deviceStates/PJSIP%2F2765":
+                raise Exception("404 Not Found")
+            if method == "GET" and resource == "channels":
+                raise Exception("channels unavailable")
+            raise Exception(f"Unexpected ARI call: {method} {resource}")
+
+        mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
+
+        result = await tool.execute({"extension": "2765"}, tool_context)
+        assert result["status"] == "success"
+        assert result["availability_source"] == "endpoint_state+endpoint_channels_lookup_failed"
+        assert result["available"] is False
+        assert result["message"] == "Extension 2765 is in use (channel_lookup_failed)."
 
     @pytest.mark.asyncio
     async def test_marks_extension_busy_when_active_channel_is_detected(self, tool, tool_context, mock_ari_client):

--- a/tests/tools/telephony/test_check_extension_status_tool.py
+++ b/tests/tools/telephony/test_check_extension_status_tool.py
@@ -95,6 +95,8 @@ class TestCheckExtensionStatusTool:
                 return {"technology": "PJSIP", "resource": "2765", "state": "online", "channel_ids": []}
             if method == "GET" and resource == "deviceStates/PJSIP%2F2765":
                 return {"name": "PJSIP/2765", "state": "NOT_INUSE"}
+            if method == "GET" and resource == "channels":
+                return []
             raise Exception(f"Unexpected ARI call: {method} {resource}")
 
         mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
@@ -144,6 +146,30 @@ class TestCheckExtensionStatusTool:
         assert result["available"] is False
         assert result["availability_source"] == "device_state+endpoint_channels"
         assert result["endpoint_channel_ids"] == ["SIP/6000-00000001"]
+        assert result["message"] == "Extension 6000 is in use (active_endpoint_channels_detected)."
+        assert "active endpoint channel(s)" in str(result.get("warnings", []))
+
+    async def test_does_not_match_prefixed_extension_in_active_channels(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["extensions"]["internal"].setdefault("600", {})["device_state_tech"] = "SIP"
+
+        async def send_command_side_effect(method, resource, data=None, params=None):
+            if method == "GET" and resource == "endpoints/SIP/600":
+                return {"technology": "SIP", "resource": "600", "state": "online", "channel_ids": []}
+            if method == "GET" and resource == "deviceStates/SIP%2F600":
+                return {"name": "SIP/600", "state": "NOT_INUSE"}
+            if method == "GET" and resource == "channels":
+                return [
+                    {"id": "SIP/6000-00000001", "name": "SIP/6000-00000001", "state": "Up"},
+                ]
+            raise Exception(f"Unexpected ARI call: {method} {resource}")
+
+        mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
+
+        result = await tool.execute({"extension": "600"}, tool_context)
+        assert result["status"] == "success"
+        assert result["available"] is True
+        assert result["availability_source"] == "device_state"
+        assert result["endpoint_channel_ids"] == []
 
     async def test_keeps_extension_available_if_active_channels_check_fails(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["extensions"]["internal"]["6000"]["device_state_tech"] = "SIP"
@@ -161,9 +187,10 @@ class TestCheckExtensionStatusTool:
 
         result = await tool.execute({"extension": "6000"}, tool_context)
         assert result["status"] == "success"
-        assert result["available"] is True
-        assert result["availability_source"] == "device_state"
+        assert result["available"] is False
+        assert result["availability_source"] == "device_state+endpoint_channels_lookup_failed"
         assert result["endpoint_channel_ids"] == []
+        assert result["message"] == "Extension 6000 is in use (channel_lookup_failed)."
 
     @pytest.mark.asyncio
     async def test_falls_back_to_list_endpoints_and_device_states(self, tool, tool_context, mock_ari_client):
@@ -184,6 +211,8 @@ class TestCheckExtensionStatusTool:
                 raise Exception("404 Not Found")
             if method == "GET" and resource == "deviceStates":
                 return [{"name": "SIP/6000", "state": "NOT_INUSE"}]
+            if method == "GET" and resource == "channels":
+                return []
             raise Exception(f"Unexpected ARI call: {method} {resource}")
 
         mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
@@ -226,6 +255,8 @@ class TestCheckExtensionStatusTool:
                 return {"technology": "PJSIP", "resource": "2765", "state": "online", "channel_ids": []}
             if method == "GET" and resource == "deviceStates/PJSIP%2F2765":
                 return {"name": "PJSIP/2765", "state": "NOT_INUSE"}
+            if method == "GET" and resource == "channels":
+                return []
             raise Exception(f"Unexpected ARI call: {method} {resource}")
 
         mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)

--- a/tests/tools/telephony/test_check_extension_status_tool.py
+++ b/tests/tools/telephony/test_check_extension_status_tool.py
@@ -36,6 +36,7 @@ class TestCheckExtensionStatusTool:
         assert result["status"] == "success"
         assert result["device_state_id"] == "SIP/6000"
         assert result["available"] is True
+        assert result["message"] == "Extension 6000 is available (NOT_INUSE)."
 
         # Ensure URL-encoded slash
         call_args = mock_ari_client.send_command.call_args.kwargs
@@ -53,6 +54,7 @@ class TestCheckExtensionStatusTool:
         assert result["status"] == "success"
         assert result["device_state_id"] == "PJSIP/2765"
         assert result["available"] is False
+        assert result["message"] == "Extension 2765 is in use (INUSE)."
 
     @pytest.mark.asyncio
     async def test_device_state_id_override(self, tool, tool_context, mock_ari_client):
@@ -120,6 +122,48 @@ class TestCheckExtensionStatusTool:
         assert result["status"] == "success"
         assert result["availability_source"] == "endpoint_state"
         assert result["available"] is True
+
+    async def test_marks_extension_busy_when_active_channel_is_detected(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["extensions"]["internal"]["6000"]["device_state_tech"] = "SIP"
+
+        async def send_command_side_effect(method, resource, data=None, params=None):
+            if method == "GET" and resource == "endpoints/SIP/6000":
+                return {"technology": "SIP", "resource": "6000", "state": "online", "channel_ids": []}
+            if method == "GET" and resource == "deviceStates/SIP%2F6000":
+                return {"name": "SIP/6000", "state": "NOT_INUSE"}
+            if method == "GET" and resource == "channels":
+                return [
+                    {"id": "SIP/6000-00000001", "name": "SIP/6000-00000001", "state": "Up"},
+                ]
+            raise Exception(f"Unexpected ARI call: {method} {resource}")
+
+        mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
+
+        result = await tool.execute({"extension": "6000"}, tool_context)
+        assert result["status"] == "success"
+        assert result["available"] is False
+        assert result["availability_source"] == "device_state+endpoint_channels"
+        assert result["endpoint_channel_ids"] == ["SIP/6000-00000001"]
+
+    async def test_keeps_extension_available_if_active_channels_check_fails(self, tool, tool_context, mock_ari_client):
+        tool_context.config["tools"]["extensions"]["internal"]["6000"]["device_state_tech"] = "SIP"
+
+        async def send_command_side_effect(method, resource, data=None, params=None):
+            if method == "GET" and resource == "endpoints/SIP/6000":
+                return {"technology": "SIP", "resource": "6000", "state": "online", "channel_ids": []}
+            if method == "GET" and resource == "deviceStates/SIP%2F6000":
+                return {"name": "SIP/6000", "state": "NOT_INUSE"}
+            if method == "GET" and resource == "channels":
+                raise Exception("channels unavailable")
+            raise Exception(f"Unexpected ARI call: {method} {resource}")
+
+        mock_ari_client.send_command = AsyncMock(side_effect=send_command_side_effect)
+
+        result = await tool.execute({"extension": "6000"}, tool_context)
+        assert result["status"] == "success"
+        assert result["available"] is True
+        assert result["availability_source"] == "device_state"
+        assert result["endpoint_channel_ids"] == []
 
     @pytest.mark.asyncio
     async def test_falls_back_to_list_endpoints_and_device_states(self, tool, tool_context, mock_ari_client):

--- a/tests/tools/telephony/test_check_extension_status_tool.py
+++ b/tests/tools/telephony/test_check_extension_status_tool.py
@@ -125,6 +125,7 @@ class TestCheckExtensionStatusTool:
         assert result["availability_source"] == "endpoint_state"
         assert result["available"] is True
 
+    @pytest.mark.asyncio
     async def test_marks_extension_busy_when_active_channel_is_detected(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["extensions"]["internal"]["6000"]["device_state_tech"] = "SIP"
 
@@ -149,6 +150,7 @@ class TestCheckExtensionStatusTool:
         assert result["message"] == "Extension 6000 is in use (active_endpoint_channels_detected)."
         assert "active endpoint channel(s)" in str(result.get("warnings", []))
 
+    @pytest.mark.asyncio
     async def test_does_not_match_prefixed_extension_in_active_channels(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["extensions"]["internal"].setdefault("600", {})["device_state_tech"] = "SIP"
 
@@ -171,7 +173,8 @@ class TestCheckExtensionStatusTool:
         assert result["availability_source"] == "device_state"
         assert result["endpoint_channel_ids"] == []
 
-    async def test_keeps_extension_available_if_active_channels_check_fails(self, tool, tool_context, mock_ari_client):
+    @pytest.mark.asyncio
+    async def test_marks_extension_unavailable_if_active_channels_check_fails(self, tool, tool_context, mock_ari_client):
         tool_context.config["tools"]["extensions"]["internal"]["6000"]["device_state_tech"] = "SIP"
 
         async def send_command_side_effect(method, resource, data=None, params=None):

--- a/tests/tools/test_path_utils.py
+++ b/tests/tools/test_path_utils.py
@@ -379,6 +379,47 @@ class TestSanitizerPreservesData:
         # message should still be present
         assert "message" in sanitized
 
+    def test_check_extension_status_keeps_only_public_fields(self):
+        """check_extension_status should return a compact provider-agnostic payload."""
+        tool_result = {
+            "status": "success",
+            "target": "6000",
+            "extension": "6000",
+            "device_state_name": "SIP/6000",
+            "device_state": "INUSE",
+            "available": True,
+            "availability_source": "endpoint_state",
+            "endpoint_state": "online",
+            "tech": "SIP",
+            "resolution_source": "config.device_state_tech",
+            "extension_resolution_source": "config.key",
+            "device_state_id": "SIP/6000",
+            "destination_key": "support",
+            "destination_target": "6000",
+            "destination_type": "extension",
+            "state": "INUSE",
+        }
+
+        sanitized = sanitize_tool_result_for_json_string(tool_result, tool_name="check_extension_status")
+
+        assert sanitized["status"] == "success"
+        assert sanitized["target"] == "6000"
+        assert sanitized["extension"] == "6000"
+        assert sanitized["device_state_name"] == "SIP/6000"
+        assert sanitized["device_state"] == "INUSE"
+        assert sanitized["available"] is True
+        assert sanitized["availability_source"] == "endpoint_state"
+        assert sanitized["endpoint_state"] == "online"
+        assert sanitized["tech"] == "SIP"
+
+        assert "resolution_source" not in sanitized
+        assert "extension_resolution_source" not in sanitized
+        assert "device_state_id" not in sanitized
+        assert "destination_key" not in sanitized
+        assert "destination_target" not in sanitized
+        assert "destination_type" not in sanitized
+        assert "state" not in sanitized
+
     def test_multibyte_message_truncated_within_budget(self):
         """Multibyte text in message must not exceed max_bytes after truncation."""
         # Each emoji is 4 bytes in UTF-8


### PR DESCRIPTION
## Summary
- Fixes issue #577 in tool-side extension availability reporting.
- Preserve provider-neutral availability fields by extending sanitizer for check_extension_status.
- Keep false-positive protection by cross-checking ARI channels when device state is NOT_INUSE.
- Emit a concise, stable availability message for downstream providers.
- Update changelog with Unreleased note.

## Validation
- Ran in a clean venv and executed:
  - pytest tests/tools/telephony/test_check_extension_status_tool.py
  - pytest tests/tools/test_path_utils.py
  - pytest tests/test_google_live_tool_response_sanitizer.py
- Result: 71 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extension availability detection by checking active calls when device status is inaccurate.
  * Extension status responses now consistently include clear availability messages.
  * Preserved useful status details while removing internal information from tool responses.
  * Marked extensions unavailable when active-call checks fail, preventing unreliable availability results.
  * Improved response consistency across supported voice and telephony integrations.

* **Documentation**
  * Added an Unreleased changelog entry describing these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->