### PR TITLE
Fix authenticated Local AI provider connection tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Local AI provider connection tests honor authenticated and modular deployments:** the Admin UI now performs the configured WebSocket authentication handshake before requesting status and evaluates only each provider's declared STT, LLM, or TTS capabilities, so intentionally unloaded components no longer make an otherwise healthy modular provider appear unavailable.
 - **`check_extension_status` now preserves full provider-compatible availability data** ([#577](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/577)): the tool now returns a stable `message` and retains key availability fields (`extension`, `device_state_name`, `device_state`, `available`, `availability_source`, `endpoint_state`, `tech`) through JSON sanitization for all tool adapters, while still filtering internal debug fields. It also cross-checks active ARI channels when device state reports `NOT_INUSE` but endpoint/channel activity is present, preventing false "available" signals during live transfers.
 
 ## [7.5.4] - 2026-07-30

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -1688,6 +1688,12 @@ async def test_provider_connection(request: ProviderTestRequest):
             # Handle env var format
             if '${' in ws_url:
                 ws_url = 'ws://127.0.0.1:8765'  # Default fallback
+
+            auth_token = str(
+                provider_config.get("auth_token")
+                or get_env_key("LOCAL_WS_AUTH_TOKEN")
+                or ""
+            ).strip()
             
             try:
                 def _fallback_ws_url(url: str) -> str:
@@ -1704,6 +1710,16 @@ async def test_provider_connection(request: ProviderTestRequest):
 
                 async def _try_connect(url: str):
                     async with websockets.connect(url, open_timeout=5.0) as ws:
+                        if auth_token:
+                            await ws.send(json.dumps({"type": "auth", "auth_token": auth_token}))
+                            response = await asyncio.wait_for(ws.recv(), timeout=5.0)
+                            auth_response = json.loads(response)
+                            if (
+                                auth_response.get("type") != "auth_response"
+                                or auth_response.get("status") != "ok"
+                            ):
+                                raise RuntimeError("Local AI Server authentication failed")
+
                         # Send status request to check models
                         await ws.send(json.dumps({"type": "status"}))
                         response = await asyncio.wait_for(ws.recv(), timeout=5.0)
@@ -1736,9 +1752,28 @@ async def test_provider_connection(request: ProviderTestRequest):
                     status_parts.append(f"LLM: {llm_model} ✓" if llm_loaded else "LLM: not loaded")
                     status_parts.append(f"TTS: {tts_backend} ✓" if tts_loaded else "TTS: not loaded")
 
-                    all_loaded = stt_loaded and llm_loaded and tts_loaded
+                    declared_capabilities = provider_config.get("capabilities") or []
+                    if isinstance(declared_capabilities, str):
+                        declared_capabilities = [declared_capabilities]
+                    loaded_by_capability = {
+                        "stt": stt_loaded,
+                        "llm": llm_loaded,
+                        "tts": tts_loaded,
+                    }
+                    required_capabilities = {
+                        str(capability).strip().lower()
+                        for capability in declared_capabilities
+                        if str(capability).strip().lower() in loaded_by_capability
+                    }
+                    if not required_capabilities:
+                        required_capabilities = set(loaded_by_capability)
+
+                    provider_ready = all(
+                        loaded_by_capability[capability]
+                        for capability in required_capabilities
+                    )
                     return {
-                        "success": all_loaded,
+                        "success": provider_ready,
                         "message": f"Local AI Server connected ({effective_url}). {' | '.join(status_parts)}",
                     }
                 return {"success": False, "message": "Local AI Server responded but status invalid"}

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -1603,6 +1603,9 @@ class ProviderTestRequest(BaseModel):
     name: str
     config: Dict[str, Any]
 
+class _LocalAIAuthenticationError(RuntimeError):
+    pass
+
 class SmtpTestRequest(BaseModel):
     to_email: str
     from_email: Optional[str] = None
@@ -1718,7 +1721,9 @@ async def test_provider_connection(request: ProviderTestRequest):
                                 auth_response.get("type") != "auth_response"
                                 or auth_response.get("status") != "ok"
                             ):
-                                raise RuntimeError("Local AI Server authentication failed")
+                                raise _LocalAIAuthenticationError(
+                                    "Local AI Server authentication failed"
+                                )
 
                         # Send status request to check models
                         await ws.send(json.dumps({"type": "status"}))
@@ -1729,6 +1734,8 @@ async def test_provider_connection(request: ProviderTestRequest):
                 try:
                     data = await _try_connect(ws_url)
                     effective_url = ws_url
+                except _LocalAIAuthenticationError:
+                    raise
                 except Exception as e:
                     alt = _fallback_ws_url(ws_url)
                     if alt != ws_url:

--- a/admin_ui/backend/tests/test_provider_connection_local.py
+++ b/admin_ui/backend/tests/test_provider_connection_local.py
@@ -124,7 +124,9 @@ async def test_local_provider_requires_only_declared_capabilities(monkeypatch, t
 
 
 @pytest.mark.asyncio
-async def test_local_provider_stops_after_failed_auth(monkeypatch, tmp_path):
+async def test_local_provider_stops_after_failed_auth_without_host_fallback(
+    monkeypatch, tmp_path
+):
     sent_messages = []
     monkeypatch.setattr(config.settings, "ENV_PATH", str(tmp_path / ".env"))
     monkeypatch.setenv("LOCAL_WS_AUTH_TOKEN", "test-secret")
@@ -141,7 +143,7 @@ async def test_local_provider_stops_after_failed_auth(monkeypatch, tmp_path):
                 "type": "local",
                 "capabilities": ["stt"],
                 "auth_token": "${LOCAL_WS_AUTH_TOKEN:-}",
-                "ws_url": "ws://127.0.0.1:8765",
+                "ws_url": "ws://local_ai_server:8765",
             },
         )
     )

--- a/admin_ui/backend/tests/test_provider_connection_local.py
+++ b/admin_ui/backend/tests/test_provider_connection_local.py
@@ -1,0 +1,151 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import websockets
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from api import config  # noqa: E402
+
+
+class _FakeLocalAIWebSocket:
+    def __init__(self, sent_messages, status_payload, auth_status="ok"):
+        self._sent_messages = sent_messages
+        self._status_payload = status_payload
+        self._auth_status = auth_status
+        self._last_message_type = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def send(self, raw):
+        message = json.loads(raw)
+        self._sent_messages.append(message)
+        self._last_message_type = message.get("type")
+
+    async def recv(self):
+        if self._last_message_type == "auth":
+            return json.dumps({"type": "auth_response", "status": self._auth_status})
+        return json.dumps(self._status_payload)
+
+
+def _status_payload(*, stt_loaded=True, llm_loaded=False, tts_loaded=True):
+    return {
+        "type": "status_response",
+        "status": "ok",
+        "stt_backend": "vosk",
+        "tts_backend": "kokoro",
+        "models": {
+            "stt": {"loaded": stt_loaded},
+            "llm": {"loaded": llm_loaded, "path": None},
+            "tts": {"loaded": tts_loaded},
+        },
+    }
+
+
+def _connect_factory(sent_messages, status_payload, auth_status="ok"):
+    def _connect(*_args, **_kwargs):
+        return _FakeLocalAIWebSocket(sent_messages, status_payload, auth_status)
+
+    return _connect
+
+
+@pytest.mark.asyncio
+async def test_local_provider_authenticates_before_status(monkeypatch, tmp_path):
+    sent_messages = []
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(tmp_path / ".env"))
+    monkeypatch.setenv("LOCAL_WS_AUTH_TOKEN", "test-secret")
+    monkeypatch.setattr(
+        websockets,
+        "connect",
+        _connect_factory(sent_messages, _status_payload()),
+    )
+
+    result = await config.test_provider_connection(
+        config.ProviderTestRequest(
+            name="local_stt",
+            config={
+                "type": "local",
+                "capabilities": ["stt"],
+                "auth_token": "${LOCAL_WS_AUTH_TOKEN:-}",
+                "ws_url": "ws://127.0.0.1:8765",
+            },
+        )
+    )
+
+    assert result["success"] is True
+    assert sent_messages == [
+        {"type": "auth", "auth_token": "test-secret"},
+        {"type": "status"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_provider_requires_only_declared_capabilities(monkeypatch, tmp_path):
+    sent_messages = []
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(tmp_path / ".env"))
+    monkeypatch.delenv("LOCAL_WS_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        websockets,
+        "connect",
+        _connect_factory(sent_messages, _status_payload()),
+    )
+
+    modular_result = await config.test_provider_connection(
+        config.ProviderTestRequest(
+            name="local_tts",
+            config={
+                "type": "local",
+                "capabilities": ["tts"],
+                "ws_url": "ws://127.0.0.1:8765",
+            },
+        )
+    )
+    full_result = await config.test_provider_connection(
+        config.ProviderTestRequest(
+            name="local",
+            config={
+                "type": "full",
+                "capabilities": ["stt", "llm", "tts"],
+                "ws_url": "ws://127.0.0.1:8765",
+            },
+        )
+    )
+
+    assert modular_result["success"] is True
+    assert full_result["success"] is False
+    assert sent_messages == [{"type": "status"}, {"type": "status"}]
+
+
+@pytest.mark.asyncio
+async def test_local_provider_stops_after_failed_auth(monkeypatch, tmp_path):
+    sent_messages = []
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(tmp_path / ".env"))
+    monkeypatch.setenv("LOCAL_WS_AUTH_TOKEN", "test-secret")
+    monkeypatch.setattr(
+        websockets,
+        "connect",
+        _connect_factory(sent_messages, _status_payload(), auth_status="error"),
+    )
+
+    result = await config.test_provider_connection(
+        config.ProviderTestRequest(
+            name="local_stt",
+            config={
+                "type": "local",
+                "capabilities": ["stt"],
+                "auth_token": "${LOCAL_WS_AUTH_TOKEN:-}",
+                "ws_url": "ws://127.0.0.1:8765",
+            },
+        )
+    )
+
+    assert result["success"] is False
+    assert "test-secret" not in result["message"]
+    assert sent_messages == [{"type": "auth", "auth_token": "test-secret"}]


### PR DESCRIPTION
## Summary

- authenticate Local AI WebSocket provider tests before requesting server status
- evaluate modular Local AI providers against only their declared capabilities
- add regression coverage for authenticated, minimal-mode, and failed-auth cases

The Providers page previously sent a `status` message immediately. A Local AI Server configured with `LOCAL_WS_AUTH_TOKEN` rejected that request before returning status. Even after authentication, an STT-only or TTS-only provider could be reported unhealthy because the test required STT, LLM, and TTS to all be loaded.

## Related Issue(s)

- None

## Implementation Notes

- Key files touched:
  - `admin_ui/backend/api/config.py`
  - `admin_ui/backend/tests/test_provider_connection_local.py`
  - `CHANGELOG.md`
- High-level design decisions:
  - Resolve the provider's configured auth token using the endpoint's existing environment substitution and `.env` fallback.
  - Complete the established `auth` / `auth_response` exchange before sending `status`.
  - Preserve the existing full-provider behavior when capabilities are absent, while modular providers require only their declared STT, LLM, or TTS component.

Codex traced the Admin UI test endpoint against the Local AI WebSocket protocol, implemented the smallest backend change, and added boundary-level WebSocket regression tests.

## Testing

- [x] Unit tests: `.venv/bin/python -m pytest admin_ui/backend/tests/test_provider_connection_local.py -q` (3 passed)
- [x] Admin UI backend suite: `.venv/bin/python -m pytest admin_ui/backend/tests -q` (546 passed)
- [x] Dependency check: `.venv/bin/python -m pip check`
- [ ] Integration / manual tests (no modified runtime was deployed)
- [ ] `agent check`
- [ ] `agent rca`
- [ ] `./scripts/rca_collect.sh` (not applicable)

This does not touch the telephony call path.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [ ] Review fixes were pushed as a cohesive batch
- [ ] Final head is frozen, the PR is ready, and the final CI gate has passed
- [ ] `@coderabbitai full review` completed on the frozen head
- [ ] Optional `codex-review` label/manual workflow completed on the frozen head, if requested
- [ ] All actionable conversations are resolved

## Documentation

- [x] `CHANGELOG.md`

No provider setup documentation changed because the authentication and capability schema are unchanged; this corrects the existing connection-test behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Local AI provider connection tests by authenticating WebSocket status requests when credentials are configured.
  * Provider readiness checks now validate only the declared speech-to-text, language, and text-to-speech capabilities.
  * Failed authentication responses are correctly rejected without unnecessary connection retries, and sensitive credentials are excluded from displayed error details.

* **Documentation**
  * Documented the fix in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->