### PR TITLE
feat: pre-call variables in post-call webhooks (#608) + collapsible sidebar (#596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Collapsible left navigation sidebar** ([#596](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/596)): the Admin UI sidebar can now collapse to an icon-only rail via a toggle in its header, reclaiming horizontal space for configuration pages and long forms — useful on portrait or smaller displays. Collapsed items keep hover tooltips and screen-reader labels, and the collapsed/expanded preference persists across sessions in browser local storage.
 - **Pre-call variables are usable directly in post-call webhook bodies** ([#608](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/608)): each pre-call output variable (e.g. `{customer_name}`) is now exposed as its own placeholder in post-call webhook payload templates, matching how the prompt and in-call tool paths already surface them. Previously only the whole `{pre_call_results_json}` object was available, so individual placeholders rendered as literal text. Built-in payload variables always take precedence — a pre-call variable named like a built-in (e.g. `caller_number`) can never override it.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pre-call variables are usable directly in post-call webhook bodies** ([#608](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/608)): each pre-call output variable (e.g. `{customer_name}`) is now exposed as its own placeholder in post-call webhook payload templates, matching how the prompt and in-call tool paths already surface them. Previously only the whole `{pre_call_results_json}` object was available, so individual placeholders rendered as literal text. Built-in payload variables always take precedence — a pre-call variable named like a built-in (e.g. `caller_number`) can never override it.
+
 ### Fixed
 
 - **`check_extension_status` now preserves full provider-compatible availability data** ([#577](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/577)): the tool now returns a stable `message` and retains key availability fields (`extension`, `device_state_name`, `device_state`, `available`, `availability_source`, `endpoint_state`, `tech`) through JSON sanitization for all tool adapters, while still filtering internal debug fields. It also cross-checks active ARI channels when device state reports `NOT_INUSE` but endpoint/channel activity is present, preventing false "available" signals during live transfers.

--- a/admin_ui/frontend/src/components/layout/Sidebar.test.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.test.tsx
@@ -1,8 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
+
+import { SIDEBAR_COLLAPSED_KEY } from '../../hooks/useSidebarCollapsed';
 
 // Sidebar reads the auth context; stub it so the component renders in isolation.
 vi.mock('../../auth/AuthContext', () => ({
@@ -11,6 +14,17 @@ vi.mock('../../auth/AuthContext', () => ({
 
 import Sidebar from './Sidebar';
 
+const renderSidebar = () =>
+    render(
+        <MemoryRouter>
+            <Sidebar />
+        </MemoryRouter>
+    );
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
 /**
  * Accessibility (WCAG 1.3.1): the primary navigation must be exposed as a
  * navigation landmark so screen-reader users can jump to it. The sidebar was a
@@ -18,11 +32,32 @@ import Sidebar from './Sidebar';
  */
 describe('Sidebar — navigation landmark', () => {
     it('exposes the primary navigation as a named navigation landmark', () => {
-        render(
-            <MemoryRouter>
-                <Sidebar />
-            </MemoryRouter>
-        );
+        renderSidebar();
         expect(screen.getByRole('navigation', { name: /main navigation/i })).toBeInTheDocument();
+    });
+});
+
+describe('Sidebar — collapse (issue #596)', () => {
+    it('hides nav labels when collapsed but keeps items reachable by accessible name', () => {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
+        renderSidebar();
+
+        // Visible label text is gone...
+        expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+        // ...but the link is still named (aria-label) for screen readers.
+        expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
+        // Toggle reflects collapsed state.
+        expect(screen.getByRole('button', { name: /expand sidebar/i })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('toggle button expands the sidebar and reveals labels', async () => {
+        const user = userEvent.setup();
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
+        renderSidebar();
+
+        await user.click(screen.getByRole('button', { name: /expand sidebar/i }));
+
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /collapse sidebar/i })).toHaveAttribute('aria-expanded', 'true');
     });
 });

--- a/admin_ui/frontend/src/components/layout/Sidebar.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.tsx
@@ -28,8 +28,8 @@ import {
     CalendarClock,
     LogOut,
     Lock,
-    PanelLeftClose,
-    PanelLeftOpen
+    ChevronsLeft,
+    ChevronsRight
 } from 'lucide-react';
 import { useAuth } from '../../auth/AuthContext';
 import { KOFI_URL, SPONSORS_URL } from '../../config/donation';
@@ -107,7 +107,7 @@ const CollapseToggle = ({ collapsed, onToggle }: { collapsed: boolean, onToggle:
             title={label}
             className="p-2 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
         >
-            {collapsed ? <PanelLeftOpen className="w-4 h-4" /> : <PanelLeftClose className="w-4 h-4" />}
+            {collapsed ? <ChevronsRight className="w-4 h-4" /> : <ChevronsLeft className="w-4 h-4" />}
         </button>
     );
 };

--- a/admin_ui/frontend/src/components/layout/Sidebar.tsx
+++ b/admin_ui/frontend/src/components/layout/Sidebar.tsx
@@ -27,166 +27,208 @@ import {
     Phone,
     CalendarClock,
     LogOut,
-    Lock
+    Lock,
+    PanelLeftClose,
+    PanelLeftOpen
 } from 'lucide-react';
 import { useAuth } from '../../auth/AuthContext';
 import { KOFI_URL, SPONSORS_URL } from '../../config/donation';
+import { useSidebarCollapsed } from '../../hooks/useSidebarCollapsed';
 import ChangePasswordModal from '../auth/ChangePasswordModal';
 import { useState } from 'react';
 
-const SidebarItem = ({ to, icon: Icon, label, end = false }: { to: string, icon: any, label: string, end?: boolean }) => (
-    <NavLink
-        to={to}
-        end={end}
-        className={({ isActive }) =>
-            `flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors ${isActive
-                ? 'bg-primary/10 text-primary'
-                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-            }`
-        }
-    >
-        <Icon className="w-4 h-4" />
-        {label}
-    </NavLink>
-);
+// Shares the collapsed state with the nested item/group components without
+// threading a prop through every SidebarItem.
+const CollapseContext = React.createContext(false);
 
-const SidebarGroup = ({ title, children }: { title: string, children: React.ReactNode }) => (
-    <div className="mb-6">
-        <h3 className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-            {title}
-        </h3>
-        <div className="space-y-1">
-            {children}
+const itemClasses = (collapsed: boolean, active: boolean) =>
+    `flex items-center ${collapsed ? 'justify-center' : 'gap-3'} px-3 py-2 rounded-md text-sm font-medium transition-colors ${active
+        ? 'bg-primary/10 text-primary'
+        : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+    }`;
+
+const SidebarItem = ({ to, icon: Icon, label, end = false }: { to: string, icon: any, label: string, end?: boolean }) => {
+    const collapsed = React.useContext(CollapseContext);
+    return (
+        <NavLink
+            to={to}
+            end={end}
+            title={collapsed ? label : undefined}
+            aria-label={collapsed ? label : undefined}
+            className={({ isActive }) => itemClasses(collapsed, isActive)}
+        >
+            <Icon className="w-4 h-4 shrink-0" />
+            {!collapsed && <span>{label}</span>}
+        </NavLink>
+    );
+};
+
+const ExternalItem = ({ href, icon: Icon, label, ariaLabel }: { href: string, icon: any, label: string, ariaLabel?: string }) => {
+    const collapsed = React.useContext(CollapseContext);
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={ariaLabel ?? (collapsed ? label : undefined)}
+            title={collapsed ? label : undefined}
+            className={itemClasses(collapsed, false)}
+        >
+            <Icon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            {!collapsed && <span>{label}</span>}
+        </a>
+    );
+};
+
+const SidebarGroup = ({ title, children }: { title: string, children: React.ReactNode }) => {
+    const collapsed = React.useContext(CollapseContext);
+    return (
+        <div className="mb-6">
+            {!collapsed && (
+                <h3 className="px-3 mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    {title}
+                </h3>
+            )}
+            <div className="space-y-1">
+                {children}
+            </div>
         </div>
-    </div>
-);
+    );
+};
+
+const CollapseToggle = ({ collapsed, onToggle }: { collapsed: boolean, onToggle: () => void }) => {
+    const label = collapsed ? 'Expand sidebar' : 'Collapse sidebar';
+    return (
+        <button
+            type="button"
+            onClick={onToggle}
+            aria-label={label}
+            aria-expanded={!collapsed}
+            title={label}
+            className="p-2 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        >
+            {collapsed ? <PanelLeftOpen className="w-4 h-4" /> : <PanelLeftClose className="w-4 h-4" />}
+        </button>
+    );
+};
 
 const Sidebar = () => {
     const { user, logout } = useAuth();
     const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+    const { collapsed, toggle } = useSidebarCollapsed();
 
     return (
-        <aside className="w-64 border-r border-border bg-card/50 backdrop-blur flex flex-col h-full">
-            <div className="p-6 border-b border-border/50">
-                <div className="flex items-center gap-3 font-bold text-xl tracking-tight">
-                    <img
-                        src="/mascot_transparent.png"
-                        alt="AVA Mascot"
-                        className="w-11 h-11 object-contain"
-                    />
-                    <div className="flex flex-col leading-none">
-                        <span>AVA</span>
-                        <span className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider mt-1">AI Voice Agent for Asterisk</span>
+        <CollapseContext.Provider value={collapsed}>
+            <aside className={`${collapsed ? 'w-16' : 'w-64'} border-r border-border bg-card/50 backdrop-blur flex flex-col h-full transition-[width] duration-200`}>
+                <div className={`${collapsed ? 'p-3' : 'p-6'} border-b border-border/50`}>
+                    <div className={`flex items-center ${collapsed ? 'justify-center' : 'gap-3'} font-bold text-xl tracking-tight`}>
+                        <img
+                            src="/mascot_transparent.png"
+                            alt="AVA Mascot"
+                            className="w-11 h-11 object-contain shrink-0"
+                        />
+                        {!collapsed && (
+                            <div className="flex flex-col leading-none flex-1 min-w-0">
+                                <span>AVA</span>
+                                <span className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider mt-1">AI Voice Agent for Asterisk</span>
+                            </div>
+                        )}
+                        {!collapsed && <CollapseToggle collapsed={collapsed} onToggle={toggle} />}
+                    </div>
+                    {collapsed && (
+                        <div className="flex justify-center mt-3">
+                            <CollapseToggle collapsed={collapsed} onToggle={toggle} />
+                        </div>
+                    )}
+                </div>
+
+                <nav aria-label="Main navigation" className="flex-1 overflow-y-auto py-6 px-3">
+                    <SidebarGroup title="Overview">
+                        <SidebarItem to="/" icon={LayoutDashboard} label="Dashboard" end />
+                        <SidebarItem to="/history" icon={Phone} label="Call History" />
+                        <SidebarItem to="/scheduling" icon={CalendarClock} label="Call Scheduling" />
+                        <SidebarItem to="/wizard" icon={Zap} label="Setup Wizard" />
+                    </SidebarGroup>
+
+                    <SidebarGroup title="Core Configuration">
+                        <SidebarItem to="/agents" icon={Users} label="Agents" />
+                        <SidebarItem to="/providers" icon={Server} label="Providers" />
+                        <SidebarItem to="/pipelines" icon={Workflow} label="Pipelines" />
+                        <SidebarItem to="/profiles" icon={Sliders} label="Audio Profiles" />
+                        <SidebarItem to="/tools" icon={Wrench} label="Tools" />
+                        <SidebarItem to="/mcp" icon={Plug} label="MCP" />
+                    </SidebarGroup>
+
+                    <SidebarGroup title="Advanced Settings">
+                        <SidebarItem to="/vad" icon={Activity} label="Voice Activity Detection" />
+                        <SidebarItem to="/streaming" icon={Zap} label="Streaming" />
+                        <SidebarItem to="/llm" icon={Brain} label="LLM Defaults" />
+                        <SidebarItem to="/transport" icon={Radio} label="Audio Transport" />
+                        <SidebarItem to="/barge-in" icon={AlertTriangle} label="Barge-in" />
+                    </SidebarGroup>
+
+                    <SidebarGroup title="System">
+                        <SidebarItem to="/env" icon={Globe} label="Environment" />
+                        <SidebarItem to="/docker" icon={Container} label="Docker Services" />
+                        <SidebarItem to="/asterisk" icon={Phone} label="Asterisk" />
+                        <SidebarItem to="/models" icon={HardDrive} label="Models" />
+                        <SidebarItem to="/updates" icon={ArrowUpCircle} label="Updates" />
+                        <SidebarItem to="/logs" icon={FileText} label="Logs" />
+                        <SidebarItem to="/terminal" icon={Terminal} label="Terminal" />
+                    </SidebarGroup>
+
+                    <SidebarGroup title="Danger Zone">
+                        <SidebarItem to="/yaml" icon={Code} label="Raw YAML" />
+                    </SidebarGroup>
+
+                    <SidebarGroup title="Support">
+                        <SidebarItem to="/help" icon={HelpCircle} label="Help" />
+                        <ExternalItem href="/docs" icon={ExternalLink} label="API Docs" />
+                        <ExternalItem href={KOFI_URL} icon={Coffee} label="Support on Ko-fi" ariaLabel="Support AVA on Ko-fi" />
+                        <ExternalItem href={SPONSORS_URL} icon={Heart} label="Sponsor" ariaLabel="Sponsor AVA on GitHub" />
+                    </SidebarGroup>
+                </nav>
+
+                <div className="p-4 border-t border-border/50">
+                    <div className={`flex items-center mb-3 ${collapsed ? 'justify-center' : 'gap-3 px-2'}`}>
+                        <div className="w-8 h-8 rounded-full bg-accent flex items-center justify-center text-xs font-bold uppercase shrink-0">
+                            {user?.username?.substring(0, 2) || 'AD'}
+                        </div>
+                        {!collapsed && (
+                            <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium truncate">{user?.username || 'Admin'}</p>
+                                <p className="text-xs text-muted-foreground truncate">Administrator</p>
+                            </div>
+                        )}
+                    </div>
+                    <div className={`flex gap-2 ${collapsed ? 'flex-col items-center' : ''}`}>
+                        <button
+                            onClick={() => setIsPasswordModalOpen(true)}
+                            className={`${collapsed ? '' : 'flex-1'} flex items-center justify-center gap-2 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors`}
+                            title="Change Password"
+                            aria-label={collapsed ? 'Change Password' : undefined}
+                        >
+                            <Lock className="w-3 h-3" />
+                            {!collapsed && 'Password'}
+                        </button>
+                        <button
+                            onClick={logout}
+                            className={`${collapsed ? '' : 'flex-1'} flex items-center justify-center gap-2 px-2 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 rounded-md transition-colors`}
+                            title="Logout"
+                            aria-label={collapsed ? 'Logout' : undefined}
+                        >
+                            <LogOut className="w-3 h-3" />
+                            {!collapsed && 'Logout'}
+                        </button>
                     </div>
                 </div>
-            </div>
 
-            <nav aria-label="Main navigation" className="flex-1 overflow-y-auto py-6 px-3">
-                <SidebarGroup title="Overview">
-                    <SidebarItem to="/" icon={LayoutDashboard} label="Dashboard" end />
-                    <SidebarItem to="/history" icon={Phone} label="Call History" />
-                    <SidebarItem to="/scheduling" icon={CalendarClock} label="Call Scheduling" />
-                    <SidebarItem to="/wizard" icon={Zap} label="Setup Wizard" />
-                </SidebarGroup>
-
-                <SidebarGroup title="Core Configuration">
-                    <SidebarItem to="/agents" icon={Users} label="Agents" />
-                    <SidebarItem to="/providers" icon={Server} label="Providers" />
-                    <SidebarItem to="/pipelines" icon={Workflow} label="Pipelines" />
-                    <SidebarItem to="/profiles" icon={Sliders} label="Audio Profiles" />
-                    <SidebarItem to="/tools" icon={Wrench} label="Tools" />
-                    <SidebarItem to="/mcp" icon={Plug} label="MCP" />
-                </SidebarGroup>
-
-                <SidebarGroup title="Advanced Settings">
-                    <SidebarItem to="/vad" icon={Activity} label="Voice Activity Detection" />
-                    <SidebarItem to="/streaming" icon={Zap} label="Streaming" />
-                    <SidebarItem to="/llm" icon={Brain} label="LLM Defaults" />
-                    <SidebarItem to="/transport" icon={Radio} label="Audio Transport" />
-                    <SidebarItem to="/barge-in" icon={AlertTriangle} label="Barge-in" />
-                </SidebarGroup>
-
-                <SidebarGroup title="System">
-                    <SidebarItem to="/env" icon={Globe} label="Environment" />
-                    <SidebarItem to="/docker" icon={Container} label="Docker Services" />
-                    <SidebarItem to="/asterisk" icon={Phone} label="Asterisk" />
-                    <SidebarItem to="/models" icon={HardDrive} label="Models" />
-                    <SidebarItem to="/updates" icon={ArrowUpCircle} label="Updates" />
-                    <SidebarItem to="/logs" icon={FileText} label="Logs" />
-                    <SidebarItem to="/terminal" icon={Terminal} label="Terminal" />
-                </SidebarGroup>
-
-                <SidebarGroup title="Danger Zone">
-                    <SidebarItem to="/yaml" icon={Code} label="Raw YAML" />
-                </SidebarGroup>
-
-                <SidebarGroup title="Support">
-                    <SidebarItem to="/help" icon={HelpCircle} label="Help" />
-                    <a
-                        href="/docs"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                    >
-                        <ExternalLink className="w-4 h-4" />
-                        API Docs
-                    </a>
-                    <a
-                        href={KOFI_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="Support AVA on Ko-fi"
-                        className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                    >
-                        <Coffee className="w-4 h-4" aria-hidden="true" /> Support on Ko-fi
-                    </a>
-                    <a
-                        href={SPONSORS_URL}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label="Sponsor AVA on GitHub"
-                        className="flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-                    >
-                        <Heart className="w-4 h-4" aria-hidden="true" /> Sponsor
-                    </a>
-                </SidebarGroup>
-            </nav>
-
-            <div className="p-4 border-t border-border/50">
-                <div className="flex items-center gap-3 px-2 mb-3">
-                    <div className="w-8 h-8 rounded-full bg-accent flex items-center justify-center text-xs font-bold uppercase">
-                        {user?.username?.substring(0, 2) || 'AD'}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium truncate">{user?.username || 'Admin'}</p>
-                        <p className="text-xs text-muted-foreground truncate">Administrator</p>
-                    </div>
-                </div>
-                <div className="flex gap-2">
-                    <button
-                        onClick={() => setIsPasswordModalOpen(true)}
-                        className="flex-1 flex items-center justify-center gap-2 px-2 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
-                        title="Change Password"
-                    >
-                        <Lock className="w-3 h-3" />
-                        Password
-                    </button>
-                    <button
-                        onClick={logout}
-                        className="flex-1 flex items-center justify-center gap-2 px-2 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 rounded-md transition-colors"
-                        title="Logout"
-                    >
-                        <LogOut className="w-3 h-3" />
-                        Logout
-                    </button>
-                </div>
-            </div>
-
-            <ChangePasswordModal
-                isOpen={isPasswordModalOpen}
-                onClose={() => setIsPasswordModalOpen(false)}
-            />
-        </aside>
+                <ChangePasswordModal
+                    isOpen={isPasswordModalOpen}
+                    onClose={() => setIsPasswordModalOpen(false)}
+                />
+            </aside>
+        </CollapseContext.Provider>
     );
 };
 

--- a/admin_ui/frontend/src/hooks/useSidebarCollapsed.test.ts
+++ b/admin_ui/frontend/src/hooks/useSidebarCollapsed.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 import { useSidebarCollapsed, SIDEBAR_COLLAPSED_KEY } from './useSidebarCollapsed';
@@ -7,6 +7,31 @@ import { useSidebarCollapsed, SIDEBAR_COLLAPSED_KEY } from './useSidebarCollapse
 describe('useSidebarCollapsed', () => {
     beforeEach(() => {
         localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('falls back to expanded when localStorage.getItem throws', () => {
+        vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
+            throw new Error('storage blocked');
+        });
+
+        const { result } = renderHook(() => useSidebarCollapsed());
+
+        expect(result.current.collapsed).toBe(false);
+    });
+
+    it('does not throw when localStorage.setItem fails', () => {
+        vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+            throw new Error('quota exceeded');
+        });
+
+        const { result } = renderHook(() => useSidebarCollapsed());
+
+        expect(() => act(() => result.current.toggle())).not.toThrow();
+        expect(result.current.collapsed).toBe(true);
     });
 
     it('defaults to expanded when nothing is stored', () => {

--- a/admin_ui/frontend/src/hooks/useSidebarCollapsed.test.ts
+++ b/admin_ui/frontend/src/hooks/useSidebarCollapsed.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useSidebarCollapsed, SIDEBAR_COLLAPSED_KEY } from './useSidebarCollapsed';
+
+describe('useSidebarCollapsed', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('defaults to expanded when nothing is stored', () => {
+        const { result } = renderHook(() => useSidebarCollapsed());
+        expect(result.current.collapsed).toBe(false);
+    });
+
+    it('initializes collapsed when localStorage says so', () => {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
+        const { result } = renderHook(() => useSidebarCollapsed());
+        expect(result.current.collapsed).toBe(true);
+    });
+
+    it('toggle flips the state and persists it', () => {
+        const { result } = renderHook(() => useSidebarCollapsed());
+
+        act(() => result.current.toggle());
+
+        expect(result.current.collapsed).toBe(true);
+        expect(localStorage.getItem(SIDEBAR_COLLAPSED_KEY)).toBe('1');
+    });
+});

--- a/admin_ui/frontend/src/hooks/useSidebarCollapsed.ts
+++ b/admin_ui/frontend/src/hooks/useSidebarCollapsed.ts
@@ -4,11 +4,20 @@ export const SIDEBAR_COLLAPSED_KEY = 'ava-sidebar-collapsed';
 
 export function useSidebarCollapsed() {
     const [collapsed, setCollapsed] = useState<boolean>(() => {
-        return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+        try {
+            return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+        } catch {
+            // Storage blocked (private mode, policy) — default to expanded.
+            return false;
+        }
     });
 
     useEffect(() => {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
+        try {
+            localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
+        } catch {
+            // Keep the in-memory preference when storage is unavailable.
+        }
     }, [collapsed]);
 
     const toggle = () => setCollapsed((c) => !c);

--- a/admin_ui/frontend/src/hooks/useSidebarCollapsed.ts
+++ b/admin_ui/frontend/src/hooks/useSidebarCollapsed.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export const SIDEBAR_COLLAPSED_KEY = 'ava-sidebar-collapsed';
+
+export function useSidebarCollapsed() {
+    const [collapsed, setCollapsed] = useState<boolean>(() => {
+        return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+    });
+
+    useEffect(() => {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? '1' : '0');
+    }, [collapsed]);
+
+    const toggle = () => setCollapsed((c) => !c);
+
+    return { collapsed, setCollapsed, toggle };
+}

--- a/docs/contributing/milestones/milestone-24-tools-enhancements.md
+++ b/docs/contributing/milestones/milestone-24-tools-enhancements.md
@@ -211,8 +211,13 @@ These variables are available for prompt/greeting substitution and tool payloads
 | `{transcript_json}` | Full conversation history as JSON array |
 | `{summary}` | AI-generated call summary (if available) |
 | `{tool_calls_json}` | List of in-call tool executions as JSON |
-| `{pre_call_results_json}` | Data from pre-call tools as JSON |
+| `{pre_call_results_json}` | Data from pre-call tools as JSON (whole object) |
 | `{provider}` | Provider name used for the call |
+
+Each pre-call output variable is **also** exposed as its own placeholder (e.g.
+`{customer_name}`), so a post-call body can reference it directly:
+`"customer_name": "{customer_name}"`. A built-in variable always wins — a
+pre-call variable named like a built-in (e.g. `caller_number`) never overrides it.
 
 ### Existing Tool Architecture (Code Analysis)
 

--- a/src/tools/context.py
+++ b/src/tools/context.py
@@ -310,7 +310,7 @@ class PostCallContext:
             Dictionary with all call data for templating.
         """
         import json
-        return {
+        payload: Dict[str, Any] = {
             "call_id": self.call_id,
             "caller_number": self.caller_number,
             "called_number": self.called_number or "",
@@ -329,3 +329,11 @@ class PostCallContext:
             "campaign_id": self.campaign_id or "",
             "lead_id": self.lead_id or "",
         }
+        # Flatten pre-call enrichment variables into individual placeholders
+        # (e.g. {customer_name}) so post-call webhook bodies can reference them
+        # directly, mirroring how the prompt and in-call paths expose them.
+        # Built-in keys always win; a pre-call variable never clobbers them.
+        for key, value in (self.pre_call_results or {}).items():
+            if key not in payload:
+                payload[key] = str(value) if value else ""
+        return payload

--- a/tests/tools/test_generic_webhook.py
+++ b/tests/tools/test_generic_webhook.py
@@ -291,6 +291,35 @@ class TestPayloadBuilding:
         assert data["id"] == "call_xyz"
         assert data["phone"] == "+1555123456"
     
+    def test_pre_call_variable_substitution(self, context):
+        """Pre-call output variables resolve as individual placeholders (issue #608)."""
+        context.pre_call_results = {"va": "Acme Corp", "customer_name": "John Smith"}
+        config = WebhookConfig(
+            name="test",
+            payload_template='{"company": "{va}", "customer_name": "{customer_name}"}',
+        )
+        tool = GenericWebhookTool(config)
+
+        payload = tool._build_payload(context)
+        data = json.loads(payload)
+
+        assert data["company"] == "Acme Corp"
+        assert data["customer_name"] == "John Smith"
+
+    def test_pre_call_variable_does_not_override_builtin(self, context):
+        """A pre-call variable named like a built-in cannot override it."""
+        context.pre_call_results = {"caller_number": "999-SPOOF"}
+        config = WebhookConfig(
+            name="test",
+            payload_template='{"phone": "{caller_number}"}',
+        )
+        tool = GenericWebhookTool(config)
+
+        payload = tool._build_payload(context)
+        data = json.loads(payload)
+
+        assert data["phone"] == "+1555123456"
+
     def test_json_field_not_quoted(self, context):
         """Test that _json fields are not quoted."""
         config = WebhookConfig(

--- a/tests/tools/test_phase_tools_base.py
+++ b/tests/tools/test_phase_tools_base.py
@@ -255,6 +255,37 @@ class TestPostCallContext:
         assert payload["campaign_id"] == ""
         assert payload["lead_id"] == ""
 
+    def test_to_payload_dict_flattens_pre_call_results(self):
+        """Pre-call output variables are exposed as individual placeholders."""
+        ctx = PostCallContext(
+            call_id="call_123",
+            caller_number="+1234567890",
+            pre_call_results={"customer_name": "John Smith", "va": "Acme Corp"},
+        )
+
+        payload = ctx.to_payload_dict()
+
+        # Individual pre-call variables usable directly in webhook templates
+        assert payload["customer_name"] == "John Smith"
+        assert payload["va"] == "Acme Corp"
+        # Blob still present for backward compatibility
+        assert '"customer_name": "John Smith"' in payload["pre_call_results_json"]
+
+    def test_to_payload_dict_pre_call_does_not_override_builtins(self):
+        """A pre-call variable must not clobber a built-in payload key."""
+        ctx = PostCallContext(
+            call_id="call_123",
+            caller_number="+1234567890",
+            caller_name="Jane Doe",
+            pre_call_results={"caller_number": "999", "caller_name": "SPOOF"},
+        )
+
+        payload = ctx.to_payload_dict()
+
+        # Built-ins win over same-named pre-call variables
+        assert payload["caller_number"] == "+1234567890"
+        assert payload["caller_name"] == "Jane Doe"
+
 
 # --- PreCallTool Base Class Tests ---
 


### PR DESCRIPTION
Two independent, low-risk enhancements.

### #608 — Pre-call variables in post-call webhook bodies
Each pre-call output variable (e.g. `{customer_name}`) is now flattened into `PostCallContext.to_payload_dict()`, so post-call webhook `payload_template`s can reference it directly instead of only the whole `{pre_call_results_json}` blob. Built-in payload keys always win (a pre-call var named `caller_number` can't override the real one). Mirrors how the prompt and in-call paths already surface these.

- Unit + integration tests (both watched failing first); milestone-24 docs + CHANGELOG updated.
- **Live-validated** on the dev server: a pre-call open-meteo lookup's `current_weather_temperature` rendered into a post-call SMS webhook body.

### #596 — Collapsible left navigation sidebar
The Admin UI sidebar collapses to an icon-only rail via a header toggle; state persists in `localStorage` (`useSidebarCollapsed`, modeled on `useTheme`). Collapsed items keep tooltips + `aria-label`/`aria-expanded`. Desktop width-toggle only — no mobile drawer.

- New hook test + sidebar collapse tests.

Closes #608
Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible Admin UI sidebar with animated resizing and persistent expanded/collapsed preferences.
  * Improved sidebar accessibility with clearer labels, tooltips, and accessible navigation links.
  * Added direct access to individual pre-call results in post-call webhook templates.

* **Bug Fixes**
  * Ensured built-in webhook payload values take precedence over conflicting pre-call variables.
  * Preserved the complete pre-call results JSON object in webhook payloads.

* **Documentation**
  * Updated post-call template guidance for pre-call variables and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->