### PR TITLE
chore(release): prepare v7.5.5

### DIFF
--- a/AVA.mdc
+++ b/AVA.mdc
@@ -15,7 +15,7 @@ It is self-contained: everything an external contributor's assistant needs is ei
 this file or in the committed docs it links to. If this file ever contradicts the code or
 the docs, trust the code, then the docs — and please open an issue so we can fix it here.
 
-> Last verified against: **v7.5.4 candidate** (2026-07). Freshness is
+> Last verified against: **v7.5.5 candidate** (2026-08). Freshness is
 > checked as part of the release checklist (`docs/RELEASE_CHECKLIST.md`).
 
 ## What This Project Is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.5.5] - 2026-08-08
+
 ### Added
 
 - **Collapsible left navigation sidebar** ([#596](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/596)): the Admin UI sidebar can now collapse to an icon-only rail via a toggle in its header, reclaiming horizontal space for configuration pages and long forms — useful on portrait or smaller displays. Collapsed items keep hover tooltips and screen-reader labels, and the collapsed/expanded preference persists across sessions in browser local storage.
@@ -2312,7 +2314,8 @@ Version 4.1 introduces **unified tool calling architecture** enabling AI agents 
 - **v4.0.0** (2025-10-29) - Modular pipeline architecture, production monitoring, golden baselines
 - **v3.0.0** (2025-09-16) - Modular pipeline architecture, file based playback
 
-[Unreleased]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.4...HEAD
+[Unreleased]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.5...HEAD
+[7.5.5]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.4...v7.5.5
 [7.5.4]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.3...v7.5.4
 [7.5.3]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.2...v7.5.3
 [7.5.2]: https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/compare/v7.5.1...v7.5.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img alt="Asterisk AI Voice Agent" src="assets/banner_light_mode.png?v=9" width="100%">
 </picture>
 
-![Version](https://img.shields.io/badge/version-7.5.4-blue.svg)
+![Version](https://img.shields.io/badge/version-7.5.5-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![Docker](https://img.shields.io/badge/docker-compose-blue.svg)
@@ -167,6 +167,37 @@ docker compose -p asterisk-ai-voice-agent logs -f ai_engine
 ## 🎉 What's New
 
 <details open>
+<summary><b>v7.5.5 — Sidebar collapse, post-call webhook variables, and configurable extension availability</b></summary>
+
+v7.5.5 is an in-place feature release. It does not migrate databases, reassign
+Agents, or change Audio Profiles.
+
+- **Collapsible Admin UI sidebar** — the left navigation can collapse to an
+  icon-only rail, with hover tooltips and a persisted preference, reclaiming
+  space on smaller displays ([#596](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/596)).
+- **Pre-call variables now flow into post-call webhooks** — each pre-call
+  output variable is exposed as its own placeholder in webhook payload
+  templates, matching prompt and in-call tool behavior
+  ([#608](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/608)).
+- **Configurable extension availability mapping** — `check_extension_status`
+  now classifies multiple ARI device states per extension (including
+  operator-configured custom states for DND/away) via a configurable
+  free/busy/unavailable mapping, with a fail-closed default and new Admin UI
+  editors for per-extension and global state mapping
+  ([#577](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/577)).
+- **`check_extension_status` reliability fixes** — availability fields
+  survive JSON sanitization across all tool adapters, live-transfer channel
+  activity is cross-checked against stale device state, and an unmapped
+  `device_state_id` can no longer bypass `restrict_to_configured_extensions`
+  ([#577](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/577)).
+
+See the [v7.5.5 changelog](CHANGELOG.md#755---2026-08-08),
+[migration notes](docs/MIGRATION.md#v754-to-v755), and
+[validation matrix](docs/baselines/golden/v7.5.5-validation-matrix.md).
+
+</details>
+
+<details>
 <summary><b>v7.5.4 — Privacy-safe diagnostics and provider/update hardening</b></summary>
 
 v7.5.4 is an in-place reliability and privacy release. It does not migrate
@@ -369,7 +400,7 @@ voicemail mailboxes it should be allowed to use.**
   working.
 
 Before upgrading—especially from v7.3.0–v7.3.3—read the
-[current upgrade procedure](docs/INSTALLATION.md#upgrade-to-v754-existing-checkout)
+[current upgrade procedure](docs/INSTALLATION.md#upgrade-to-v755-existing-checkout)
 and [Contexts → Agents migration guide](docs/OPERATOR_MIGRATION.md).
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1165,4 +1165,10 @@ If you find this project useful, please also give it a ⭐️!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hkjarral/AVA-AI-Voice-Agent-for-Asterisk&type=date&legend=top-left)](https://www.star-history.com/#hkjarral/AVA-AI-Voice-Agent-for-Asterisk&type=date&legend=top-left)
+<a href="https://www.star-history.com/?repos=hkjarral%2FAVA-AI-Voice-Agent-for-Asterisk&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hkjarral/AVA-AI-Voice-Agent-for-Asterisk&type=date&theme=dark&legend=top-left&sealed_token=OFUaTIQ_cHQIeI9JOUvCGWT1NhM4MLx-xr5TRZEdODgPVlh-fSiAKxhs6Oa328sldbZyjiYVOHXlxkkn02lMmVdoYXZdQRMWI72Dzjddo9VI67yQaZHOqg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hkjarral/AVA-AI-Voice-Agent-for-Asterisk&type=date&legend=top-left&sealed_token=OFUaTIQ_cHQIeI9JOUvCGWT1NhM4MLx-xr5TRZEdODgPVlh-fSiAKxhs6Oa328sldbZyjiYVOHXlxkkn02lMmVdoYXZdQRMWI72Dzjddo9VI67yQaZHOqg" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hkjarral/AVA-AI-Voice-Agent-for-Asterisk&type=date&legend=top-left&sealed_token=OFUaTIQ_cHQIeI9JOUvCGWT1NhM4MLx-xr5TRZEdODgPVlh-fSiAKxhs6Oa328sldbZyjiYVOHXlxkkn02lMmVdoYXZdQRMWI72Dzjddo9VI67yQaZHOqg" />
+ </picture>
+</a>

--- a/admin_ui/backend/main.py
+++ b/admin_ui/backend/main.py
@@ -152,7 +152,7 @@ Most endpoints require JWT authentication. Obtain a token via `POST /api/auth/lo
 |---------|-----------|
 | **AI Engine Health Server** (port 15000) | `/health`, `/metrics`, `/live`, `/ready`, `/reload` |
 """,
-    version="7.5.4",
+    version="7.5.5",
     docs_url="/docs" if _enable_api_docs else None,
     redoc_url="/redoc" if _enable_api_docs else None,
     openapi_url="/openapi.json" if _enable_api_docs else None,

--- a/admin_ui/backend/tests/test_agents_api.py
+++ b/admin_ui/backend/tests/test_agents_api.py
@@ -679,7 +679,7 @@ def _load_backend_main():
 def test_main_app_openapi_version_and_tag():
     """version literal + agents tag description live in admin_ui/backend/main.py."""
     main = _load_backend_main()
-    assert main.app.version == "7.5.4"
+    assert main.app.version == "7.5.5"
     spec = main.app.openapi()
     tags = {t["name"]: t.get("description", "") for t in spec.get("tags", [])}
     assert tags.get("agents")  # present with a non-empty description

--- a/admin_ui/frontend/src/pages/System/EnvPage.callHistoryPrivacy.test.tsx
+++ b/admin_ui/frontend/src/pages/System/EnvPage.callHistoryPrivacy.test.tsx
@@ -59,7 +59,7 @@ describe('EnvPage Call History privacy', () => {
         expect(screen.getByRole('option', { name: /Strict/ })).toBeInTheDocument();
         expect(screen.getByRole('option', { name: /Show routing/ })).toBeInTheDocument();
         expect(screen.getByRole('option', { name: /Off/ })).toBeInTheDocument();
-        expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+        await waitFor(() => expect(Element.prototype.scrollIntoView).toHaveBeenCalled());
 
         fireEvent.change(select, { target: { value: 'off' } });
         expect(screen.getByText(/Redaction is off/)).toBeInTheDocument();

--- a/docs/CLI_TOOLS_GUIDE.md
+++ b/docs/CLI_TOOLS_GUIDE.md
@@ -151,7 +151,7 @@ Apply an update:
 
 ```bash
 agent update
-agent update --ref v7.5.4
+agent update --ref v7.5.5
 agent update --checkout --ref main
 agent update --rebuild auto
 agent update --rebuild none

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,15 +1,15 @@
 # Asterisk AI Voice Agent - Installation and Upgrade Guide (v7.5)
 
-This guide covers fresh installations and the supported upgrade path to v7.5.4.
+This guide covers fresh installations and the supported upgrade path to v7.5.5.
 For release-specific behavior changes, also read the
-[v7.5.4 migration notes](MIGRATION.md#v753-to-v754). Operators upgrading from
+[v7.5.5 migration notes](MIGRATION.md#v754-to-v755). Operators upgrading from
 v7.3.x or earlier must also follow the [v7.4 Agent migration](MIGRATION.md#v73x-to-v740).
 
 ## Three Setup Paths
 
 Choose the path that best fits your experience level:
 
-## Upgrade to v7.5.4 (Existing Checkout)
+## Upgrade to v7.5.5 (Existing Checkout)
 
 This section is for operators upgrading an existing repo checkout (not a fresh install).
 
@@ -72,7 +72,7 @@ Preferred CLI path:
 
 ```bash
 git fetch origin --prune --tags
-agent update --ref v7.5.4 --include-ui --local-changes=retain
+agent update --ref v7.5.5 --include-ui --local-changes=retain
 ```
 
 Replace `retain` with your explicit `overwrite` or `abort` decision. In an interactive
@@ -103,7 +103,7 @@ Run the host recovery script from an SSH shell on the AAVA server. This path doe
 depend on the failing Admin UI planner container:
 
 ```bash
-AAVA_RECOVERY_REF=v7.5.4
+AAVA_RECOVERY_REF=v7.5.5
 AAVA_REPO=/path/to/AVA-AI-Voice-Agent-for-Asterisk
 AAVA_RECOVERY_STATUS=0
 AAVA_RECOVERY_SCRIPT="$(mktemp)" &&
@@ -139,7 +139,7 @@ terminal:
 For non-interactive recovery, pass the decision explicitly:
 
 ```bash
-AAVA_RECOVERY_REF=v7.5.4
+AAVA_RECOVERY_REF=v7.5.5
 AAVA_REPO=/path/to/AVA-AI-Voice-Agent-for-Asterisk
 AAVA_RECOVERY_STATUS=0
 AAVA_RECOVERY_SCRIPT="$(mktemp)" &&
@@ -154,7 +154,7 @@ Use `overwrite` only when the operator accepts that tracked local code changes w
 discarded:
 
 ```bash
-AAVA_RECOVERY_REF=v7.5.4
+AAVA_RECOVERY_REF=v7.5.5
 AAVA_REPO=/path/to/AVA-AI-Voice-Agent-for-Asterisk
 AAVA_RECOVERY_STATUS=0
 AAVA_RECOVERY_SCRIPT="$(mktemp)" &&
@@ -248,7 +248,7 @@ explicit policy. Never use `git reset --hard` as generic upgrade advice.
 
 Do not treat a second update run as proof that the containers were updated. If the first
 job reached **Fast-forwarding code** and then failed during Docker Compose, the checkout may
-already be at v7.5.4 while the old containers are still running. Save the failed job log and
+already be at v7.5.5 while the old containers are still running. Save the failed job log and
 either use its **Rollback** action or, after fixing the reported Compose/build error, reconcile
 only the services that were running before the update:
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -37,8 +37,8 @@ Run these commands from your actual checkout path. Do not assume it is `/root/..
 ```bash
 cd /path/to/AVA-AI-Voice-Agent-for-Asterisk
 git status --short
-git diff --binary > ../aava-pre-v754-working-tree.patch
-git diff --binary --cached > ../aava-pre-v754-staged.patch
+git diff --binary > ../aava-pre-v755-working-tree.patch
+git diff --binary --cached > ../aava-pre-v755-staged.patch
 docker compose config --quiet
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -2,6 +2,27 @@
 
 This guide covers upgrading between major versions of Asterisk AI Voice Agent.
 
+## v7.5.4 to v7.5.5
+
+v7.5.5 is an in-place feature release with no database migration, Agent
+reassignment, provider credential change, or default Audio Profile change.
+
+After upgrading:
+
+1. Rebuild and recreate `admin_ui` and `ai_engine`.
+2. If you use `check_extension_status`, review the new global "State Value
+   Mapping" (Tools → Check Extension Status) and any per-extension
+   "Availability Signals" you want to configure (Live Agents → advanced
+   routing). Existing behavior is preserved by documented defaults; values
+   not explicitly listed as Free or Busy are treated as not available
+   (fail-closed) — confirm this matches your prior expectations if you relied
+   on undocumented device-state values resolving to "available."
+3. No action required for the collapsible sidebar or post-call webhook
+   variable changes — both are additive and backward compatible.
+
+Rollback uses the normal prior tagged images and the pre-update configuration
+backup. There is no database downgrade step.
+
 ## v7.5.3 to v7.5.4
 
 v7.5.4 is an in-place patch release with no database migration, Agent

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ## User Documentation
 
 - **[Quick Start Guide](../README.md)** - Get started in 10 minutes
-- **[Installation and Upgrade Guide](INSTALLATION.md)** - Fresh setup, v7.5.4 upgrade steps, and older-installation updater recovery
+- **[Installation and Upgrade Guide](INSTALLATION.md)** - Fresh setup, v7.5.5 upgrade steps, and older-installation updater recovery
 - **[Admin UI Guide](ADMIN_UI_GUIDE.md)** - Web interface for configuration and monitoring
 - **[FreePBX Integration Guide](FreePBX-Integration-Guide.md)** - Dialplan and queue configuration
 - **[Outbound Calling (Alpha)](OUTBOUND_CALLING.md)** - Scheduled outbound campaigns, voicemail drop, consent gate
@@ -11,6 +11,7 @@
 - **[Configuration Reference](Configuration-Reference.md)** - All settings explained
 - **[Caller Inactivity Watchdog](Configuration-Reference.md#caller-inactivity-no_input)** - 30-second inbound silence protection, per-agent overrides, and safe terminal playback (v7.3.1+)
 - **[Agents](AGENTS.md)** - v7.4 Agent routing, dialplan selection, and per-Agent tool access
+- **[v7.5.5 Validation Matrix](baselines/golden/v7.5.5-validation-matrix.md)** - Admin UI sidebar, post-call webhook variable, and extension availability mapping evidence
 - **[v7.5.4 Validation Matrix](baselines/golden/v7.5.4-validation-matrix.md)** - diagnostic privacy, ARI fault recovery, Deepgram telephony compatibility, Docker status, and updater-state evidence
 - **[v7.5.3 Validation Matrix](baselines/golden/v7.5.3-validation-matrix.md)** - audio recovery, transfer safety, post-deploy calls, and known-issue evidence
 - **[v7.5.2 Validation Matrix](baselines/golden/v7.5.2-validation-matrix.md)** - 16 kHz AudioSocket, G.722 provider/pipeline calls, compatibility, and deployment evidence

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -232,4 +232,4 @@ Longer-term goals that will shape the project's direction:
 
 ---
 
-**Last Updated**: July 2026 | **Latest Stable**: v7.5.4 | **Next**: Unreleased
+**Last Updated**: August 2026 | **Latest Stable**: v7.5.5 | **Next**: Unreleased

--- a/docs/baselines/golden/v7.5.5-validation-matrix.md
+++ b/docs/baselines/golden/v7.5.5-validation-matrix.md
@@ -10,9 +10,12 @@ availability mapping.
 ## Candidate
 
 - **Release candidate / runtime validation baseline:** `f1b8bf72` (the PR #610
-  merge — the last call-path change in this release); the v7.5.5 release-prep
-  commit on top of it is documentation-only (changelog, version strings, docs,
-  this matrix) and does not alter runtime behavior
+  merge — the last call-path change in this release). The v7.5.5 release-prep
+  commits on top of it are limited to documentation, version-string, and
+  test-only changes (changelog, version strings, docs, this matrix, and a
+  flaky-test hardening) and do not alter runtime/call-path behavior, so the
+  runtime gate evidence is inherited from `f1b8bf72` while the current head is
+  validated for docs/version/test consistency by CI
 - **Live validation target:** voiprnd (Sangoma 7, Asterisk 20.17.0)
 - **Database migration:** none
 - **Default Audio Profile or Agent assignment change:** none

--- a/docs/baselines/golden/v7.5.5-validation-matrix.md
+++ b/docs/baselines/golden/v7.5.5-validation-matrix.md
@@ -1,0 +1,86 @@
+# v7.5.5 Admin UI, Webhook, and Extension Availability Validation Matrix
+
+Release evidence for the collapsible Admin UI sidebar, pre-call variables in
+post-call webhook payloads, and configurable `check_extension_status`
+availability mapping.
+
+> PASS verdicts recorded as maintainer attestation; v7.5.5 makes no
+> audio/call-path change (UI + post-call webhook + check_extension_status only).
+
+## Candidate
+
+- **Release candidate / runtime validation baseline:** `f1b8bf72` (the PR #610
+  merge — the last call-path change in this release); the v7.5.5 release-prep
+  commit on top of it is documentation-only (changelog, version strings, docs,
+  this matrix) and does not alter runtime behavior
+- **Live validation target:** voiprnd (Sangoma 7, Asterisk 20.17.0)
+- **Database migration:** none
+- **Default Audio Profile or Agent assignment change:** none
+- **Production diagnostics default:** disabled (unchanged from v7.5.4)
+
+## Automated and static gates
+
+| Gate | Status |
+|---|---|
+| Python full suite | green on f1b8bf72 (PR #610 CI) |
+| Admin backend full suite | green on f1b8bf72 (PR #610 CI) |
+| Admin frontend tests, lint, and production build | green on f1b8bf72 (PR #610 CI) |
+| Go full suite and updater-focused suite | green on f1b8bf72 (PR #610 CI) |
+| Compose, shell syntax, source compilation, and diff checks | green on f1b8bf72 (PR #610 CI) |
+| OrbStack AI Engine and Admin UI builds and smoke tests | green on f1b8bf72 (PR #610 CI) |
+| PR CI, CodeQL, CLI cross-compile, and required conversations | green on f1b8bf72 (PR #610 CI) |
+
+Gate counts are not restated here from v7.5.4 to avoid implying they were
+re-run for this release; see the PR #610 CI run for current pass/fail detail.
+The frozen release-candidate head must repeat the GitHub final gate before merge.
+
+## Fault and lifecycle verification
+
+v7.5.5 does not change diagnostic capture, ARI liveness, or Local AI update
+behavior — those scenarios are unchanged from the v7.5.4 baseline
+(`v7.5.4-validation-matrix.md`) and are not re-verified here since this
+release makes no call-path change.
+
+| Scenario | Result |
+|---|---|
+| `check_extension_status` custom device-state mapping (per-extension "Availability Signals") | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+| `check_extension_status` global "State Value Mapping" (free/busy/unavailable, fail-closed default) | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+| `check_extension_status` unmapped `device_state_id` guardrail (no `restrict_to_configured_extensions` bypass) | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+| Post-call webhook pre-call variable placeholder interpolation | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+| Collapsible Admin UI sidebar (icon-only rail, tooltips, persisted preference) | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+
+## Provider/transport call matrix
+
+v7.5.5 makes no audio pipeline, provider, or transport change. No new
+provider/transport calls were made for this release; the v7.5.4 supervised
+Deepgram call matrix and prior providers' golden baselines remain the
+currently valid audio-path evidence and are not restated here.
+
+| Provider configuration | Transport | Call ID / evidence | Result |
+|---|---|---|---|
+| All providers/transports still claimed supported | — | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) | PASS |
+
+## Live evidence
+
+- **#577 `check_extension_status` DND** — live-verified on Google Live /
+  AudioSocket (voiprnd), calls `1786169824.674` (pre-fix) →
+  `1786170407.682` (DND detected).
+- **#608 post-call webhook variables** — pre-call→post-call webhook variable
+  interpolation verified on voiprnd.
+
+## Admin UI and deployment verification
+
+| Scenario | Result |
+|---|---|
+| Dashboard after runtime-baseline deployment | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+| Post-deployment services (`ai_engine`, `admin_ui` rebuilt/recreated) | maintainer-attested (v7.5.5 scope: Admin UI + post-call webhook templating + check_extension_status; no audio/call-path change) |
+
+## Compatibility and rollback boundary
+
+- v7.5.5 is an in-place feature release with no database downgrade step.
+- No provider, Audio Profile, or transport contract changes; the audio/call
+  path is unmodified from v7.5.4.
+- `check_extension_status` availability defaults are fail-closed: values not
+  explicitly listed as Free or Busy are treated as not available.
+- Application rollback uses the prior tagged images and the pre-update
+  operator configuration backup.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -119,7 +119,7 @@ For end-user and operator documentation, see the parent [/docs](../) directory:
 
 ## 📅 Project Status
 
-- **Latest Stable Version:** 7.5.4
+- **Latest Stable Version:** 7.5.5
 - **Next Release:** Unreleased (see the [roadmap](../ROADMAP.md))
 - **Active Branch:** `main` (feature branches → PR to `main`)
 - **Roadmap:** See [/docs/ROADMAP.md](../ROADMAP.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,7 +80,7 @@ This document summarizes the utilities under `scripts/` and when to use them.
 - `scripts/update-recover.sh`
   - Host-side recovery for Admin UI update planner failures, stale updater images, mixed `.git`/`.agent` ownership, and local tracked source edits that need an explicit retain/overwrite/abort decision.
   - Captures diagnostics under `/var/tmp/aava-update-recovery-*`, tracked-change patches, conflicted-file copies when a previous merge is unresolved, and a best-effort config/data backup before update. The script may repair `.git` and Git-tracked path ownership before inspection; later ownership repair is bounded to `.agent`, and it does not recursively chown the whole checkout.
-  - Usage: `sudo bash scripts/update-recover.sh --repo /path/to/AVA-AI-Voice-Agent-for-Asterisk --ref v7.5.4 --include-ui`
+  - Usage: `sudo bash scripts/update-recover.sh --repo /path/to/AVA-AI-Voice-Agent-for-Asterisk --ref v7.5.5 --include-ui`
 
 ## Admin UI URL and Catalog Maintenance
 

--- a/scripts/update-recover.sh
+++ b/scripts/update-recover.sh
@@ -42,7 +42,7 @@ Usage:
   sudo bash scripts/update-recover.sh [options]
 
 Recommended for a stuck release upgrade:
-  AAVA_RECOVERY_REF=v7.5.4
+  AAVA_RECOVERY_REF=v7.5.5
   AAVA_RECOVERY_STATUS=0
   AAVA_RECOVERY_SCRIPT="$(mktemp)" &&
     curl -fsSL "https://raw.githubusercontent.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/${AAVA_RECOVERY_REF}/scripts/update-recover.sh" -o "${AAVA_RECOVERY_SCRIPT}" &&


### PR DESCRIPTION
Release-prep for **v7.5.5** (docs + version metadata only; the runtime code shipped in prior merges).

### What v7.5.5 ships
- Collapsible Admin UI sidebar (#596)
- Pre-call variables usable directly in post-call webhook bodies (#608)
- Configurable extension availability mapping for `check_extension_status`, incl. two fixes (#577)

### Changes in this PR
- **CHANGELOG.md** — `[Unreleased]` → `[7.5.5] - 2026-08-08` + fresh Unreleased scaffold + compare links
- **Version strings → 7.5.5** — `admin_ui/backend/main.py`, `test_agents_api.py`, `AVA.mdc`, `scripts/update-recover.sh`, `scripts/README.md`, `docs/CLI_TOOLS_GUIDE.md`
- **Release docs** — `README.md` (badge, upgrade anchor, new "What's New" block), `docs/INSTALLATION.md`, `docs/MIGRATION.md` (new `v7.5.4 → v7.5.5` section), `docs/ROADMAP.md`, `docs/contributing/README.md`, `docs/README.md`
- **New** `docs/baselines/golden/v7.5.5-validation-matrix.md`
- **README star-history chart fix** — restored via the new sealed-token embed (GitHub's stargazer-API restriction broke the old tokenless badge)
- `scripts/check_release_docs.py` now reports **v7.5.5 consistent** across upgrade/migration/support/roadmap/recovery/validation docs.
- Deliberately unchanged: `SECURITY.md` (train window already 7.5.x + 7.4.x), `docs/SUPPORTED_PLATFORMS.md`, `src/providers/deepgram.py` (a historical docstring marker, not the app version).

### Validation matrix — maintainer attestation
v7.5.5's scope is **Admin UI + post-call webhook templating + `check_extension_status`** — **no audio/call-path change**. Per maintainer sign-off, provider/transport rows are recorded **PASS as attestation** (not per-provider call IDs), with the real live evidence we have cited: #577 DND detection on Google Live/AudioSocket (voiprnd calls `1786169824.674` → `1786170407.682`) and #608 pre-call→post-call webhook variable interpolation (voiprnd). Runtime validation baseline: `f1b8bf72` (the #610 merge); this PR is documentation-only on top.

### After merge
Cut the `v7.5.5` tag from the merge commit once CI is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sidebar collapse support.
  - Added pre-call variables for post-call webhooks.
  - Added configurable extension availability mappings.
  - Improved reliability of extension status checks.

- **Documentation**
  - Published release 7.5.5 documentation, migration guidance, installation updates, and validation details.
  - Updated upgrade, recovery, and reference links for version 7.5.5.

- **Release**
  - Updated the application and documentation to reflect version 7.5.5, released August 8, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->