### PR TITLE
feat: add Agent-scoped hangup intent markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent-scoped hangup intent markers:** Agents can inherit, extend, or replace the global `hangup_call` end-of-call markers from the Admin UI. New calls capture an immutable effective marker policy, and Full Local sends it as call-scoped tool context with capability negotiation so reused sessions cannot leak markers between Agents and older Local AI Server builds fail closed instead of silently ignoring an override.
+
 ### Fixed
 
 - **Outbound campaign lead context now reaches the selected Agent and fails closed when unavailable** ([#613](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/613)): ARI channel creation now sends originate-time values in the documented JSON `variables` object instead of the ignored `channelVars` member, restoring outbound routing, FreePBX identity, AudioSocket, predial-transfer, and campaign metadata. Nonempty lead `custom_vars` use bounded canonical JSON, are reapplied and read back before the AMD hop, and terminate the attempt without starting an AI session if their exact value cannot be confirmed. Answered calls recover unfinished attempt/lead metadata from SQLite after an engine restart and fail closed when that authoritative state is unavailable. Diagnostics record identifiers and byte counts without logging lead context. Broader verification of all correlation/AMD/consent safety-net writes is tracked in [#614](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/614).

--- a/admin_ui/backend/agents_migration.py
+++ b/admin_ui/backend/agents_migration.py
@@ -28,6 +28,10 @@ from src.tools.runtime_config import (
     dump_agent_tool_configs,
     merge_legacy_tool_overrides,
 )
+from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    dump_agent_hangup_policy,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -207,7 +211,8 @@ MIGRATION_VERSION = 1
 # into extra_json (which EngineAgentStore does NOT read for email dispatch).
 _FIRST_CLASS = {
     "provider", "voice", "greeting", "prompt", "audio_profile", "profile", "tools",
-    "tool_configs", "tool_overrides", "email_recipient", "email_from", "email_enabled",
+    "tool_configs", "tool_overrides", "hangup_policy",
+    "email_recipient", "email_from", "email_enabled",
 }
 
 
@@ -276,7 +281,8 @@ def run_migration(store: AgentsStore, yaml_path: str, contexts_dir: str) -> dict
             tool_configs_json = dump_agent_tool_configs(
                 _migrated_tool_configs(ctx)
             )
-        except ToolConfigPolicyError as exc:
+            hangup_policy_json = dump_agent_hangup_policy(ctx.get("hangup_policy"))
+        except (ToolConfigPolicyError, HangupPolicyConfigError) as exc:
             skipped.append((key, f"invalid tool configuration: {exc}"))
             continue
         extra = {k: v for k, v in ctx.items() if k not in _FIRST_CLASS}
@@ -314,6 +320,7 @@ def run_migration(store: AgentsStore, yaml_path: str, contexts_dir: str) -> dict
             prompt,
             json.dumps(ctx["tools"]) if ctx.get("tools") else None,
             tool_configs_json,
+            hangup_policy_json,
             ctx.get("profile") or ctx.get("audio_profile"),
             json.dumps(extra) if extra else None,
             1 if key == "default" else 0,  # is_default
@@ -329,10 +336,10 @@ def run_migration(store: AgentsStore, yaml_path: str, contexts_dir: str) -> dict
         for r in rows:
             store.conn.execute(
                 """INSERT INTO agents (id, slug, display_name, provider, voice, greeting,
-                   prompt, tools_json, tool_configs_json, audio_profile, extra_json, is_operator_managed,
+                   prompt, tools_json, tool_configs_json, hangup_policy_json, audio_profile, extra_json, is_operator_managed,
                    is_active, is_default, source_file, created_at, updated_at,
                    email_recipient, email_from, email_enabled)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,0,1,?,?,?,?,?,?,?)""",
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,0,1,?,?,?,?,?,?,?)""",
                 r,
             )
         store.conn.execute(

--- a/admin_ui/backend/agents_store.py
+++ b/admin_ui/backend/agents_store.py
@@ -77,11 +77,14 @@ class AgentsStore:
         except OSError: pass
 
     def _ensure_schema_sync(self):
-        """Best-effort additive migrations for existing installs.
+        """Apply additive migrations for existing installs and verify them.
 
         SQLite has limited ALTER TABLE support; we only add nullable columns
-        when missing — never drop or rename. Safe on populated production DBs.
+        when missing — never drop or rename. A partially migrated store must
+        fail during initialization instead of serving requests whose writes
+        reference columns that do not exist.
         """
+        migration_error = None
         try:
             existing = {str(r[1]) for r in
                         self.conn.execute("PRAGMA table_info(agents)").fetchall()}
@@ -96,8 +99,21 @@ class AgentsStore:
                     self.conn.execute("ALTER TABLE agents ADD COLUMN tool_configs_json TEXT")
                 if "hangup_policy_json" not in existing:
                     self.conn.execute("ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT")
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            migration_error = exc
+
+        required = {
+            "email_recipient", "email_from", "email_enabled",
+            "tool_configs_json", "hangup_policy_json",
+        }
+        actual = {
+            str(r[1]) for r in self.conn.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        missing = sorted(required - actual)
+        if missing:
+            raise RuntimeError(
+                f"agents schema migration incomplete; missing columns: {', '.join(missing)}"
+            ) from migration_error
 
     def upgrade_legacy_resource_policies(self) -> int:
         """Idempotently promote legacy calendar selections into tool_configs_json.

--- a/admin_ui/backend/agents_store.py
+++ b/admin_ui/backend/agents_store.py
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS agents (
     prompt TEXT NOT NULL,
     tools_json TEXT,
     tool_configs_json TEXT,             -- v7.4: structured per-agent tool-scope policies
+    hangup_policy_json TEXT,             -- Per-agent end-call marker strategy and values
     mcp_json TEXT,                    -- NOTE: not read at runtime — MCP is configured globally, not per-agent (audit LOW-T2). Stored/round-tripped only.
     audio_profile TEXT,
     extra_json TEXT,                 -- D3: pipeline, background_music, phase tools, disable flags, anything else
@@ -53,7 +54,7 @@ def _now() -> str:
 
 class AgentsStore:
     COLUMNS = ["id","slug","display_name","extension","role_label","provider","voice",
-               "greeting","prompt","tools_json","tool_configs_json","mcp_json","audio_profile","extra_json",
+               "greeting","prompt","tools_json","tool_configs_json","hangup_policy_json","mcp_json","audio_profile","extra_json",
                "is_operator_managed","is_active","is_default","source_file",
                "created_at","updated_at","notes",
                "email_recipient","email_from","email_enabled"]
@@ -93,6 +94,8 @@ class AgentsStore:
                     self.conn.execute("ALTER TABLE agents ADD COLUMN email_enabled INTEGER")
                 if "tool_configs_json" not in existing:
                     self.conn.execute("ALTER TABLE agents ADD COLUMN tool_configs_json TEXT")
+                if "hangup_policy_json" not in existing:
+                    self.conn.execute("ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT")
         except sqlite3.Error:
             pass
 
@@ -188,7 +191,7 @@ class AgentsStore:
     # -- writes ------------------------------------------------------------
     def create(self, *, display_name, provider=None, prompt, slug=None, extension=None,
                role_label=None, voice=None, greeting=None, tools_json=None,
-               tool_configs_json=None, mcp_json=None, audio_profile=None, extra_json=None,
+               tool_configs_json=None, hangup_policy_json=None, mcp_json=None, audio_profile=None, extra_json=None,
                is_operator_managed=1, source_file=None, notes=None,
                email_recipient=None, email_from=None, email_enabled=None) -> dict:
         slug = slug or slugify(display_name)
@@ -201,12 +204,12 @@ class AgentsStore:
         with self.conn:
             self.conn.execute(
                 """INSERT INTO agents (id,slug,display_name,extension,role_label,provider,
-                   voice,greeting,prompt,tools_json,tool_configs_json,mcp_json,audio_profile,extra_json,
+                   voice,greeting,prompt,tools_json,tool_configs_json,hangup_policy_json,mcp_json,audio_profile,extra_json,
                    is_operator_managed,is_active,is_default,source_file,created_at,updated_at,notes,
                    email_recipient,email_from,email_enabled)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1,0,?,?,?,?,?,?,?)""",
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1,0,?,?,?,?,?,?,?)""",
                 (str(uuid.uuid4()), slug, display_name, extension, role_label, provider,
-                 voice, greeting, prompt, tools_json, tool_configs_json, mcp_json, audio_profile, extra_json,
+                 voice, greeting, prompt, tools_json, tool_configs_json, hangup_policy_json, mcp_json, audio_profile, extra_json,
                  is_operator_managed, source_file, now, now, notes,
                  email_recipient, email_from, email_enabled))
         self._ensure_default_invariant()

--- a/admin_ui/backend/api/agents.py
+++ b/admin_ui/backend/api/agents.py
@@ -22,6 +22,10 @@ from src.tools.runtime_config import (
     dump_agent_tool_configs,
     merge_legacy_tool_overrides,
 )
+from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    dump_agent_hangup_policy,
+)
 
 
 def _validate_optional_email(v):
@@ -77,6 +81,7 @@ class AgentIn(BaseModel):
     audio_profile: str | None = None
     tools_json: str | None = None
     tool_configs_json: str | None = None
+    hangup_policy_json: str | None = None
     # NOTE: not read at runtime — MCP is configured globally, not per-agent (audit LOW-T2). Stored/round-tripped only.
     mcp_json: str | None = None
     extra_json: str | None = None
@@ -96,6 +101,14 @@ class AgentIn(BaseModel):
         except ToolConfigPolicyError as exc:
             raise ValueError(str(exc)) from exc
 
+    @field_validator("hangup_policy_json")
+    @classmethod
+    def _check_hangup_policy(cls, value):
+        try:
+            return dump_agent_hangup_policy(value)
+        except HangupPolicyConfigError as exc:
+            raise ValueError(str(exc)) from exc
+
 class AgentPatch(BaseModel):
     display_name: str | None = None
     provider: str | None = None
@@ -107,6 +120,7 @@ class AgentPatch(BaseModel):
     audio_profile: str | None = None
     tools_json: str | None = None
     tool_configs_json: str | None = None
+    hangup_policy_json: str | None = None
     # NOTE: not read at runtime — MCP is configured globally, not per-agent (audit LOW-T2). Stored/round-tripped only.
     mcp_json: str | None = None
     extra_json: str | None = None
@@ -127,6 +141,14 @@ class AgentPatch(BaseModel):
         except ToolConfigPolicyError as exc:
             raise ValueError(str(exc)) from exc
 
+    @field_validator("hangup_policy_json")
+    @classmethod
+    def _check_hangup_policy(cls, value):
+        try:
+            return dump_agent_hangup_policy(value)
+        except HangupPolicyConfigError as exc:
+            raise ValueError(str(exc)) from exc
+
 class AgentOut(BaseModel):
     """Full agent row as stored in agents.db. Declares every column so attaching this
     as a response_model never drops a field (wire-compatible with the raw rows we
@@ -143,6 +165,7 @@ class AgentOut(BaseModel):
     prompt: str
     tools_json: str | None = None
     tool_configs_json: str | None = None
+    hangup_policy_json: str | None = None
     # NOTE: not read at runtime — MCP is configured globally, not per-agent (audit LOW-T2). Stored/round-tripped only.
     mcp_json: str | None = None
     audio_profile: str | None = None
@@ -560,7 +583,7 @@ def migration_ack():
 _RECONCILE_FIRST_CLASS = {
     "provider", "prompt", "voice", "greeting", "extension", "role_label", "notes",
     "email_recipient", "email_from", "email_enabled", "tools", "audio_profile",
-    "profile", "tool_configs", "tool_overrides",
+    "profile", "tool_configs", "tool_overrides", "hangup_policy",
 }
 
 
@@ -587,6 +610,7 @@ def _context_to_agent_fields(ctx: dict) -> dict:
                 ctx.get("tool_configs"), ctx.get("tool_overrides")
             )
         ),
+        "hangup_policy_json": dump_agent_hangup_policy(ctx.get("hangup_policy")),
         "audio_profile": ctx.get("profile") or ctx.get("audio_profile"),
         "extra_json": json.dumps(extra) if extra else None,
     }
@@ -619,9 +643,13 @@ def migration_reconcile():
     seen_slugs = {a["slug"] for a in store.list_all()}
     for key, ctx in merged.items():
         src = ctx.pop("_source_file", None)
-        fields = _context_to_agent_fields(ctx)
         existing = existing_by_name.get(key)
         slug_key = existing["slug"] if existing else slugify(key)
+        try:
+            fields = _context_to_agent_fields(ctx)
+        except (ToolConfigPolicyError, HangupPolicyConfigError) as exc:
+            skipped.append((slug_key, f"invalid tool configuration: {exc}"))
+            continue
         if not fields["prompt"]:
             skipped.append((slug_key, "missing prompt"))
             continue

--- a/admin_ui/backend/export_agents_yaml.py
+++ b/admin_ui/backend/export_agents_yaml.py
@@ -41,6 +41,9 @@ def export_yaml(store: AgentsStore) -> str:
         tool_configs = _safe_json(a.get("tool_configs_json"))
         if tool_configs is not None:
             ctx["tool_configs"] = tool_configs
+        hangup_policy = _safe_json(a.get("hangup_policy_json"))
+        if hangup_policy is not None:
+            ctx["hangup_policy"] = hangup_policy
         contexts[a["slug"]] = ctx
     return yaml.safe_dump({"contexts": contexts}, sort_keys=True)
 

--- a/admin_ui/backend/export_agents_yaml.py
+++ b/admin_ui/backend/export_agents_yaml.py
@@ -2,6 +2,15 @@
 Usage: docker exec admin_ui python -m export_agents_yaml > contexts-recovered.yaml"""
 import json, sys, yaml
 from agents_store import AgentsStore
+import settings
+
+
+if settings.PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, settings.PROJECT_ROOT)
+from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    dump_agent_hangup_policy,
+)
 
 
 def _safe_json(raw):
@@ -41,9 +50,19 @@ def export_yaml(store: AgentsStore) -> str:
         tool_configs = _safe_json(a.get("tool_configs_json"))
         if tool_configs is not None:
             ctx["tool_configs"] = tool_configs
-        hangup_policy = _safe_json(a.get("hangup_policy_json"))
-        if hangup_policy is not None:
-            ctx["hangup_policy"] = hangup_policy
+        raw_hangup_policy = a.get("hangup_policy_json")
+        if raw_hangup_policy:
+            # Unlike optional diagnostic fields, this policy controls an
+            # irreversible call action. Refuse a lossy disaster-recovery
+            # export instead of silently converting corrupt data to inherit.
+            try:
+                canonical = dump_agent_hangup_policy(raw_hangup_policy)
+            except HangupPolicyConfigError as exc:
+                raise HangupPolicyConfigError(
+                    f"Agent {a['slug']!r} has an invalid hangup policy: {exc}"
+                ) from exc
+            if canonical is not None:
+                ctx["hangup_policy"] = json.loads(canonical)
         contexts[a["slug"]] = ctx
     return yaml.safe_dump({"contexts": contexts}, sort_keys=True)
 

--- a/admin_ui/backend/tests/test_agents_api.py
+++ b/admin_ui/backend/tests/test_agents_api.py
@@ -94,6 +94,47 @@ def test_invalid_tool_configs_rejected(client, raw):
     )
     assert response.status_code == 422
 
+
+def test_agent_hangup_policy_is_validated_and_canonicalized(client):
+    response = client.post(
+        "/api/agents",
+        json={
+            "display_name": "Russian Confirmation",
+            "provider": "local",
+            "prompt": "p",
+            "hangup_policy_json": __import__("json").dumps(
+                {"strategy": "extend", "end_call": [" Да ", "нет", "да"]}
+            ),
+        },
+    )
+    assert response.status_code == 201, response.text
+    assert __import__("json").loads(response.json()["hangup_policy_json"]) == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not-json",
+        '{"strategy":"all","end_call":["bye"]}',
+        '{"strategy":"extend","end_call":[]}',
+        '{"strategy":"inherit","end_call":["bye"]}',
+    ],
+)
+def test_invalid_agent_hangup_policy_is_rejected(client, raw):
+    response = client.post(
+        "/api/agents",
+        json={
+            "display_name": "Bad Hangup Policy",
+            "provider": "local",
+            "prompt": "p",
+            "hangup_policy_json": raw,
+        },
+    )
+    assert response.status_code == 422
+
 def test_delete_default_with_others_promotes(client):
     client.post("/api/agents", json={"display_name": "A", "provider": "x", "prompt": "p"})
     client.post("/api/agents", json={"display_name": "B", "provider": "x", "prompt": "p"})

--- a/admin_ui/backend/tests/test_agents_migration_v701.py
+++ b/admin_ui/backend/tests/test_agents_migration_v701.py
@@ -87,3 +87,24 @@ def test_relative_agents_db_path_yields_nonempty_dirname():
     op_dir = os.path.dirname(agents_db)
     assert op_dir, "abspath() must yield a non-empty parent dir for a bare filename"
     assert os.path.basename(agents_db) == "agents.db"
+
+
+def test_migration_promotes_and_normalizes_agent_hangup_policy(tmp_path):
+    yaml_path = _write_yaml(tmp_path, {
+        "Russian Confirmations": {
+            "provider": "local",
+            "prompt": "Confirm the appointment",
+            "hangup_policy": {
+                "strategy": "extend",
+                "end_call": [" Да ", "нет", "да"],
+            },
+        }
+    })
+    store = AgentsStore(db_path=str(tmp_path / "agents.db"))
+
+    assert run_migration(store, yaml_path, str(tmp_path / "contexts"))["imported"] == 1
+    row = store.get_by_slug("russian_confirmations")
+    assert _yaml.safe_load(row["hangup_policy_json"]) == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }

--- a/admin_ui/backend/tests/test_agents_reconcile_v710.py
+++ b/admin_ui/backend/tests/test_agents_reconcile_v710.py
@@ -108,6 +108,49 @@ def test_reconcile_records_promptless_skip(env):
     assert ["noprompt", "missing prompt"] in r.json()["skipped"]
 
 
+def test_reconcile_imports_agent_hangup_policy(env):
+    client, yaml_path = env
+    _write_yaml(yaml_path, {
+        "Russian": {
+            "provider": "local",
+            "prompt": "Confirm the appointment",
+            "hangup_policy": {
+                "strategy": "extend",
+                "end_call": [" Да ", "нет", "да"],
+            },
+        },
+    })
+
+    response = client.post("/api/agents-migration/reconcile")
+
+    assert response.status_code == 200, response.text
+    stored = client.get("/api/agents/russian").json()
+    assert json.loads(stored["hangup_policy_json"]) == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }
+
+
+def test_reconcile_skips_invalid_agent_hangup_policy(env):
+    client, yaml_path = env
+    _write_yaml(yaml_path, {
+        "Broken Markers": {
+            "provider": "local",
+            "prompt": "p",
+            "hangup_policy": {"strategy": "replace", "end_call": []},
+        },
+    })
+
+    response = client.post("/api/agents-migration/reconcile")
+
+    assert response.status_code == 200, response.text
+    assert client.get("/api/agents/broken_markers").status_code == 404
+    assert response.json()["skipped"] == [[
+        "broken_markers",
+        "invalid tool configuration: replace requires at least one end_call marker",
+    ]]
+
+
 def test_reconcile_imports_pipeline_context(env):
     # A context with no monolithic provider but a pipeline passes _engine_ok and
     # imports (pipeline is an arbitrary key -> extra_json).

--- a/admin_ui/backend/tests/test_agents_store.py
+++ b/admin_ui/backend/tests/test_agents_store.py
@@ -8,7 +8,7 @@ def store(tmp_path):
 def test_schema_created_with_wal(store):
     assert store.conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
     cols = {r[1] for r in store.conn.execute("PRAGMA table_info(agents)")}
-    assert {"slug", "extra_json", "tool_configs_json", "is_operator_managed", "is_default", "source_file"} <= cols
+    assert {"slug", "extra_json", "tool_configs_json", "hangup_policy_json", "is_operator_managed", "is_default", "source_file"} <= cols
 
 
 def test_additive_migration_adds_tool_configs_column(tmp_path):
@@ -26,6 +26,7 @@ def test_additive_migration_adds_tool_configs_column(tmp_path):
     migrated = AgentsStore(db_path=str(db))
     cols = {r[1] for r in migrated.conn.execute("PRAGMA table_info(agents)")}
     assert "tool_configs_json" in cols
+    assert "hangup_policy_json" in cols
 
 def test_slugify():
     assert slugify("Maria - Vendas") == "maria_vendas"
@@ -45,6 +46,19 @@ def test_tool_configs_roundtrip(store):
     assert row["tool_configs_json"] == raw
     updated = store.update("scoped", tool_configs_json=None)
     assert updated["tool_configs_json"] is None
+
+
+def test_hangup_policy_roundtrip(store):
+    raw = '{"end_call":["да","нет"],"strategy":"extend"}'
+    row = store.create(
+        display_name="Russian Confirmation",
+        provider="local",
+        prompt="p",
+        hangup_policy_json=raw,
+    )
+    assert row["hangup_policy_json"] == raw
+    updated = store.update("russian_confirmation", hangup_policy_json=None)
+    assert updated["hangup_policy_json"] is None
 
 
 def test_existing_extra_calendar_bindings_are_promoted(tmp_path):

--- a/admin_ui/backend/tests/test_agents_store.py
+++ b/admin_ui/backend/tests/test_agents_store.py
@@ -28,6 +28,37 @@ def test_additive_migration_adds_tool_configs_column(tmp_path):
     assert "tool_configs_json" in cols
     assert "hangup_policy_json" in cols
 
+
+def test_additive_migration_fails_closed_when_required_column_cannot_be_added():
+    import sqlite3
+
+    existing = {
+        "email_recipient", "email_from", "email_enabled", "tool_configs_json"
+    }
+
+    class Cursor:
+        def fetchall(self):
+            return [(index, name) for index, name in enumerate(sorted(existing))]
+
+    class FailingConnection:
+        def execute(self, sql):
+            if sql.startswith("PRAGMA table_info"):
+                return Cursor()
+            if "ADD COLUMN hangup_policy_json" in sql:
+                raise sqlite3.OperationalError("read only")
+            return Cursor()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    uninitialized = object.__new__(AgentsStore)
+    uninitialized.conn = FailingConnection()
+    with pytest.raises(RuntimeError, match="missing columns: hangup_policy_json"):
+        uninitialized._ensure_schema_sync()
+
 def test_slugify():
     assert slugify("Maria - Vendas") == "maria_vendas"
     assert slugify("Demo Deepgram!") == "demo_deepgram"

--- a/admin_ui/backend/tests/test_export_agents_yaml.py
+++ b/admin_ui/backend/tests/test_export_agents_yaml.py
@@ -6,12 +6,17 @@ def test_roundtrip(tmp_path):
     store = AgentsStore(db_path=str(tmp_path / "agents.db"))
     store.create(display_name="Sales", provider="p", prompt="sys", greeting="hi",
                  extra_json='{"pipeline":"local_hybrid"}',
-                 tool_configs_json='{"transfer":{"destination_policy":"none","destination_keys":[]}}')
+                 tool_configs_json='{"transfer":{"destination_policy":"none","destination_keys":[]}}',
+                 hangup_policy_json='{"strategy":"extend","end_call":["да","нет"]}')
     out = export_yaml(store)
     doc = yaml.safe_load(out)
     assert doc["contexts"]["sales"]["prompt"] == "sys"
     assert doc["contexts"]["sales"]["pipeline"] == "local_hybrid"
     assert doc["contexts"]["sales"]["tool_configs"]["transfer"]["destination_policy"] == "none"
+    assert doc["contexts"]["sales"]["hangup_policy"] == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }
 
 
 def test_malformed_json_fields_skipped_not_crashed(tmp_path):

--- a/admin_ui/backend/tests/test_export_agents_yaml.py
+++ b/admin_ui/backend/tests/test_export_agents_yaml.py
@@ -1,6 +1,8 @@
+import pytest
 import yaml
 from agents_store import AgentsStore
 from export_agents_yaml import export_yaml
+from src.tools.telephony.hangup_policy import HangupPolicyConfigError
 
 def test_roundtrip(tmp_path):
     store = AgentsStore(db_path=str(tmp_path / "agents.db"))
@@ -32,6 +34,19 @@ def test_malformed_json_fields_skipped_not_crashed(tmp_path):
     assert "bad" in doc["contexts"]
     # Malformed fields are simply absent (skipped), not raised
     assert "tools" not in doc["contexts"]["bad"]
+
+
+def test_malformed_hangup_policy_aborts_lossy_export(tmp_path):
+    store = AgentsStore(db_path=str(tmp_path / "agents.db"))
+    store.create(
+        display_name="Unsafe",
+        provider="p",
+        prompt="bad policy",
+        hangup_policy_json="{broken",
+    )
+
+    with pytest.raises(HangupPolicyConfigError, match="valid JSON"):
+        export_yaml(store)
 
 
 def test_canonical_tool_configs_win_over_stale_extra_payload(tmp_path):

--- a/admin_ui/frontend/src/components/agents/AgentForm.tsx
+++ b/admin_ui/frontend/src/components/agents/AgentForm.tsx
@@ -37,6 +37,7 @@ export interface Agent {
     mcp_json?: string;
     extra_json?: string;
     tool_configs_json?: string;
+    hangup_policy_json?: string;
     notes?: string;
     email_recipient?: string;
     email_from?: string;
@@ -325,6 +326,12 @@ const AgentForm: React.FC<AgentFormProps> = ({ isOpen, onClose, onSaved, agent }
         if (!toolState.provider && !toolState.pipeline) {
             toast.error('Choose an AI engine (a provider or a pipeline)'); return;
         }
+        if (
+            toolState.hangupMarkerStrategy !== 'inherit'
+            && !toolState.hangupEndCallMarkers.some((marker) => marker.trim())
+        ) {
+            toast.error('Add at least one end-call marker or select Inherit global'); return;
+        }
 
         const cfg = serializeAgentConfig(toolState);
         // Don't persist a voice the selected engine can't use: if the voice
@@ -349,6 +356,7 @@ const AgentForm: React.FC<AgentFormProps> = ({ isOpen, onClose, onSaved, agent }
                 mcp_json: cfg.mcp_json,
                 extra_json: cfg.extra_json,
                 tool_configs_json: cfg.tool_configs_json,
+                hangup_policy_json: cfg.hangup_policy_json,
                 email_recipient: emailRecipient || null,
                 email_from: emailFrom || null,
                 // Tri-state: '' means inherit — send explicit null (PATCH clears the column),
@@ -856,6 +864,64 @@ const AgentForm: React.FC<AgentFormProps> = ({ isOpen, onClose, onSaved, agent }
                     microsoftAccounts={microsoftAccounts}
                     voicemailMailboxes={voicemailMailboxes}
                 />
+
+                <details className="mt-4 border border-border rounded-lg bg-card/50">
+                    <summary className="cursor-pointer px-3 py-3 text-sm font-medium">
+                        Hangup Guardrail Markers
+                    </summary>
+                    <div className="px-3 pb-3 pt-3 space-y-3 border-t border-border">
+                        <p className="text-xs text-muted-foreground">
+                            Configure end-call phrases for this Agent. The effective list is captured
+                            when a new call starts and is sent to Full Local as call-scoped state.
+                        </p>
+                        <FormSelect
+                            id="agent-hangup-marker-strategy"
+                            label="Marker Policy"
+                            options={[
+                                { value: 'inherit', label: 'Inherit global markers' },
+                                { value: 'extend', label: 'Extend global markers' },
+                                { value: 'replace', label: 'Replace global markers' },
+                            ]}
+                            value={toolState.hangupMarkerStrategy}
+                            onChange={(e) => setToolState((state) => ({
+                                ...state,
+                                hangupMarkerStrategy: e.target.value as AgentToolState['hangupMarkerStrategy'],
+                                hangupEndCallMarkers: e.target.value === 'inherit'
+                                    ? [] : state.hangupEndCallMarkers,
+                            }))}
+                            tooltip="Inherit keeps the global list. Extend adds Agent-specific phrases. Replace makes this Agent's list authoritative."
+                        />
+                        {toolState.hangupMarkerStrategy !== 'inherit' && (
+                            <div>
+                                <FormLabel
+                                    htmlFor="agent-hangup-end-call-markers"
+                                    tooltip="One literal phrase per line. Matching is case-insensitive."
+                                >
+                                    End-Call Markers
+                                </FormLabel>
+                                <textarea
+                                    id="agent-hangup-end-call-markers"
+                                    value={toolState.hangupEndCallMarkers.join('\n')}
+                                    onChange={(e) => setToolState((state) => ({
+                                        ...state,
+                                        hangupEndCallMarkers: e.target.value.split('\n'),
+                                    }))}
+                                    rows={6}
+                                    placeholder={'да\nнет\nдо свидания'}
+                                    className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-y"
+                                />
+                                {toolState.hangupEndCallMarkers.some((marker) =>
+                                    marker.trim() && marker.trim().split(/\s+/).length === 1
+                                ) && (
+                                    <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                                        Single-word markers such as “yes”, “no”, “да”, or “нет” are broad.
+                                        Use them only for Agents whose workflow treats that answer as terminal.
+                                    </p>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </details>
             </div>
         </Modal>
     );

--- a/admin_ui/frontend/src/components/agents/agentToolConfig.test.ts
+++ b/admin_ui/frontend/src/components/agents/agentToolConfig.test.ts
@@ -3,6 +3,37 @@ import { describe, expect, it } from 'vitest';
 import { parseAgentConfig, serializeAgentConfig } from './agentToolConfig';
 
 
+describe('per-agent hangup marker policy', () => {
+    it('round-trips an extend policy through the first-class column', () => {
+        const state = parseAgentConfig({
+            provider: 'local',
+            hangup_policy_json: JSON.stringify({ strategy: 'extend', end_call: ['да', 'нет'] }),
+        });
+        expect(state.hangupMarkerStrategy).toBe('extend');
+        expect(state.hangupEndCallMarkers).toEqual(['да', 'нет']);
+        expect(JSON.parse(serializeAgentConfig(state).hangup_policy_json || '{}')).toEqual({
+            strategy: 'extend', end_call: ['да', 'нет'],
+        });
+    });
+
+    it('omits inherited markers for backward compatibility', () => {
+        const state = parseAgentConfig({ provider: 'local' });
+        expect(state.hangupMarkerStrategy).toBe('inherit');
+        expect(state.hangupEndCallMarkers).toEqual([]);
+        expect(serializeAgentConfig(state).hangup_policy_json).toBeNull();
+    });
+
+    it('trims, de-duplicates, and removes blank marker rows before saving', () => {
+        const state = parseAgentConfig({ provider: 'local' });
+        state.hangupMarkerStrategy = 'replace';
+        state.hangupEndCallMarkers = [' да ', '', 'нет', 'да'];
+        expect(JSON.parse(serializeAgentConfig(state).hangup_policy_json || '{}')).toEqual({
+            strategy: 'replace', end_call: ['да', 'нет'],
+        });
+    });
+});
+
+
 describe('per-agent no-input configuration', () => {
     it('round-trips no_input overrides without clobbering unknown extra fields', () => {
         const state = parseAgentConfig({

--- a/admin_ui/frontend/src/components/agents/agentToolConfig.ts
+++ b/admin_ui/frontend/src/components/agents/agentToolConfig.ts
@@ -22,6 +22,8 @@ export interface AgentToolState {
     backgroundMusic: string;          // extra.background_music
     connectionAudio: string;          // extra.connection_audio (Asterisk media URI)
     noInput: Record<string, unknown>; // extra.no_input per-agent policy overrides
+    hangupMarkerStrategy: 'inherit' | 'extend' | 'replace';
+    hangupEndCallMarkers: string[];
     extraPassthrough: Record<string, unknown>; // extra keys we do not own (+ object-form in_call_http_tools)
     mcpJsonRaw: string;               // mcp_json preserved verbatim — NOTE: no runtime effect, MCP is configured globally not per-agent (audit LOW-T2)
     transferDestinationPolicy: ResourcePolicy;
@@ -101,11 +103,16 @@ export interface AgentLike {
     mcp_json?: string;
     extra_json?: string;
     tool_configs_json?: string;
+    hangup_policy_json?: string;
 }
 
 export function parseAgentConfig(agent: AgentLike | null | undefined): AgentToolState {
     const extra = safeParseObject(agent?.extra_json);
     const toolConfigs = safeParseObject(agent?.tool_configs_json);
+    const hangupPolicy = safeParseObject(agent?.hangup_policy_json);
+    const rawHangupStrategy = asString(hangupPolicy['strategy']);
+    const hangupMarkerStrategy = rawHangupStrategy === 'extend' || rawHangupStrategy === 'replace'
+        ? rawHangupStrategy : 'inherit';
     const transferConfig = asObject(toolConfigs['transfer']);
     const rawTransferPolicy = asString(transferConfig['destination_policy']);
     const transferDestinationPolicy = parsePolicy(rawTransferPolicy);
@@ -148,6 +155,9 @@ export function parseAgentConfig(agent: AgentLike | null | undefined): AgentTool
         backgroundMusic: asString(extra['background_music']),
         connectionAudio: asString(extra['connection_audio']),
         noInput: asObject(extra['no_input']),
+        hangupMarkerStrategy,
+        hangupEndCallMarkers: hangupMarkerStrategy === 'inherit'
+            ? [] : asStrArray(hangupPolicy['end_call']),
         extraPassthrough: passthrough,
         mcpJsonRaw: agent?.mcp_json || '',
         transferDestinationPolicy,
@@ -171,6 +181,7 @@ export interface SerializedAgentConfig {
     mcp_json: string | null;
     extra_json: string | null;
     tool_configs_json: string | null;
+    hangup_policy_json: string | null;
 }
 
 export function serializeAgentConfig(state: AgentToolState): SerializedAgentConfig {
@@ -231,6 +242,10 @@ export function serializeAgentConfig(state: AgentToolState): SerializedAgentConf
         mcp_json: state.mcpJsonRaw.trim() || null,
         extra_json: Object.keys(extra).length ? JSON.stringify(extra) : null,
         tool_configs_json: Object.keys(toolConfigs).length ? JSON.stringify(toolConfigs) : null,
+        hangup_policy_json: state.hangupMarkerStrategy === 'inherit' ? null : JSON.stringify({
+            strategy: state.hangupMarkerStrategy,
+            end_call: [...new Set(state.hangupEndCallMarkers.map((marker) => marker.trim()).filter(Boolean))],
+        }),
     };
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -9,6 +9,7 @@ An **agent** is the v1a evolution of a "context": a named configuration bundle t
 - **Voice** — per-agent voice override (v7.3.0+): pick a voice for this agent, or leave empty to use the provider's default voice. Multiple agents can share one provider, each with its own voice. See [Voice Selection](VOICE_SELECTION.md)
 - **Audio profile** — telephony format / sample-rate profile (e.g. `telephony_ulaw_8k`)
 - **Tools** — optional callable tools plus per-agent resource policies for transfer destinations, Google calendars, Microsoft calendar accounts, and voicemail mailboxes. Global configuration owns inventory and hard disables; an agent can only narrow it.
+- **Hangup intent markers** — optional per-Agent end-of-call phrases that inherit, extend, or replace the global `hangup_call` markers for newly started calls.
 
 Agents are managed in the Admin UI **Agents** tab and stored in `agents.db`. v7.4 removes Contexts from navigation and runtime routing. Visiting the old `/contexts` URL shows a one-time migration notice and then opens Agents.
 
@@ -109,6 +110,28 @@ Empty or stale selections fail closed. Existing single-calendar/account installa
 The same effective snapshot governs provider schemas, prompt guidance, execution, deferred transfer, and audit metadata. A global disabled tool always wins. Tool names and Call History records remain unchanged (`google_calendar`, `microsoft_calendar`, and `leave_voicemail`), so existing tool-usage filters and aggregation remain compatible.
 
 **Tools → Save & Apply** builds an isolated generation for built-ins and managed HTTP tools. New calls capture the new generation; active calls keep their previous registry and configuration until they end. Build/validation failure leaves the previous generation running. Python code, environment/credential changes, provider/VAD changes, and MCP process configuration still require an engine restart.
+
+### Per-Agent hangup intent markers
+
+Under **Agents → Edit Agent → Tools → Hangup Guardrail**, choose how the Agent recognizes caller end-of-call intent:
+
+- **Inherit global markers** is the backward-compatible default.
+- **Extend global markers** adds Agent-specific phrases, such as localized confirmations, while preserving the global list.
+- **Replace global markers** uses only the Agent list. At least one marker is required.
+
+Enter one normalized phrase per line. Very short or single-word markers can match ordinary conversation, so the UI warns about them; use distinctive phrases where possible and test both expected and false-positive utterances. Saving an Agent affects new calls only. Active calls keep the effective marker snapshot they started with.
+
+The Agent row stores this nullable first-class value in `hangup_policy_json`. Legacy YAML imports may use the equivalent form:
+
+```yaml
+hangup_policy:
+  strategy: extend
+  end_call:
+    - да
+    - нет
+```
+
+Global enable/disable and execution settings still belong to **Tools → Hang Up Call**. A per-Agent marker policy does not enable a globally disabled tool.
 
 ---
 

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -1015,6 +1015,9 @@ tools:
     enabled: true
     require_confirmation: false        # Don't ask "shall I hang up?"
     farewell_message: "Thank you for calling. Goodbye!"
+    # Global end-of-call intent markers remain the default for every Agent.
+    # Agents can inherit, extend, or replace them in:
+    # Admin UI → Agents → Edit Agent → Tools → Hangup Guardrail.
   
   # ----------------------------------------------------------------------------
   # LEAVE_VOICEMAIL - Send caller to voicemail

--- a/docs/local-ai-server/PROTOCOL.md
+++ b/docs/local-ai-server/PROTOCOL.md
@@ -340,6 +340,11 @@ Request:
     { "name": "hangup_call", "parameters": { "type": "object", "properties": { "farewell_message": { "type": "string" } } } }
   ],
   "tool_policy": "auto",
+  "hangup_policy": {
+    "markers": { "end_call": ["goodbye", "да", "нет"] }
+  },
+  "hangup_marker_source": "agent_extend",
+  "hangup_marker_digest": "0123456789abcdef",
   "protocol_version": 2
 }
 ```
@@ -348,6 +353,9 @@ Notes:
 
 - `tool_policy` valid values: `"auto"`, `"strict"`, `"compatible"`, `"off"`.
 - Sending `tool_context` more than once per call is allowed and replaces the prior state.
+- `hangup_policy.markers.end_call` is the effective, normalized list captured by the engine for this call. The Local AI Server binds it to `call_id`; a different call clears the previous list before processing.
+- `hangup_marker_source` and `hangup_marker_digest` are diagnostic metadata. The server recomputes the digest from the accepted markers rather than trusting the client value.
+- Invalid marker payloads disable `hangup_call` for that call. Full Local clients check `status_response.capabilities.session_hangup_markers` before sending a non-default list and fail call setup against older servers.
 
 ---
 
@@ -492,6 +500,7 @@ Response:
 {
   "type": "status_response",
   "status": "ok",
+  "capabilities": { "session_hangup_markers": true },
   "stt_backend": "vosk|kroko|sherpa|faster_whisper|whisper_cpp",
   "tts_backend": "piper|kokoro|melotts|silero",
   "models": {
@@ -549,6 +558,7 @@ Notes:
 
 - `models.stt.device` and `models.stt.compute_type` are only emitted for the `faster_whisper` backend (otherwise `null`).
 - `config.enable_filler_audio` and `config.llm_streaming_tts_overlap` reflect runtime-only flags that can be flipped via `switch_model` `runtime_config` without reloading STT/LLM/TTS.
+- `capabilities.session_hangup_markers=true` means this server accepts effective call-scoped end-of-call markers in `tool_context` and isolates them by `call_id`.
 
 Schema:
 

--- a/docs/local-ai-server/PROTOCOL.md
+++ b/docs/local-ai-server/PROTOCOL.md
@@ -344,7 +344,7 @@ Request:
     "markers": { "end_call": ["goodbye", "да", "нет"] }
   },
   "hangup_marker_source": "agent_extend",
-  "hangup_marker_digest": "0123456789abcdef",
+  "hangup_marker_digest": "1a6c689923e0cb01",
   "protocol_version": 2
 }
 ```
@@ -354,8 +354,8 @@ Notes:
 - `tool_policy` valid values: `"auto"`, `"strict"`, `"compatible"`, `"off"`.
 - Sending `tool_context` more than once per call is allowed and replaces the prior state.
 - `hangup_policy.markers.end_call` is the effective, normalized list captured by the engine for this call. The Local AI Server binds it to `call_id`; a different call clears the previous list before processing.
-- `hangup_marker_source` and `hangup_marker_digest` are diagnostic metadata. The server recomputes the digest from the accepted markers rather than trusting the client value.
-- Invalid marker payloads disable `hangup_call` for that call. Full Local clients check `status_response.capabilities.session_hangup_markers` before sending a non-default list and fail call setup against older servers.
+- `hangup_marker_source` is diagnostic metadata. When `hangup_policy` is present, `protocol_version` and `hangup_marker_digest` are required. The server normalizes the accepted markers, recomputes the digest, and requires an exact match before enabling `hangup_call`.
+- Invalid marker payloads, unsupported protocol versions, and digest mismatches disable `hangup_call` for that call. Tool contexts without `hangup_policy` retain the legacy global-marker behavior. Full Local clients check `status_response.capabilities.session_hangup_markers` before sending a non-default list and fail call setup against older servers.
 
 ---
 

--- a/docs/local-ai-server/protocol.schema.json
+++ b/docs/local-ai-server/protocol.schema.json
@@ -924,6 +924,7 @@
               "properties": {
                 "end_call": {
                   "type": "array",
+                  "minItems": 1,
                   "maxItems": 100,
                   "items": {
                     "type": "string",

--- a/docs/local-ai-server/protocol.schema.json
+++ b/docs/local-ai-server/protocol.schema.json
@@ -165,6 +165,7 @@
       "required": [
         "type",
         "status",
+        "capabilities",
         "stt_backend",
         "tts_backend",
         "models",
@@ -178,6 +179,18 @@
         },
         "status": {
           "type": "string"
+        },
+        "capabilities": {
+          "type": "object",
+          "required": [
+            "session_hangup_markers"
+          ],
+          "properties": {
+            "session_hangup_markers": {
+              "const": true
+            }
+          },
+          "additionalProperties": true
         },
         "stt_backend": {
           "type": "string"
@@ -895,6 +908,42 @@
             "strict",
             "compatible",
             "off"
+          ]
+        },
+        "hangup_policy": {
+          "type": "object",
+          "required": [
+            "markers"
+          ],
+          "properties": {
+            "markers": {
+              "type": "object",
+              "required": [
+                "end_call"
+              ],
+              "properties": {
+                "end_call": {
+                  "type": "array",
+                  "maxItems": 100,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
+        "hangup_marker_source": {
+          "type": "string"
+        },
+        "hangup_marker_digest": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "protocol_version": {

--- a/docs/local-ai-server/protocol.schema.json
+++ b/docs/local-ai-server/protocol.schema.json
@@ -883,6 +883,21 @@
       "required": [
         "type"
       ],
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "hangup_policy"
+            ]
+          },
+          "then": {
+            "required": [
+              "protocol_version",
+              "hangup_marker_digest"
+            ]
+          }
+        }
+      ],
       "properties": {
         "type": {
           "const": "tool_context"
@@ -942,10 +957,8 @@
           "type": "string"
         },
         "hangup_marker_digest": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string",
+          "pattern": "^[0-9a-f]{16}$"
         },
         "protocol_version": {
           "type": "integer"

--- a/local_ai_server/protocol_contract.py
+++ b/local_ai_server/protocol_contract.py
@@ -394,6 +394,7 @@ PROTOCOL_SCHEMA: Dict[str, Any] = {
                             "properties": {
                                 "end_call": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "maxItems": 100,
                                     "items": {"type": "string", "minLength": 1, "maxLength": 160},
                                 }

--- a/local_ai_server/protocol_contract.py
+++ b/local_ai_server/protocol_contract.py
@@ -88,10 +88,18 @@ PROTOCOL_SCHEMA: Dict[str, Any] = {
         },
         "StatusResponse": {
             "type": "object",
-            "required": ["type", "status", "stt_backend", "tts_backend", "models", "kroko", "kokoro", "config"],
+            "required": ["type", "status", "capabilities", "stt_backend", "tts_backend", "models", "kroko", "kokoro", "config"],
             "properties": {
                 "type": {"const": "status_response"},
                 "status": {"type": "string"},
+                "capabilities": {
+                    "type": "object",
+                    "required": ["session_hangup_markers"],
+                    "properties": {
+                        "session_hangup_markers": {"const": True},
+                    },
+                    "additionalProperties": True,
+                },
                 "stt_backend": {"type": "string"},
                 "tts_backend": {"type": "string"},
                 "models": {
@@ -376,6 +384,27 @@ PROTOCOL_SCHEMA: Dict[str, Any] = {
                 "allowed_tools": {"type": "array", "items": {"type": "string"}},
                 "tools": {"type": "array", "items": {"type": "object"}},
                 "tool_policy": {"enum": ["auto", "strict", "compatible", "off"]},
+                "hangup_policy": {
+                    "type": "object",
+                    "required": ["markers"],
+                    "properties": {
+                        "markers": {
+                            "type": "object",
+                            "required": ["end_call"],
+                            "properties": {
+                                "end_call": {
+                                    "type": "array",
+                                    "maxItems": 100,
+                                    "items": {"type": "string", "minLength": 1, "maxLength": 160},
+                                }
+                            },
+                            "additionalProperties": True,
+                        }
+                    },
+                    "additionalProperties": True,
+                },
+                "hangup_marker_source": {"type": "string"},
+                "hangup_marker_digest": {"type": ["string", "null"]},
                 "protocol_version": {"type": "integer"},
             },
             "additionalProperties": True,

--- a/local_ai_server/protocol_contract.py
+++ b/local_ai_server/protocol_contract.py
@@ -378,6 +378,14 @@ PROTOCOL_SCHEMA: Dict[str, Any] = {
         "ToolContext": {
             "type": "object",
             "required": ["type"],
+            "allOf": [
+                {
+                    "if": {"required": ["hangup_policy"]},
+                    "then": {
+                        "required": ["protocol_version", "hangup_marker_digest"]
+                    },
+                }
+            ],
             "properties": {
                 "type": {"const": "tool_context"},
                 "call_id": {"type": "string"},
@@ -405,7 +413,10 @@ PROTOCOL_SCHEMA: Dict[str, Any] = {
                     "additionalProperties": True,
                 },
                 "hangup_marker_source": {"type": "string"},
-                "hangup_marker_digest": {"type": ["string", "null"]},
+                "hangup_marker_digest": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{16}$",
+                },
                 "protocol_version": {"type": "integer"},
             },
             "additionalProperties": True,

--- a/local_ai_server/server.py
+++ b/local_ai_server/server.py
@@ -7,6 +7,7 @@ import audioop
 import base64
 import contextlib
 import contextvars
+import hashlib
 import io
 import json
 import logging
@@ -94,6 +95,8 @@ _END_CALL_MARKERS: Tuple[str, ...] = (
     "take care",
     "talk to you later",
 )
+_MAX_SESSION_END_CALL_MARKERS = 100
+_MAX_SESSION_END_CALL_MARKER_LENGTH = 160
 
 
 class _LegacyKrokoSTTBackend:
@@ -4388,7 +4391,9 @@ class LocalAIServer:
         allowed = {str(name).strip() for name in (session.allowed_tools or []) if str(name).strip()}
         if not allowed:
             return False
-        if allowed == {"hangup_call"} and not self._text_has_end_call_intent(latest_user_text):
+        if allowed == {"hangup_call"} and not self._text_has_end_call_intent(
+            latest_user_text, session.hangup_end_call_markers
+        ):
             return False
         return True
 
@@ -4563,7 +4568,9 @@ class LocalAIServer:
         
         return clean
 
-    def _text_has_end_call_intent(self, text: str) -> bool:
+    def _text_has_end_call_intent(
+        self, text: str, markers: Optional[List[str]] = None
+    ) -> bool:
         import re
         t = _normalize_text(text or "")
         if not t:
@@ -4583,7 +4590,10 @@ class LocalAIServer:
         )
         if any(re.search(pattern, t) for pattern in meta_patterns):
             return False
-        for marker in _END_CALL_MARKERS:
+        effective_markers = (
+            list(_END_CALL_MARKERS) if markers is None else list(markers)
+        )
+        for marker in effective_markers:
             m = _normalize_text(marker)
             if not m:
                 continue
@@ -4594,6 +4604,37 @@ class LocalAIServer:
             if re.search(rf"(?:^|\b){re.escape(m)}(?:\b|$)", t):
                 return True
         return False
+
+    @staticmethod
+    def _normalize_session_end_call_markers(data: Dict[str, Any]) -> Optional[List[str]]:
+        """Return validated call-scoped markers, or None for legacy defaults."""
+        if "hangup_policy" not in data:
+            return None
+        policy = data.get("hangup_policy")
+        if not isinstance(policy, dict):
+            raise ValueError("hangup_policy must be an object")
+        markers_cfg = policy.get("markers")
+        if not isinstance(markers_cfg, dict):
+            raise ValueError("hangup_policy.markers must be an object")
+        raw_markers = markers_cfg.get("end_call")
+        if not isinstance(raw_markers, list):
+            raise ValueError("hangup_policy.markers.end_call must be an array")
+        if len(raw_markers) > _MAX_SESSION_END_CALL_MARKERS:
+            raise ValueError("too many session end-call markers")
+        normalized: List[str] = []
+        seen = set()
+        for raw_marker in raw_markers:
+            if not isinstance(raw_marker, str):
+                raise ValueError("session end-call markers must be strings")
+            marker = _normalize_text(raw_marker)
+            if not marker:
+                raise ValueError("session end-call markers must not be empty")
+            if len(marker) > _MAX_SESSION_END_CALL_MARKER_LENGTH:
+                raise ValueError("session end-call marker is too long")
+            if marker not in seen:
+                normalized.append(marker)
+                seen.add(marker)
+        return normalized
 
     def _text_has_hangup_tool_call(self, text: str) -> bool:
         import re
@@ -4945,6 +4986,39 @@ class LocalAIServer:
         session.allowed_tools = self._extract_allowed_tool_names(data)
         session.tool_schemas = data.get("tools") if isinstance(data.get("tools"), list) else []
         session.tool_policy = self._normalize_tool_policy(data.get("tool_policy"))
+        try:
+            session.hangup_end_call_markers = self._normalize_session_end_call_markers(data)
+            effective_markers = (
+                list(_END_CALL_MARKERS)
+                if session.hangup_end_call_markers is None
+                else list(session.hangup_end_call_markers)
+            )
+            requested_source = str(data.get("hangup_marker_source") or "").strip()
+            session.hangup_marker_source = requested_source or (
+                "global" if session.hangup_end_call_markers is None else "session"
+            )
+            session.hangup_marker_digest = hashlib.sha256(
+                json.dumps(
+                    effective_markers,
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()[:16]
+        except (TypeError, ValueError) as exc:
+            # Explicit malformed policy must never fall back to permissive
+            # server defaults. Remove the irreversible tool from this call.
+            session.hangup_end_call_markers = []
+            session.hangup_marker_source = "invalid"
+            session.hangup_marker_digest = None
+            session.allowed_tools = [
+                name for name in session.allowed_tools if name != "hangup_call"
+            ]
+            logging.error(
+                "🧩 TOOL CONTEXT - Invalid hangup policy; hangup_call disabled "
+                "call_id=%s error=%s",
+                session.call_id,
+                exc,
+            )
         # Bind the cached tool context to its originating call_id. A long-lived
         # WebSocket session can serve multiple calls; without this binding the
         # ACL/schemas/policy would silently leak from one call to the next when
@@ -4953,11 +5027,19 @@ class LocalAIServer:
         # PR #384 comment 3214130571.
         session.tool_context_call_id = session.call_id or None
         logging.info(
-            "🧩 TOOL CONTEXT - call_id=%s allowed_tools=%s policy=%s schemas=%s",
+            "🧩 TOOL CONTEXT - call_id=%s allowed_tools=%s policy=%s schemas=%s "
+            "hangup_marker_source=%s hangup_marker_count=%s hangup_marker_digest=%s",
             session.call_id,
             session.allowed_tools,
             session.tool_policy,
             len(session.tool_schemas or []),
+            session.hangup_marker_source,
+            len(
+                _END_CALL_MARKERS
+                if session.hangup_end_call_markers is None
+                else session.hangup_end_call_markers
+            ),
+            session.hangup_marker_digest,
         )
 
     async def _build_llm_tool_response_payload(
@@ -5022,7 +5104,9 @@ class LocalAIServer:
             tool_choice != "none"
             and not tool_calls
             and "hangup_call" in allowed_set
-            and self._text_has_end_call_intent(latest_user_text)
+            and self._text_has_end_call_intent(
+                latest_user_text, session.hangup_end_call_markers
+            )
         )
         if should_apply_hangup_heuristic:
             tool_calls = [
@@ -5073,7 +5157,9 @@ class LocalAIServer:
             tool_calls = []
             tool_path = "none"
 
-        if tool_calls and not self._text_has_end_call_intent(latest_user_text):
+        if tool_calls and not self._text_has_end_call_intent(
+            latest_user_text, session.hangup_end_call_markers
+        ):
             kept_calls = [
                 tc
                 for tc in tool_calls
@@ -5147,6 +5233,9 @@ class LocalAIServer:
             session.allowed_tools = []
             session.tool_schemas = []
             session.tool_policy = "auto"
+            session.hangup_end_call_markers = None
+            session.hangup_marker_source = "global"
+            session.hangup_marker_digest = None
             session.tool_context_call_id = None
         text = str(data.get("text") or "")
         # When the request omits tool metadata, pass None so
@@ -5629,7 +5718,9 @@ class LocalAIServer:
 
         if mode in {"full", "llm"} and normalized_text:
             words = normalized_text.split()
-            end_call_like = self._text_has_end_call_intent(clean_text)
+            end_call_like = self._text_has_end_call_intent(
+                clean_text, session.hangup_end_call_markers
+            )
             single_word_fragments = {"a", "an", "the", "then", "uh", "um", "hmm"}
             filler_tail_words = {"uh", "um", "hmm"}
             should_suppress_short = (
@@ -5796,7 +5887,9 @@ class LocalAIServer:
         # hasn't indicated they want to end the call (e.g., "how to set up the project").
         # When this happens, retry once with an explicit "no tools" instruction.
         if mode == "full" and llm_response and self._text_has_hangup_tool_call(llm_response):
-            if not self._text_has_end_call_intent(clean_text):
+            if not self._text_has_end_call_intent(
+                clean_text, session.hangup_end_call_markers
+            ):
                 logging.warning(
                     "⚠️ LLM emitted hangup_call without end-of-call intent; retrying without tools call_id=%s mode=%s preview=%s",
                     session.call_id,
@@ -6050,7 +6143,9 @@ class LocalAIServer:
         if llm_response:
             # Hangup tool call guardrail (same as serial path)
             if self._text_has_hangup_tool_call(llm_response):
-                if not self._text_has_end_call_intent(clean_text):
+                if not self._text_has_end_call_intent(
+                    clean_text, session.hangup_end_call_markers
+                ):
                     logging.warning(
                         "⚠️ STREAMING: LLM emitted hangup_call without end-of-call intent call_id=%s",
                         session.call_id,

--- a/local_ai_server/server.py
+++ b/local_ai_server/server.py
@@ -4619,6 +4619,8 @@ class LocalAIServer:
         raw_markers = markers_cfg.get("end_call")
         if not isinstance(raw_markers, list):
             raise ValueError("hangup_policy.markers.end_call must be an array")
+        if not raw_markers:
+            raise ValueError("hangup_policy.markers.end_call must not be empty")
         if len(raw_markers) > _MAX_SESSION_END_CALL_MARKERS:
             raise ValueError("too many session end-call markers")
         normalized: List[str] = []
@@ -4981,8 +4983,7 @@ class LocalAIServer:
         data: Dict[str, Any],
     ) -> None:
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
+        self._bind_session_call_id(session, call_id)
         session.allowed_tools = self._extract_allowed_tool_names(data)
         session.tool_schemas = data.get("tools") if isinstance(data.get("tools"), list) else []
         session.tool_policy = self._normalize_tool_policy(data.get("tool_policy"))
@@ -5041,6 +5042,26 @@ class LocalAIServer:
             ),
             session.hangup_marker_digest,
         )
+
+    @staticmethod
+    def _bind_session_call_id(session: SessionContext, call_id: Any) -> None:
+        """Bind a call-bearing message and clear stale call-scoped tool state."""
+        cached_call_id = getattr(session, "tool_context_call_id", None)
+        if cached_call_id and call_id and cached_call_id != call_id:
+            logging.warning(
+                "🧩 TOOL CONTEXT - call_id mismatch (cached=%s incoming=%s); clearing stale cache",
+                cached_call_id,
+                call_id,
+            )
+            session.allowed_tools = []
+            session.tool_schemas = []
+            session.tool_policy = "auto"
+            session.hangup_end_call_markers = None
+            session.hangup_marker_source = "global"
+            session.hangup_marker_digest = None
+            session.tool_context_call_id = None
+        if call_id:
+            session.call_id = call_id
 
     async def _build_llm_tool_response_payload(
         self,
@@ -5213,30 +5234,7 @@ class LocalAIServer:
     ) -> None:
         request_id = str(data.get("request_id") or "").strip()
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
-        # Cross-call leakage guard: a long-lived WebSocket session can serve
-        # multiple calls. The cached `tool_context` (allowed_tools / schemas /
-        # policy) is bound to the call_id that created it; if a different
-        # call_id arrives without sending a fresh `tool_context`, drop the
-        # stale cache so we don't authorize tools the new call wasn't given.
-        # The request will then fall through with an empty allowlist
-        # (effectively rejecting tool calls until a `tool_context` is sent
-        # for this call). Per CodeRabbit review of PR #384 comment 3214130571.
-        cached_ctx_call_id = getattr(session, "tool_context_call_id", None)
-        if cached_ctx_call_id and call_id and cached_ctx_call_id != call_id:
-            logging.warning(
-                "🧩 TOOL CONTEXT - call_id mismatch (cached=%s incoming=%s); clearing stale cache",
-                cached_ctx_call_id,
-                call_id,
-            )
-            session.allowed_tools = []
-            session.tool_schemas = []
-            session.tool_policy = "auto"
-            session.hangup_end_call_markers = None
-            session.hangup_marker_source = "global"
-            session.hangup_marker_digest = None
-            session.tool_context_call_id = None
+        self._bind_session_call_id(session, call_id)
         text = str(data.get("text") or "")
         # When the request omits tool metadata, pass None so
         # `_build_llm_tool_response_payload` can fall back to whatever was
@@ -5270,8 +5268,7 @@ class LocalAIServer:
         data: Dict[str, Any],
     ) -> None:
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
+        self._bind_session_call_id(session, call_id)
         request_id = str(data.get("request_id") or "").strip() or None
         tool_name = str(data.get("tool_name") or data.get("function_call_id") or "tool").strip()
         result = data.get("result") if isinstance(data.get("result"), dict) else {"value": data.get("result")}
@@ -6241,8 +6238,7 @@ class LocalAIServer:
         mode = self._normalize_mode(data.get("mode"), session)
         request_id = data.get("request_id")
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
+        self._bind_session_call_id(session, call_id)
         
         if DEBUG_AUDIO_FLOW:
             logging.debug(
@@ -6421,8 +6417,7 @@ class LocalAIServer:
 
         request_id = data.get("request_id")
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
+        self._bind_session_call_id(session, call_id)
 
         generation = self._start_output_generation(session)
 
@@ -6492,8 +6487,7 @@ class LocalAIServer:
         mode = self._normalize_mode(data.get("mode"), session)
         request_id = data.get("request_id")
         call_id = data.get("call_id")
-        if call_id:
-            session.call_id = call_id
+        self._bind_session_call_id(session, call_id)
 
         generation = self._start_output_generation(session)
 

--- a/local_ai_server/server.py
+++ b/local_ai_server/server.py
@@ -8,6 +8,7 @@ import base64
 import contextlib
 import contextvars
 import hashlib
+import hmac
 import io
 import json
 import logging
@@ -4579,9 +4580,10 @@ class LocalAIServer:
         # Do not turn quoted/metalinguistic uses of farewell words into an
         # irreversible hangup.  Weak phone STT commonly produces phrases such
         # as "reply with the word goodbye" while the caller is correcting the
-        # agent.  Explicit commands ("hang up", "end call") remain terminal.
+        # agent. Explicit English commands remain terminal only for the legacy
+        # global policy; a call-scoped replacement list is authoritative.
         explicit_commands = ("hang up", "end call")
-        if any(command in t for command in explicit_commands):
+        if markers is None and any(command in t for command in explicit_commands):
             return True
         meta_patterns = (
             r"\b(?:say|saying|said|repeat|reply|respond|answer)\b.{0,32}\b(?:goodbye|bye|thanks|thank you)\b",
@@ -5005,6 +5007,20 @@ class LocalAIServer:
                     separators=(",", ":"),
                 ).encode("utf-8")
             ).hexdigest()[:16]
+            if "hangup_policy" in data:
+                requested_version = data.get("protocol_version")
+                if requested_version != PROTOCOL_VERSION:
+                    raise ValueError(
+                        "call-scoped hangup policy requires protocol_version "
+                        f"{PROTOCOL_VERSION}"
+                    )
+                supplied_digest = str(
+                    data.get("hangup_marker_digest") or ""
+                ).strip()
+                if not supplied_digest or not hmac.compare_digest(
+                    supplied_digest, session.hangup_marker_digest
+                ):
+                    raise ValueError("hangup marker digest mismatch")
         except (TypeError, ValueError) as exc:
             # Explicit malformed policy must never fall back to permissive
             # server defaults. Remove the irreversible tool from this call.

--- a/local_ai_server/session.py
+++ b/local_ai_server/session.py
@@ -42,6 +42,11 @@ class SessionContext:
     allowed_tools: List[str] = field(default_factory=list)
     tool_schemas: List[Dict[str, Any]] = field(default_factory=list)
     tool_policy: str = "auto"
+    # Effective end-call markers supplied by the engine for this call. ``None``
+    # preserves the legacy server defaults for older clients.
+    hangup_end_call_markers: Optional[List[str]] = None
+    hangup_marker_source: str = "global"
+    hangup_marker_digest: Optional[str] = None
     # `call_id` of the most recent `tool_context` message that populated the
     # three fields above. Used to detect cross-call leakage on long-lived
     # WebSocket sessions: when a different `call_id` arrives, the server

--- a/local_ai_server/status_builder.py
+++ b/local_ai_server/status_builder.py
@@ -152,6 +152,9 @@ def build_status_response(server) -> Dict[str, Any]:
     return {
         "type": "status_response",
         "status": "ok",
+        "capabilities": {
+            "session_hangup_markers": True,
+        },
         "stt_backend": server.stt_backend,
         "tts_backend": server.tts_backend,
         "models": {

--- a/src/core/agent_store.py
+++ b/src/core/agent_store.py
@@ -8,6 +8,10 @@ import json, logging, os, re, sqlite3
 from contextlib import closing
 from typing import Optional
 from src.core.transport_orchestrator import ContextConfig
+from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    normalize_agent_hangup_policy,
+)
 
 logger = logging.getLogger(__name__)
 DB_DEFAULT = "/app/data/operator/agents.db"
@@ -127,12 +131,27 @@ class EngineAgentStore:
         email_from = r["email_from"] if "email_from" in cols else None
         email_enabled_raw = r["email_enabled"] if "email_enabled" in cols else None
         email_enabled = None if email_enabled_raw is None else bool(email_enabled_raw)
+        try:
+            hangup_policy = normalize_agent_hangup_policy(
+                json.loads(r["hangup_policy_json"])
+                if "hangup_policy_json" in cols and r["hangup_policy_json"]
+                else None
+            )
+            hangup_policy = hangup_policy or None
+        except (json.JSONDecodeError, TypeError, HangupPolicyConfigError) as exc:
+            logger.error(
+                "agents.db hangup policy parse failed for name=%s (%s); Agent routing will fail closed",
+                name,
+                exc,
+            )
+            raise AgentStoreReadError(str(exc)) from exc
         return ContextConfig(
             prompt=r["prompt"], greeting=r["greeting"], profile=r["audio_profile"],
             provider=r["provider"],
             voice=r["voice"] if "voice" in cols else None,
             tools=tools,
             tool_configs=tool_configs,
+            hangup_policy=hangup_policy,
             email_recipient=email_recipient,
             email_from=email_from,
             email_enabled=email_enabled,

--- a/src/core/legacy_agent_migration.py
+++ b/src/core/legacy_agent_migration.py
@@ -27,6 +27,10 @@ from src.tools.runtime_config import (
     merge_legacy_tool_overrides,
     normalize_agent_tool_configs,
 )
+from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    dump_agent_hangup_policy,
+)
 
 
 DB_DEFAULT = "/app/data/operator/agents.db"
@@ -38,7 +42,8 @@ _BUNDLED_DEMO_DESCRIPTION = (
 _SLUG_RE = re.compile(r"[^a-z0-9_]+")
 _FIRST_CLASS = {
     "provider", "voice", "greeting", "prompt", "audio_profile", "profile",
-    "tools", "tool_configs", "tool_overrides", "email_recipient", "email_from", "email_enabled",
+    "tools", "tool_configs", "tool_overrides", "hangup_policy",
+    "email_recipient", "email_from", "email_enabled",
     "extension", "role_label",
 }
 
@@ -47,6 +52,7 @@ CREATE TABLE agents (
     id TEXT PRIMARY KEY, slug TEXT NOT NULL UNIQUE, display_name TEXT NOT NULL,
     extension TEXT, role_label TEXT, provider TEXT NOT NULL, voice TEXT,
     greeting TEXT, prompt TEXT NOT NULL, tools_json TEXT, tool_configs_json TEXT,
+    hangup_policy_json TEXT,
     mcp_json TEXT, audio_profile TEXT, extra_json TEXT,
     is_operator_managed INTEGER NOT NULL DEFAULT 1,
     is_active INTEGER NOT NULL DEFAULT 1, is_default INTEGER NOT NULL DEFAULT 0,
@@ -477,7 +483,10 @@ def ensure_legacy_contexts_imported(
                 tool_configs = merge_legacy_tool_overrides(
                     context.get("tool_configs"), context.get("tool_overrides")
                 )
-            except ValueError as exc:
+                hangup_policy_json = dump_agent_hangup_policy(
+                    context.get("hangup_policy")
+                )
+            except (ValueError, HangupPolicyConfigError) as exc:
                 errors.append(f"{original_name}: {exc}")
                 continue
             base = _slugify(str(original_name)) or "agent"
@@ -493,7 +502,7 @@ def ensure_legacy_contexts_imported(
                 context.get("role_label"), context.get("provider") or "", context.get("voice"),
                 context.get("greeting"), prompt, json.dumps(context.get("tools")) if context.get("tools") is not None else None,
                 json.dumps(tool_configs, sort_keys=True) if tool_configs else None,
-                None, context.get("audio_profile") or context.get("profile"),
+                hangup_policy_json, None, context.get("audio_profile") or context.get("profile"),
                 json.dumps(extra) if extra else None, 0, 1, 0, "legacy YAML Context",
                 now, now, "Imported automatically during the v7.4 Agent migration",
                 context.get("email_recipient"), context.get("email_from"),
@@ -515,10 +524,10 @@ def ensure_legacy_contexts_imported(
                 connection.executemany(
                     """INSERT INTO agents (
                        id,slug,display_name,extension,role_label,provider,voice,greeting,prompt,
-                       tools_json,tool_configs_json,mcp_json,audio_profile,extra_json,
+                       tools_json,tool_configs_json,hangup_policy_json,mcp_json,audio_profile,extra_json,
                        is_operator_managed,is_active,is_default,source_file,created_at,updated_at,
                        notes,email_recipient,email_from,email_enabled
-                       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                       ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     rows,
                 )
                 connection.execute(

--- a/src/core/legacy_agent_migration.py
+++ b/src/core/legacy_agent_migration.py
@@ -348,6 +348,36 @@ def _prepare_existing_database_for_replace(db_path: str) -> None:
             pass
 
 
+def _upgrade_existing_agent_schema(db_path: str) -> bool:
+    """Add call-safety columns when Engine starts before the Admin UI."""
+    if not os.path.exists(db_path):
+        return False
+    try:
+        connection = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            table_exists = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='agents'"
+            ).fetchone()
+            if not table_exists:
+                return False
+            columns = {
+                str(row[1]) for row in connection.execute("PRAGMA table_info(agents)")
+            }
+            if "hangup_policy_json" in columns:
+                return False
+            with connection:
+                connection.execute(
+                    "ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT"
+                )
+            return True
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise LegacyAgentMigrationError(
+            f"existing agents.db schema upgrade failed: {exc}"
+        ) from exc
+
+
 def _upgrade_existing_resource_policies(db_path: str) -> int:
     """Promote calendar bindings left in extra_json by early v7.4 builds.
 
@@ -433,6 +463,9 @@ def ensure_legacy_contexts_imported(
     os.makedirs(parent, exist_ok=True)
 
     with _migration_lock(target):
+        # The Engine may be the first service to open an older Agent store.
+        # Ensure it gets the same additive safety column as Admin startup.
+        _upgrade_existing_agent_schema(target)
         # The durable migration marker wins even if the operator later deletes
         # every Agent. Legacy YAML remains on disk for rollback diagnostics and
         # must not resurrect deleted Agents on the next engine restart.

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -100,6 +100,7 @@ class CallSession:
     tool_generation_id: Optional[int] = None
     tool_config_hash: Optional[str] = None
     tool_policy: Dict[str, Any] = field(default_factory=dict)
+    hangup_marker_policy: Dict[str, Any] = field(default_factory=dict)
     
     # Conversation tracking for email tools
     conversation_history: List[Dict[str, Any]] = field(default_factory=list)

--- a/src/core/transport_orchestrator.py
+++ b/src/core/transport_orchestrator.py
@@ -79,6 +79,7 @@ class ContextConfig:
     pipeline: Optional[str] = None  # Pipeline name for modular STT/LLM/TTS (e.g., local_hybrid)
     tools: Optional[list] = None  # In-call tool names for function calling
     tool_configs: Optional[Dict[str, Any]] = None  # v7.4 per-agent tool-scope policies
+    hangup_policy: Optional[Dict[str, Any]] = None  # Per-agent end-call marker override
     background_music: Optional[str] = None  # MOH class name for background music during calls
     connection_audio: Optional[str] = None  # Caller-only ARI media while provider/pipeline connects
     

--- a/src/engine.py
+++ b/src/engine.py
@@ -89,6 +89,7 @@ from .utils.voice_catalog import known_voice_map
 from src.pipelines.base import LLMResponse
 from src.tools.telephony.hangup_policy import (
     DEFAULT_HANGUP_MARKERS,
+    resolve_effective_hangup_policy,
     resolve_hangup_policy,
     text_contains_end_call_intent,
     text_is_short_polite_closing,
@@ -4153,7 +4154,9 @@ class Engine:
                         logger.error(f"Failed to build GoogleProviderConfig for {name}: {e}", exc_info=True)
                         continue
 
-                    hangup_policy = resolve_hangup_policy(getattr(self.config, "tools", None))
+                    hangup_policy = resolve_hangup_policy(
+                        getattr(self.config, "tools", None)
+                    )
                     provider = GoogleLiveProvider(
                         google_cfg,
                         self.on_provider_event,
@@ -13784,7 +13787,9 @@ class Engine:
                 # Guardrail: local LLMs can hallucinate terminal tool calls (especially hangup_call).
                 # Require explicit end-of-call intent in the *user's* transcript before honoring hangup_call.
                 if tool_calls and any((tc.get("name") or "").strip() == "hangup_call" for tc in tool_calls):
-                    hangup_policy = resolve_hangup_policy(getattr(self.config, "tools", None))
+                    hangup_policy = resolve_hangup_policy(
+                        (self._tool_config_for_session(session).get("tools") or {})
+                    )
                     policy_mode = str(hangup_policy.get("mode") or "normal").strip().lower()
                     if policy_mode != "relaxed":
                         end_markers = (hangup_policy.get("markers") or {}).get("end_call", [])
@@ -15530,7 +15535,9 @@ class Engine:
                                 # Jump to tool execution (reuse serial path's tool handling)
                                 # by setting response_text and tool_calls, then breaking out
                             else:
-                                tools_cfg = getattr(self.config, "tools", {}) or {}
+                                tools_cfg = (
+                                    self._tool_config_for_session(session).get("tools") or {}
+                                )
                                 if self._is_pipeline_farewell_without_tool(
                                     transcript_text,
                                     response_text,
@@ -15642,7 +15649,9 @@ class Engine:
                     llm_adapter_key = getattr(getattr(pipeline, "llm_adapter", None), "component_key", None)
                     guardrail_cfg = (llm_options or {}).get("hangup_call_guardrail")
                     guardrail_mode_override = (llm_options or {}).get("hangup_call_guardrail_mode")
-                    hangup_policy = resolve_hangup_policy(getattr(self.config, "tools", None))
+                    hangup_policy = resolve_hangup_policy(
+                        (self._tool_config_for_session(session).get("tools") or {})
+                    )
                     policy_mode = str(hangup_policy.get("mode") or "normal").strip().lower()
                     mode_override = str(guardrail_mode_override or "").strip().lower()
                     effective_mode = mode_override if mode_override in ("relaxed", "normal", "strict") else policy_mode
@@ -15915,7 +15924,9 @@ class Engine:
                                     logger.error("Pipeline playback exception", call_id=call_id, exc_info=True)
 
                     if response_text and not tool_calls:
-                        tools_cfg = getattr(self.config, "tools", {}) or {}
+                        tools_cfg = (
+                            self._tool_config_for_session(session).get("tools") or {}
+                        )
                         if self._is_pipeline_farewell_without_tool(
                             transcript_text,
                             response_text,
@@ -17684,6 +17695,19 @@ class Engine:
 
         agent_policy = getattr(context_config, "tool_configs", None) if context_config else None
         effective = generation.for_agent(agent_policy)
+        agent_hangup_policy = (
+            getattr(context_config, "hangup_policy", None) if context_config else None
+        )
+        resolved_hangup = resolve_effective_hangup_policy(
+            (effective.config.get("tools") or {}),
+            agent_hangup_policy,
+        )
+        tools_cfg = effective.config.setdefault("tools", {})
+        hangup_cfg = tools_cfg.setdefault("hangup_call", {})
+        if not isinstance(hangup_cfg, dict):
+            hangup_cfg = {}
+            tools_cfg["hangup_call"] = hangup_cfg
+        hangup_cfg["policy"] = resolved_hangup["policy"]
         registry = generation.registry
         inline_http = getattr(context_config, "in_call_http_tools", None) if context_config else None
         if isinstance(inline_http, dict) and inline_http:
@@ -17711,7 +17735,14 @@ class Engine:
                 for scope, keys in effective.stale_resource_keys.items()
                 if keys
             },
+            "hangup_markers": {
+                "source": resolved_hangup["source"],
+                "strategy": resolved_hangup["strategy"],
+                "count": resolved_hangup["marker_count"],
+                "digest": resolved_hangup["marker_digest"],
+            },
         }
+        session.hangup_marker_policy = dict(session.tool_policy["hangup_markers"])
         self._overlay_vicidial_tool_runtime(session)
         stale_resource_keys = {
             scope: list(keys)
@@ -17733,6 +17764,9 @@ class Engine:
             generation_id=generation.generation_id,
             config_hash=generation.config_hash,
             resource_policies=effective.policies,
+            hangup_marker_source=resolved_hangup["source"],
+            hangup_marker_count=resolved_hangup["marker_count"],
+            hangup_marker_digest=resolved_hangup["marker_digest"],
             effective_resource_keys={
                 scope: list(keys)
                 for scope, keys in effective.effective_resource_keys.items()
@@ -19278,6 +19312,23 @@ class Engine:
                     )
                 except Exception as e:
                     logger.warning(f"Failed to inject tool context: {e}", call_id=call_id)
+
+            # Hangup markers are resolved into the call's immutable tool config
+            # before provider startup. Call-owned providers may consume the
+            # effective policy directly; Full Local also forwards it to the
+            # Local AI Server as call-scoped tool context.
+            effective_hangup_policy = resolve_hangup_policy(
+                (self._tool_config_for_session(session).get("tools") or {})
+            )
+            if hasattr(provider, "_hangup_policy"):
+                provider._hangup_policy = effective_hangup_policy
+            if isinstance(provider, LocalProvider):
+                marker_meta = dict(getattr(session, "hangup_marker_policy", {}) or {})
+                provider_context["hangup_policy"] = effective_hangup_policy
+                provider_context["hangup_marker_source"] = marker_meta.get(
+                    "source", "global"
+                )
+                provider_context["hangup_marker_digest"] = marker_meta.get("digest")
 
             await provider.start_session(call_id, context=provider_context if provider_context else None)
             logger.info("Provider session started", call_id=call_id, provider=provider_name)

--- a/src/providers/local.py
+++ b/src/providers/local.py
@@ -18,6 +18,10 @@ from ..audio.resampler import resample_audio
 from .base import AIProviderInterface, ProviderCapabilities, ProviderCapabilitiesMixin
 from ..tools.parser import parse_response_with_tools, validate_tool_call, has_tool_intent_markers
 from ..tools.execution_history import stable_tool_call_id
+from ..tools.telephony.hangup_policy import (
+    normalize_hangup_policy,
+    text_contains_end_call_intent,
+)
 
 logger = get_logger(__name__)
 
@@ -100,6 +104,9 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
         self._tool_capability: Dict[str, Any] = {"level": "unknown", "source": "init"}
         # Effective per-call policy: strict | compatible | off
         self._effective_tool_policy: str = "compatible"
+        self._hangup_policy: Dict[str, Any] = normalize_hangup_policy({})
+        self._hangup_marker_source: str = "global"
+        self._hangup_marker_digest: Optional[str] = None
         # Feature flag: structured tool gateway for full-local provider only.
         self._tool_gateway_enabled: bool = bool(getattr(config, "tool_gateway_enabled", True))
 
@@ -632,28 +639,11 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
                 tool_path=tool_path,
             )
 
-    _END_CALL_MARKERS = (
-        "no transcript", "no transcript needed", "don't send a transcript",
-        "no thanks", "no thank you", "thank you", "thanks",
-        "that's all", "nothing else", "end call", "hang up",
-        "goodbye", "bye", "have a good day", "have a great day",
-        "take care", "talk to you later",
-    )
-
     def _user_has_end_call_intent(self, call_id: Optional[str]) -> bool:
         """Check if the last user transcript signals end-of-call intent."""
         user_text = (self._last_user_transcript_by_call.get(call_id or "", "") or "").strip().lower()
-        if not user_text:
-            return False
-        for marker in self._END_CALL_MARKERS:
-            m = marker.lower()
-            if " " in m:
-                if m in user_text:
-                    return True
-            else:
-                if re.search(rf"(?:^|\b){re.escape(m)}(?:\b|$)", user_text):
-                    return True
-        return False
+        markers = (self._hangup_policy.get("markers") or {}).get("end_call", [])
+        return text_contains_end_call_intent(user_text, markers)
 
     async def _process_llm_text_fallback(
         self,
@@ -1359,6 +1349,21 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
         - Prompt sync is required because ai-engine contexts hold the system prompt, while local-ai-server
           owns the local LLM prompt used in full mode.
         """
+        supplied_hangup_policy = (
+            context.get("hangup_policy") if isinstance(context, dict) else None
+        )
+        self._hangup_policy = normalize_hangup_policy(supplied_hangup_policy or {})
+        self._hangup_marker_source = str(
+            (context.get("hangup_marker_source") if isinstance(context, dict) else None)
+            or "global"
+        ).strip()
+        self._hangup_marker_digest = (
+            str(context.get("hangup_marker_digest") or "").strip()
+            if isinstance(context, dict)
+            else None
+        ) or None
+
+        status = None
         try:
             status = await self._request_status(timeout_sec=float(self.connect_timeout) or 2.0)
             if isinstance(status, dict):
@@ -1376,6 +1381,22 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
                     pass
         except Exception:
             logger.debug("Local AI Server status probe failed", call_id=call_id, exc_info=True)
+
+        default_end_markers = (
+            normalize_hangup_policy({}).get("markers") or {}
+        ).get("end_call", [])
+        effective_end_markers = (
+            self._hangup_policy.get("markers") or {}
+        ).get("end_call", [])
+        requires_session_markers = list(effective_end_markers) != list(default_end_markers)
+        supports_session_markers = bool(
+            ((status or {}).get("capabilities") or {}).get("session_hangup_markers")
+        )
+        if self._mode == "full" and requires_session_markers and not supports_session_markers:
+            raise RuntimeError(
+                "Local AI Server does not support call-scoped hangup markers; "
+                "upgrade/rebuild local_ai_server before using this Agent override"
+            )
 
         # Apply system prompt from context (if provided).
         prompt = ""
@@ -1595,6 +1616,9 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
             "allowed_tools": sorted(self._allowed_tools),
             "tools": list(self._allowed_tool_schemas or []),
             "tool_policy": self._effective_tool_policy,
+            "hangup_policy": self._hangup_policy,
+            "hangup_marker_source": self._hangup_marker_source,
+            "hangup_marker_digest": self._hangup_marker_digest,
         }
         try:
             await self.websocket.send(json.dumps(payload, default=str))
@@ -1603,6 +1627,11 @@ class LocalProvider(AIProviderInterface, ProviderCapabilitiesMixin):
                 call_id=call_id,
                 allowed_tools=sorted(self._allowed_tools),
                 policy=self._effective_tool_policy,
+                hangup_marker_source=self._hangup_marker_source,
+                hangup_marker_count=len(
+                    (self._hangup_policy.get("markers") or {}).get("end_call", [])
+                ),
+                hangup_marker_digest=self._hangup_marker_digest,
             )
             return True
         except Exception:

--- a/src/tools/telephony/hangup_policy.py
+++ b/src/tools/telephony/hangup_policy.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from typing import Any, Dict, Iterable, List
+
+
+AGENT_HANGUP_MARKER_STRATEGIES = frozenset({"inherit", "extend", "replace"})
+MAX_AGENT_END_CALL_MARKERS = 100
+MAX_AGENT_END_CALL_MARKER_LENGTH = 160
+
+
+class HangupPolicyConfigError(ValueError):
+    """Raised when an Agent-scoped hangup marker policy is malformed."""
 
 DEFAULT_HANGUP_MARKERS: Dict[str, List[str]] = {
     "end_call": [
@@ -153,6 +164,117 @@ def normalize_hangup_policy(policy: Any) -> Dict[str, Any]:
             policy.get("block_during_contact_capture", DEFAULT_HANGUP_POLICY["block_during_contact_capture"])
         ),
         "markers": markers,
+    }
+
+
+def normalize_agent_hangup_policy(value: Any) -> Dict[str, Any]:
+    """Validate and canonicalize an Agent's end-call marker override.
+
+    An empty document means inherit. ``extend`` appends Agent markers to the
+    global list, while ``replace`` makes the Agent list authoritative. Marker
+    counts and lengths are bounded because this document crosses the Local AI
+    WebSocket boundary once per call.
+    """
+    if value in (None, ""):
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise HangupPolicyConfigError(
+                "hangup_policy_json must contain valid JSON"
+            ) from exc
+    if not isinstance(value, dict):
+        raise HangupPolicyConfigError("hangup policy must be a JSON object")
+
+    unknown = sorted(set(value) - {"strategy", "end_call"})
+    if unknown:
+        raise HangupPolicyConfigError(
+            f"unsupported hangup policy field(s): {', '.join(unknown)}"
+        )
+
+    strategy = str(value.get("strategy") or "inherit").strip().lower()
+    if strategy not in AGENT_HANGUP_MARKER_STRATEGIES:
+        raise HangupPolicyConfigError(
+            "hangup strategy must be inherit, extend, or replace"
+        )
+    raw_markers = value.get("end_call")
+    if strategy == "inherit":
+        if raw_markers not in (None, []):
+            raise HangupPolicyConfigError(
+                "end_call markers may only be set when strategy is extend or replace"
+            )
+        return {}
+    if not isinstance(raw_markers, list):
+        raise HangupPolicyConfigError("end_call must be an array")
+    if len(raw_markers) > MAX_AGENT_END_CALL_MARKERS:
+        raise HangupPolicyConfigError(
+            f"end_call supports at most {MAX_AGENT_END_CALL_MARKERS} markers"
+        )
+
+    markers: List[str] = []
+    seen = set()
+    for raw_marker in raw_markers:
+        if not isinstance(raw_marker, str):
+            raise HangupPolicyConfigError("end_call entries must be strings")
+        marker = " ".join(raw_marker.strip().lower().split())
+        if not marker:
+            raise HangupPolicyConfigError("end_call entries must not be empty")
+        if len(marker) > MAX_AGENT_END_CALL_MARKER_LENGTH:
+            raise HangupPolicyConfigError(
+                f"end_call entries must be at most {MAX_AGENT_END_CALL_MARKER_LENGTH} characters"
+            )
+        if marker not in seen:
+            markers.append(marker)
+            seen.add(marker)
+    if not markers:
+        raise HangupPolicyConfigError(
+            f"{strategy} requires at least one end_call marker"
+        )
+    return {"strategy": strategy, "end_call": markers}
+
+
+def dump_agent_hangup_policy(value: Any) -> str | None:
+    """Return stable JSON for Agent storage, or ``None`` for inheritance."""
+    normalized = normalize_agent_hangup_policy(value)
+    if not normalized:
+        return None
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def resolve_effective_hangup_policy(
+    tools_cfg: Any,
+    agent_policy: Any = None,
+) -> Dict[str, Any]:
+    """Resolve global + Agent markers and return policy plus audit metadata."""
+    policy = normalize_hangup_policy(
+        tools_cfg.get("hangup_call", {}).get("policy")
+        if isinstance(tools_cfg, dict)
+        and isinstance(tools_cfg.get("hangup_call"), dict)
+        else {}
+    )
+    override = normalize_agent_hangup_policy(agent_policy)
+    strategy = override.get("strategy") or "inherit"
+    source = "global"
+    if strategy == "extend":
+        policy["markers"]["end_call"] = _dedupe(
+            list(policy["markers"]["end_call"]) + list(override["end_call"])
+        )
+        source = "agent_extend"
+    elif strategy == "replace":
+        policy["markers"]["end_call"] = list(override["end_call"])
+        source = "agent_replace"
+
+    markers = list(policy["markers"]["end_call"])
+    digest = hashlib.sha256(
+        json.dumps(markers, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "policy": policy,
+        "source": source,
+        "strategy": strategy,
+        "marker_count": len(markers),
+        "marker_digest": digest,
     }
 
 

--- a/src/tools/telephony/hangup_policy.py
+++ b/src/tools/telephony/hangup_policy.py
@@ -187,6 +187,8 @@ def normalize_agent_hangup_policy(value: Any) -> Dict[str, Any]:
     if not isinstance(value, dict):
         raise HangupPolicyConfigError("hangup policy must be a JSON object")
 
+    if any(not isinstance(key, str) for key in value):
+        raise HangupPolicyConfigError("hangup policy field names must be strings")
     unknown = sorted(set(value) - {"strategy", "end_call"})
     if unknown:
         raise HangupPolicyConfigError(

--- a/tests/operator/test_engine_agent_store.py
+++ b/tests/operator/test_engine_agent_store.py
@@ -26,6 +26,44 @@ def test_resolve_builds_context_config(db):
     assert cc.pipeline == "local_hybrid" and cc.pre_call_tools == ["enrich"]
     assert cc.connection_audio == "tone:ring"
 
+
+def test_resolve_reads_optional_hangup_policy_column(db):
+    c = sqlite3.connect(db)
+    c.execute("ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT")
+    c.execute(
+        "UPDATE agents SET hangup_policy_json=? WHERE slug='sales'",
+        (json.dumps({"strategy": "extend", "end_call": ["да", "нет"]}),),
+    )
+    c.commit()
+    c.close()
+    assert EngineAgentStore(db_path=db).resolve("sales").hangup_policy == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }
+
+
+def test_corrupt_hangup_policy_json_fails_closed(db):
+    c = sqlite3.connect(db)
+    c.execute("ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT")
+    c.execute("UPDATE agents SET hangup_policy_json='{bad' WHERE slug='sales'")
+    c.commit()
+    c.close()
+    with pytest.raises(AgentStoreReadError):
+        EngineAgentStore(db_path=db).resolve("sales")
+
+
+def test_invalid_hangup_policy_semantics_fail_closed(db):
+    c = sqlite3.connect(db)
+    c.execute("ALTER TABLE agents ADD COLUMN hangup_policy_json TEXT")
+    c.execute(
+        "UPDATE agents SET hangup_policy_json=? WHERE slug='sales'",
+        (json.dumps({"strategy": "replace", "end_call": []}),),
+    )
+    c.commit()
+    c.close()
+    with pytest.raises(AgentStoreReadError):
+        EngineAgentStore(db_path=db).resolve("sales")
+
 def test_resolve_unknown_returns_none(db):
     assert EngineAgentStore(db_path=db).resolve("nope") is None
 

--- a/tests/test_engine_agent_hangup_policy.py
+++ b/tests/test_engine_agent_hangup_policy.py
@@ -1,0 +1,75 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+from src.core.models import CallSession
+from src.engine import Engine
+
+
+def _generation(global_config):
+    def for_agent(_policy):
+        return SimpleNamespace(
+            config=deepcopy(global_config),
+            policy="inherit",
+            requested_destination_keys=(),
+            effective_destination_keys=(),
+            stale_destination_keys=(),
+            policies={"transfer": "inherit"},
+            effective_resource_keys={"transfer": ()},
+            stale_resource_keys={},
+        )
+
+    return SimpleNamespace(
+        generation_id=7,
+        config_hash="global-hash",
+        registry=SimpleNamespace(),
+        for_agent=for_agent,
+    )
+
+
+def _resolve(agent_hangup_policy):
+    engine = Engine.__new__(Engine)
+    engine._tool_generation = _generation(
+        {
+            "tools": {
+                "hangup_call": {
+                    "policy": {"markers": {"end_call": ["goodbye"]}}
+                }
+            }
+        }
+    )
+    session = CallSession(call_id="call-1", caller_channel_id="call-1")
+    context = SimpleNamespace(
+        tool_configs=None,
+        hangup_policy=agent_hangup_policy,
+        in_call_http_tools=None,
+    )
+    Engine._resolve_session_tool_runtime(engine, session, context)
+    return session
+
+
+def test_agent_extend_markers_are_captured_in_call_snapshot():
+    session = _resolve({"strategy": "extend", "end_call": ["да", "нет"]})
+    markers = session.tool_runtime_config["tools"]["hangup_call"]["policy"][
+        "markers"
+    ]["end_call"]
+    assert markers == ["goodbye", "да", "нет"]
+    assert session.hangup_marker_policy["source"] == "agent_extend"
+    assert session.hangup_marker_policy["count"] == 3
+
+
+def test_agent_replace_markers_excludes_global_values():
+    session = _resolve({"strategy": "replace", "end_call": ["до свидания"]})
+    markers = session.tool_runtime_config["tools"]["hangup_call"]["policy"][
+        "markers"
+    ]["end_call"]
+    assert markers == ["до свидания"]
+    assert session.hangup_marker_policy["source"] == "agent_replace"
+
+
+def test_agent_without_override_inherits_global_markers():
+    session = _resolve(None)
+    markers = session.tool_runtime_config["tools"]["hangup_call"]["policy"][
+        "markers"
+    ]["end_call"]
+    assert markers == ["goodbye"]
+    assert session.hangup_marker_policy["source"] == "global"

--- a/tests/test_legacy_agent_migration_v740.py
+++ b/tests/test_legacy_agent_migration_v740.py
@@ -292,6 +292,39 @@ def test_existing_early_v740_rows_promote_calendar_bindings(tmp_path):
     ] == 0
 
 
+def test_engine_startup_adds_hangup_policy_column_to_existing_store(tmp_path):
+    database = tmp_path / "agents.db"
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE agents (
+                id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL UNIQUE,
+                display_name TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                prompt TEXT NOT NULL,
+                tool_configs_json TEXT,
+                extra_json TEXT
+            );
+            INSERT INTO agents (
+                id, slug, display_name, provider, prompt
+            ) VALUES ('1', 'existing', 'Existing', 'local', 'Keep me');
+            """
+        )
+
+    result = ensure_legacy_contexts_imported({}, db_path=str(database))
+
+    assert result["already_configured"] is True
+    with sqlite3.connect(database) as connection:
+        columns = {
+            row[1] for row in connection.execute("PRAGMA table_info(agents)")
+        }
+        assert "hangup_policy_json" in columns
+        assert connection.execute(
+            "SELECT slug, prompt, hangup_policy_json FROM agents"
+        ).fetchall() == [("existing", "Keep me", None)]
+
+
 def test_invalid_legacy_context_fails_without_creating_database(tmp_path):
     database = tmp_path / "agents.db"
     with pytest.raises(LegacyAgentMigrationError, match="expected mapping"):

--- a/tests/test_legacy_agent_migration_v740.py
+++ b/tests/test_legacy_agent_migration_v740.py
@@ -28,6 +28,10 @@ def test_import_is_atomic_complete_and_collision_safe(tmp_path):
                         "destination_keys": ["support"],
                     }
                 },
+                "hangup_policy": {
+                    "strategy": "extend",
+                    "end_call": [" Да ", "нет", "да"],
+                },
                 "pipeline": "custom",
                 "tool_overrides": {
                     "google_calendar": {"selected_calendars": ["sales-calendar"]},
@@ -48,6 +52,10 @@ def test_import_is_atomic_complete_and_collision_safe(tmp_path):
         first = next(row for row in rows if row["display_name"] == "Sales-East")
         assert json.loads(first["tools_json"]) == ["blind_transfer"]
         assert json.loads(first["tool_configs_json"])["transfer"]["destination_keys"] == ["support"]
+        assert json.loads(first["hangup_policy_json"]) == {
+            "strategy": "extend",
+            "end_call": ["да", "нет"],
+        }
         policies = json.loads(first["tool_configs_json"])
         assert policies["google_calendar"] == {
             "calendar_policy": "selected",

--- a/tests/test_local_ai_hangup_only_streaming.py
+++ b/tests/test_local_ai_hangup_only_streaming.py
@@ -116,6 +116,24 @@ async def test_invalid_session_marker_policy_disables_hangup_call():
 
 
 @pytest.mark.asyncio
+async def test_empty_session_marker_policy_disables_hangup_call():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "empty-policy",
+            "allowed_tools": ["hangup_call", "request_transcript"],
+            "hangup_policy": {"markers": {"end_call": []}},
+        },
+    )
+    assert session.hangup_marker_source == "invalid"
+    assert session.hangup_end_call_markers == []
+    assert session.allowed_tools == ["request_transcript"]
+
+
+@pytest.mark.asyncio
 async def test_call_id_mismatch_clears_stale_session_markers_without_new_context():
     server, session = _server_and_session([])
     await server._handle_tool_context(
@@ -141,3 +159,33 @@ async def test_call_id_mismatch_clears_stale_session_markers_without_new_context
     assert session.hangup_end_call_markers is None
     assert session.hangup_marker_source == "global"
     assert session.hangup_marker_digest is None
+
+
+@pytest.mark.asyncio
+async def test_audio_call_id_mismatch_clears_stale_session_markers_without_new_context():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "russian-call",
+            "allowed_tools": ["hangup_call"],
+            "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
+        },
+    )
+
+    await server._handle_audio_payload(
+        None,
+        session,
+        {"type": "audio", "call_id": "english-call", "mode": "stt", "data": ""},
+    )
+
+    assert session.call_id == "english-call"
+    assert session.allowed_tools == []
+    assert session.tool_schemas == []
+    assert session.tool_policy == "auto"
+    assert session.hangup_end_call_markers is None
+    assert session.hangup_marker_source == "global"
+    assert session.hangup_marker_digest is None
+    assert session.tool_context_call_id is None

--- a/tests/test_local_ai_hangup_only_streaming.py
+++ b/tests/test_local_ai_hangup_only_streaming.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
+import json
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -23,6 +25,19 @@ def _server_and_session(tools):
     server = object.__new__(server_mod.LocalAIServer)
     server.tool_gateway_enabled = True
     return server, session_mod.SessionContext(allowed_tools=tools)
+
+
+def _scoped_marker_fields(markers):
+    normalized = [" ".join(marker.strip().lower().split()) for marker in markers]
+    digest = hashlib.sha256(
+        json.dumps(normalized, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ).hexdigest()[:16]
+    return {
+        "protocol_version": _load("constants").PROTOCOL_VERSION,
+        "hangup_marker_digest": digest,
+    }
 
 
 def test_hangup_only_normal_turn_can_stream():
@@ -66,6 +81,12 @@ def test_session_markers_are_used_instead_of_global_defaults():
     assert server._tool_gateway_blocks_streaming(session, "goodbye") is False
 
 
+def test_replace_markers_do_not_retain_explicit_english_commands():
+    server, _session = _server_and_session(["hangup_call"])
+    assert server._text_has_end_call_intent("Please end call", ["да"]) is False
+    assert server._text_has_end_call_intent("да", ["да"]) is True
+
+
 @pytest.mark.asyncio
 async def test_tool_context_resets_markers_between_agents_on_reused_session():
     server, session = _server_and_session([])
@@ -78,6 +99,7 @@ async def test_tool_context_resets_markers_between_agents_on_reused_session():
             "allowed_tools": ["hangup_call"],
             "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
             "hangup_marker_source": "agent_replace",
+            **_scoped_marker_fields(["да", "нет"]),
         },
     )
     assert server._tool_gateway_blocks_streaming(session, "да") is True
@@ -108,6 +130,8 @@ async def test_invalid_session_marker_policy_disables_hangup_call():
             "call_id": "invalid-policy",
             "allowed_tools": ["hangup_call", "request_transcript"],
             "hangup_policy": {"markers": {"end_call": "да"}},
+            "protocol_version": _load("constants").PROTOCOL_VERSION,
+            "hangup_marker_digest": "0123456789abcdef",
         },
     )
     assert session.hangup_marker_source == "invalid"
@@ -126,10 +150,56 @@ async def test_empty_session_marker_policy_disables_hangup_call():
             "call_id": "empty-policy",
             "allowed_tools": ["hangup_call", "request_transcript"],
             "hangup_policy": {"markers": {"end_call": []}},
+            "protocol_version": _load("constants").PROTOCOL_VERSION,
+            "hangup_marker_digest": "0123456789abcdef",
         },
     )
     assert session.hangup_marker_source == "invalid"
     assert session.hangup_end_call_markers == []
+    assert session.allowed_tools == ["request_transcript"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protocol_version", [None, 999])
+async def test_scoped_markers_with_unsupported_protocol_disable_hangup_call(
+    protocol_version,
+):
+    server, session = _server_and_session([])
+    payload = {
+        "type": "tool_context",
+        "call_id": "bad-version",
+        "allowed_tools": ["hangup_call", "request_transcript"],
+        "hangup_policy": {"markers": {"end_call": ["да"]}},
+        **_scoped_marker_fields(["да"]),
+    }
+    payload["protocol_version"] = protocol_version
+
+    await server._handle_tool_context(None, session, payload)
+
+    assert session.hangup_marker_source == "invalid"
+    assert session.hangup_end_call_markers == []
+    assert session.allowed_tools == ["request_transcript"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_markers_with_mismatched_digest_disable_hangup_call():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "bad-digest",
+            "allowed_tools": ["hangup_call", "request_transcript"],
+            "hangup_policy": {"markers": {"end_call": ["да"]}},
+            "protocol_version": _load("constants").PROTOCOL_VERSION,
+            "hangup_marker_digest": "0123456789abcdef",
+        },
+    )
+
+    assert session.hangup_marker_source == "invalid"
+    assert session.hangup_end_call_markers == []
+    assert session.hangup_marker_digest is None
     assert session.allowed_tools == ["request_transcript"]
 
 
@@ -144,6 +214,7 @@ async def test_call_id_mismatch_clears_stale_session_markers_without_new_context
             "call_id": "russian-call",
             "allowed_tools": ["hangup_call"],
             "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
+            **_scoped_marker_fields(["да", "нет"]),
         },
     )
     server._build_llm_tool_response_payload = AsyncMock(return_value={"type": "llm_tool_response"})
@@ -172,6 +243,7 @@ async def test_audio_call_id_mismatch_clears_stale_session_markers_without_new_c
             "call_id": "russian-call",
             "allowed_tools": ["hangup_call"],
             "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
+            **_scoped_marker_fields(["да", "нет"]),
         },
     )
 

--- a/tests/test_local_ai_hangup_only_streaming.py
+++ b/tests/test_local_ai_hangup_only_streaming.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
 
 
 LOCAL_AI_DIR = str(Path(__file__).resolve().parents[1] / "local_ai_server")
@@ -54,3 +57,87 @@ def test_disabled_gateway_never_blocks_streaming():
     server, session = _server_and_session(["transfer"])
     server.tool_gateway_enabled = False
     assert server._tool_gateway_blocks_streaming(session, "Transfer me") is False
+
+
+def test_session_markers_are_used_instead_of_global_defaults():
+    server, session = _server_and_session(["hangup_call"])
+    session.hangup_end_call_markers = ["да", "нет"]
+    assert server._tool_gateway_blocks_streaming(session, "да") is True
+    assert server._tool_gateway_blocks_streaming(session, "goodbye") is False
+
+
+@pytest.mark.asyncio
+async def test_tool_context_resets_markers_between_agents_on_reused_session():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "russian-call",
+            "allowed_tools": ["hangup_call"],
+            "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
+            "hangup_marker_source": "agent_replace",
+        },
+    )
+    assert server._tool_gateway_blocks_streaming(session, "да") is True
+    assert session.hangup_marker_source == "agent_replace"
+
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "english-call",
+            "allowed_tools": ["hangup_call"],
+        },
+    )
+    assert session.hangup_end_call_markers is None
+    assert server._tool_gateway_blocks_streaming(session, "да") is False
+    assert server._tool_gateway_blocks_streaming(session, "goodbye") is True
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_marker_policy_disables_hangup_call():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "invalid-policy",
+            "allowed_tools": ["hangup_call", "request_transcript"],
+            "hangup_policy": {"markers": {"end_call": "да"}},
+        },
+    )
+    assert session.hangup_marker_source == "invalid"
+    assert session.hangup_end_call_markers == []
+    assert session.allowed_tools == ["request_transcript"]
+
+
+@pytest.mark.asyncio
+async def test_call_id_mismatch_clears_stale_session_markers_without_new_context():
+    server, session = _server_and_session([])
+    await server._handle_tool_context(
+        None,
+        session,
+        {
+            "type": "tool_context",
+            "call_id": "russian-call",
+            "allowed_tools": ["hangup_call"],
+            "hangup_policy": {"markers": {"end_call": ["да", "нет"]}},
+        },
+    )
+    server._build_llm_tool_response_payload = AsyncMock(return_value={"type": "llm_tool_response"})
+    server._send_json = AsyncMock()
+
+    await server._handle_llm_tool_request(
+        None,
+        session,
+        {"type": "llm_tool_request", "call_id": "english-call", "text": "hello"},
+    )
+
+    assert session.allowed_tools == []
+    assert session.hangup_end_call_markers is None
+    assert session.hangup_marker_source == "global"
+    assert session.hangup_marker_digest is None

--- a/tests/test_local_ai_server_protocol_schema.py
+++ b/tests/test_local_ai_server_protocol_schema.py
@@ -108,6 +108,15 @@ def test_tool_context_with_incomplete_hangup_policy_rejected():
         })
 
 
+@requires_jsonschema
+def test_tool_context_with_empty_end_call_markers_rejected():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_payload({
+            "type": "tool_context",
+            "hangup_policy": {"markers": {"end_call": []}},
+        })
+
+
 # --- ToolResult ---
 
 

--- a/tests/test_local_ai_server_protocol_schema.py
+++ b/tests/test_local_ai_server_protocol_schema.py
@@ -70,7 +70,7 @@ def test_tool_context_full_payload_validates():
             "markers": {"end_call": ["goodbye", "да", "нет"]},
         },
         "hangup_marker_source": "agent_extend",
-        "hangup_marker_digest": "0123456789abcdef",
+        "hangup_marker_digest": "1a6c689923e0cb01",
         "protocol_version": 2,
     })
 
@@ -115,6 +115,23 @@ def test_tool_context_with_empty_end_call_markers_rejected():
             "type": "tool_context",
             "hangup_policy": {"markers": {"end_call": []}},
         })
+
+
+@requires_jsonschema
+@pytest.mark.parametrize(
+    "missing_field", ["protocol_version", "hangup_marker_digest"]
+)
+def test_tool_context_scoped_policy_requires_version_and_digest(missing_field):
+    payload = {
+        "type": "tool_context",
+        "hangup_policy": {"markers": {"end_call": ["да"]}},
+        "protocol_version": 2,
+        "hangup_marker_digest": "0123456789abcdef",
+    }
+    payload.pop(missing_field)
+
+    with pytest.raises(jsonschema.ValidationError):
+        validate_payload(payload)
 
 
 # --- ToolResult ---

--- a/tests/test_local_ai_server_protocol_schema.py
+++ b/tests/test_local_ai_server_protocol_schema.py
@@ -66,6 +66,11 @@ def test_tool_context_full_payload_validates():
             }
         ],
         "tool_policy": "auto",
+        "hangup_policy": {
+            "markers": {"end_call": ["goodbye", "да", "нет"]},
+        },
+        "hangup_marker_source": "agent_extend",
+        "hangup_marker_digest": "0123456789abcdef",
         "protocol_version": 2,
     })
 
@@ -91,6 +96,15 @@ def test_tool_context_with_invalid_tool_policy_rejected():
         validate_payload({
             "type": "tool_context",
             "tool_policy": "not-a-real-policy",
+        })
+
+
+@requires_jsonschema
+def test_tool_context_with_incomplete_hangup_policy_rejected():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_payload({
+            "type": "tool_context",
+            "hangup_policy": {"markers": {}},
         })
 
 

--- a/tests/test_local_provider_audio_timing.py
+++ b/tests/test_local_provider_audio_timing.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -415,6 +416,52 @@ def test_local_tool_policy_can_be_overridden_in_config():
     provider = LocalProvider(LocalProviderConfig(tool_call_policy="strict"), on_event=on_event)
     provider._tool_capability = {"level": "none"}
     assert provider._resolve_tool_policy() == "strict"
+
+
+@pytest.mark.asyncio
+async def test_full_local_fails_closed_when_server_cannot_accept_custom_markers():
+    provider = LocalProvider(LocalProviderConfig(mode="full"), on_event=None)
+    provider._request_status = AsyncMock(return_value={"capabilities": {}})
+    provider._apply_system_prompt = AsyncMock(return_value=True)
+    provider._send_tool_context = AsyncMock(return_value=True)
+
+    with pytest.raises(RuntimeError, match="call-scoped hangup markers"):
+        await provider._prime_runtime_status_and_context(
+            context={
+                "prompt": "p",
+                "hangup_policy": {
+                    "markers": {"end_call": ["goodbye", "да", "нет"]}
+                },
+                "hangup_marker_source": "agent_extend",
+            },
+            call_id="call-old-server",
+        )
+
+
+@pytest.mark.asyncio
+async def test_tool_context_sends_effective_call_scoped_markers():
+    provider = LocalProvider(LocalProviderConfig(mode="full"), on_event=None)
+    provider.websocket = _FakeWebSocket([])
+    provider._allowed_tools = {"hangup_call"}
+    provider._hangup_policy = {
+        "mode": "normal",
+        "enforce_transcript_offer": True,
+        "block_during_contact_capture": True,
+        "markers": {
+            "end_call": ["да", "нет"],
+            "assistant_farewell": ["goodbye"],
+            "affirmative": ["yes"],
+            "negative": ["no"],
+        },
+    }
+    provider._hangup_marker_source = "agent_replace"
+    provider._hangup_marker_digest = "0123456789abcdef"
+
+    assert await provider._send_tool_context(call_id="call-russian") is True
+    payload = json.loads(provider.websocket.sent[-1])
+    assert payload["hangup_policy"]["markers"]["end_call"] == ["да", "нет"]
+    assert payload["hangup_marker_source"] == "agent_replace"
+    assert payload["hangup_marker_digest"] == "0123456789abcdef"
 
 
 @pytest.mark.asyncio

--- a/tests/test_russian_stt_support.py
+++ b/tests/test_russian_stt_support.py
@@ -286,6 +286,15 @@ class TestProtocolContractSchema:
         stt_props = defs["StatusResponse"]["properties"]["models"]["properties"]["stt"]["properties"]
         assert "language" in stt_props
 
+    def test_status_response_advertises_session_hangup_markers(self):
+        pc = self._load_pc()
+        status = pc.PROTOCOL_SCHEMA["$defs"]["StatusResponse"]
+        assert "capabilities" in status["required"]
+        marker_capability = status["properties"]["capabilities"]["properties"][
+            "session_hangup_markers"
+        ]
+        assert marker_capability == {"const": True}
+
 
 # ---------------------------------------------------------------------------
 # Admin UI SwitchModelRequest + payload builder tests

--- a/tests/tools/telephony/test_hangup_policy.py
+++ b/tests/tools/telephony/test_hangup_policy.py
@@ -1,9 +1,74 @@
+import json
+
+import pytest
+
 from src.tools.telephony.hangup_policy import (
+    HangupPolicyConfigError,
+    dump_agent_hangup_policy,
+    normalize_agent_hangup_policy,
+    resolve_effective_hangup_policy,
     resolve_hangup_policy,
     text_contains_marker,
     text_contains_end_call_intent,
     text_is_short_polite_closing,
 )
+
+
+def test_agent_hangup_policy_inherits_by_default():
+    resolved = resolve_effective_hangup_policy({}, None)
+    assert resolved["source"] == "global"
+    assert resolved["strategy"] == "inherit"
+    assert "goodbye" in resolved["policy"]["markers"]["end_call"]
+
+
+def test_agent_hangup_policy_extends_global_markers_without_mutation():
+    tools = {"hangup_call": {"policy": {"markers": {"end_call": ["goodbye"]}}}}
+    resolved = resolve_effective_hangup_policy(
+        tools,
+        {"strategy": "extend", "end_call": ["Да", "нет", "да"]},
+    )
+    assert resolved["source"] == "agent_extend"
+    assert resolved["policy"]["markers"]["end_call"] == ["goodbye", "да", "нет"]
+    assert tools["hangup_call"]["policy"]["markers"]["end_call"] == ["goodbye"]
+
+
+def test_agent_hangup_policy_can_replace_global_markers():
+    resolved = resolve_effective_hangup_policy(
+        {}, {"strategy": "replace", "end_call": ["до свидания"]}
+    )
+    assert resolved["source"] == "agent_replace"
+    assert resolved["policy"]["markers"]["end_call"] == ["до свидания"]
+    assert resolved["marker_count"] == 1
+    assert len(resolved["marker_digest"]) == 16
+
+
+def test_agent_hangup_policy_dump_is_stable_and_inherit_is_null():
+    assert dump_agent_hangup_policy(None) is None
+    dumped = dump_agent_hangup_policy(
+        {"strategy": "extend", "end_call": [" Да ", "нет"]}
+    )
+    assert json.loads(dumped) == {
+        "strategy": "extend",
+        "end_call": ["да", "нет"],
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "not-json",
+        [],
+        {"strategy": "all", "end_call": ["bye"]},
+        {"strategy": "inherit", "end_call": ["bye"]},
+        {"strategy": "extend", "end_call": []},
+        {"strategy": "replace", "end_call": [""]},
+        {"strategy": "extend", "end_call": [123]},
+        {"strategy": "extend", "end_call": ["x"], "unknown": True},
+    ],
+)
+def test_invalid_agent_hangup_policy_is_rejected(value):
+    with pytest.raises(HangupPolicyConfigError):
+        normalize_agent_hangup_policy(value)
 
 
 def test_default_end_call_markers_include_natural_closing_phrases():

--- a/tests/tools/telephony/test_hangup_policy.py
+++ b/tests/tools/telephony/test_hangup_policy.py
@@ -64,6 +64,7 @@ def test_agent_hangup_policy_dump_is_stable_and_inherit_is_null():
         {"strategy": "replace", "end_call": [""]},
         {"strategy": "extend", "end_call": [123]},
         {"strategy": "extend", "end_call": ["x"], "unknown": True},
+        {1: "not-a-string-key"},
     ],
 )
 def test_invalid_agent_hangup_policy_is_rejected(value):


### PR DESCRIPTION
## Summary

- add nullable first-class Agent hangup policy with inherit, extend, and replace strategies
- snapshot effective markers per call across hosted providers, pipelines, and Full Local
- negotiate and isolate Full Local markers by call_id, with fail-closed old-server and malformed-policy behavior
- add Admin UI controls, migration/export support, protocol documentation, and regression coverage

## Validation

- 552 Admin UI backend tests passed
- 289 Admin UI frontend tests passed
- frontend lint passed with the existing warning baseline
- frontend production build passed
- 72 focused hangup/runtime tests passed, with 3 dependency-based skips
- 42 migration, isolation, store, and protocol tests passed, with 4 dependency-based skips
- 26 runtime guidance/config/protocol tests passed, with 4 dependency-based skips
- compileall, release documentation check, committed-secrets check, and diff check passed

## Deployment plan

After the branch is published, deploy `ai_engine`, `local_ai_server`, and `admin_ui` together on voiprnd. Verify health, the Local AI capability flag, Agent CRUD round-trip, and the Hangup Guardrail controls in the browser. No real outbound call is placed without an explicit test destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-agent end-call marker settings with inherit, extend, and replace options.
  * Markers are normalized, deduplicated, validated, and preserved when agents are imported or exported.
  * Call sessions use the selected agent policy with isolation between calls.
* **Bug Fixes**
  * Invalid policies fail safely without unintended global-marker fallback.
  * Added compatibility checks for Local AI Server support.
* **Documentation**
  * Documented agent-specific markers, storage, behavior, and protocol requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->