### PR TITLE
feat: add bounded call metadata persistence and correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in call metadata persistence and call-local correction** ([#625](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/625), [#627](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/627)): individual pre-call HTTP lookup outputs can be selected for bounded, non-authoritative persistence in Call History, exposed to prompts and post-call webhooks, filtered by exact field/value, and included in CSV/JSON exports. Fields explicitly marked correctable can be changed during the active call only when the Agent is separately granted `update_call_metadata`; corrections preserve the original pre-call snapshot and never write back to the CRM or mutate caller identity, routing, consent/DNC, transfer, disposition, provider, or external-dialer state. The Admin UI adds per-output persistence/correction controls plus metadata provenance in Call History. Existing databases receive two additive SQLite columns automatically; existing records remain valid with empty metadata, and disabling the policy stops future persistence without removing historical values.
+
 ## [7.5.6] - 2026-08-26
 
 ### Added

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -50,8 +50,11 @@ _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 def _csv_safe_cell(value: Any) -> Any:
     """Prevent spreadsheet applications from evaluating untrusted CSV cells."""
-    if isinstance(value, str) and value.startswith(("=", "+", "-", "@", "\t", "\r")):
-        return f"'{value}"
+    if isinstance(value, str):
+        starts_with_control = value.startswith(("\t", "\r", "\n"))
+        starts_with_formula = value.lstrip().startswith(("=", "+", "-", "@"))
+        if starts_with_control or starts_with_formula:
+            return f"'{value}"
     return value
 
 

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import wave
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pathlib import Path
 
@@ -46,6 +46,13 @@ def _get_server_timezone():
 
 
 _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _csv_safe_cell(value: Any) -> Any:
+    """Prevent spreadsheet applications from evaluating untrusted CSV cells."""
+    if isinstance(value, str) and value.startswith(("=", "+", "-", "@", "\t", "\r")):
+        return f"'{value}"
+    return value
 
 
 def _parse_datetime_param(value: Optional[str], *, end_of_day_if_date_only: bool) -> Optional[datetime]:
@@ -1037,7 +1044,7 @@ async def export_calls_csv(
     
     # Data rows
     for r in records:
-        writer.writerow([
+        row = [
             r.id, r.call_id, r.caller_number or "", r.caller_name or "",
             r.start_time.isoformat() if r.start_time else "",
             r.end_time.isoformat() if r.end_time else "",
@@ -1047,7 +1054,8 @@ async def export_calls_csv(
             len(r.tool_calls), round(r.avg_turn_latency_ms, 2), round(r.max_turn_latency_ms, 2),
             r.total_turns, r.barge_in_count,
             json.dumps(getattr(r, "call_metadata", {}) or {}, ensure_ascii=False, sort_keys=True),
-        ])
+        ]
+        writer.writerow([_csv_safe_cell(value) for value in row])
     
     csv_content = output.getvalue()
     

--- a/admin_ui/backend/api/calls.py
+++ b/admin_ui/backend/api/calls.py
@@ -147,6 +147,8 @@ class CallRecordResponse(BaseModel):
     external_direction: Optional[str] = None
     external_disposition: Optional[str] = None
     external_metadata: dict = Field(default_factory=dict)
+    call_metadata: dict = Field(default_factory=dict)
+    call_metadata_updates: list = Field(default_factory=list)
     tool_calls: list = Field(default_factory=list)
     pre_call_tool_calls: list = Field(default_factory=list)
     post_call_tool_calls: list = Field(default_factory=list)
@@ -359,6 +361,8 @@ def _record_to_response(record, agent_names: Optional[Dict[str, str]] = None) ->
         external_direction=getattr(record, "external_direction", None),
         external_disposition=getattr(record, "external_disposition", None),
         external_metadata=getattr(record, "external_metadata", {}) or {},
+        call_metadata=getattr(record, "call_metadata", {}) or {},
+        call_metadata_updates=getattr(record, "call_metadata_updates", []) or [],
         tool_calls=_normalize_tool_calls(record.tool_calls or []),
         pre_call_tool_calls=_normalize_phase_tool_calls(
             getattr(record, "pre_call_tool_calls", None) or [], "pre_call"
@@ -485,6 +489,8 @@ async def list_calls(
     min_duration: Optional[float] = Query(None, description="Minimum duration in seconds"),
     max_duration: Optional[float] = Query(None, description="Maximum duration in seconds"),
     transcript_search: Optional[str] = Query(None, min_length=1, max_length=256, description="Search within conversation transcripts (case-insensitive substring match)"),
+    call_metadata_key: Optional[str] = Query(None, max_length=64, description="Exact call metadata field name"),
+    call_metadata_value: Optional[str] = Query(None, max_length=1024, description="Exact call metadata value"),
     order_by: str = Query("start_time", description="Column to order by"),
     order_dir: str = Query("DESC", description="Order direction (ASC/DESC)"),
 ):
@@ -495,6 +501,15 @@ async def list_calls(
     
     parsed_start = _parse_datetime_param(start_date, end_of_day_if_date_only=False)
     parsed_end = _parse_datetime_param(end_date, end_of_day_if_date_only=True)
+    if (call_metadata_key is None) != (call_metadata_value is None):
+        raise HTTPException(status_code=422, detail="call_metadata_key and call_metadata_value must be provided together")
+    if call_metadata_key is not None:
+        from src.core.call_metadata import CallMetadataValidationError, validate_call_metadata_key
+
+        try:
+            call_metadata_key = validate_call_metadata_key(call_metadata_key)
+        except CallMetadataValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     
     # Get total count (with all filters for accurate pagination)
     total = await store.count(
@@ -510,6 +525,8 @@ async def list_calls(
         min_duration=min_duration,
         max_duration=max_duration,
         transcript_search=transcript_search,
+        call_metadata_key=call_metadata_key,
+        call_metadata_value=call_metadata_value,
     )
     
     # Get paginated records
@@ -529,6 +546,8 @@ async def list_calls(
         min_duration=min_duration,
         max_duration=max_duration,
         transcript_search=transcript_search,
+        call_metadata_key=call_metadata_key,
+        call_metadata_value=call_metadata_value,
         order_by=order_by,
         order_dir=order_dir,
         include_details=False,
@@ -963,6 +982,8 @@ async def export_calls_csv(
     has_tool_calls: Optional[bool] = Query(None, description="Filter by tool usage"),
     min_duration: Optional[float] = Query(None, description="Minimum duration in seconds"),
     max_duration: Optional[float] = Query(None, description="Maximum duration in seconds"),
+    call_metadata_key: Optional[str] = Query(None, max_length=64),
+    call_metadata_value: Optional[str] = Query(None, max_length=1024),
 ):
     """
     Export call records as CSV with all filters matching the UI.
@@ -971,6 +992,14 @@ async def export_calls_csv(
     
     parsed_start = _parse_datetime_param(start_date, end_of_day_if_date_only=False)
     parsed_end = _parse_datetime_param(end_date, end_of_day_if_date_only=True)
+    if (call_metadata_key is None) != (call_metadata_value is None):
+        raise HTTPException(status_code=422, detail="call_metadata_key and call_metadata_value must be provided together")
+    if call_metadata_key is not None:
+        from src.core.call_metadata import CallMetadataValidationError, validate_call_metadata_key
+        try:
+            call_metadata_key = validate_call_metadata_key(call_metadata_key)
+        except CallMetadataValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     
     # Get all matching records (limit to 10000 for safety)
     records = await store.list(
@@ -987,6 +1016,8 @@ async def export_calls_csv(
         has_tool_calls=has_tool_calls,
         min_duration=min_duration,
         max_duration=max_duration,
+        call_metadata_key=call_metadata_key,
+        call_metadata_value=call_metadata_value,
         include_details=True,
     )
     
@@ -1001,7 +1032,7 @@ async def export_calls_csv(
         "Provider", "Pipeline", "Context", "Outcome",
         "Transfer Destination", "Error Message",
         "Tool Calls", "Avg Latency (ms)", "Max Latency (ms)",
-        "Total Turns", "Barge-ins"
+        "Total Turns", "Barge-ins", "Call Metadata"
     ])
     
     # Data rows
@@ -1014,7 +1045,8 @@ async def export_calls_csv(
             r.provider_name, r.pipeline_name or "", r.context_name or "", r.outcome,
             r.transfer_destination or "", r.error_message or "",
             len(r.tool_calls), round(r.avg_turn_latency_ms, 2), round(r.max_turn_latency_ms, 2),
-            r.total_turns, r.barge_in_count
+            r.total_turns, r.barge_in_count,
+            json.dumps(getattr(r, "call_metadata", {}) or {}, ensure_ascii=False, sort_keys=True),
         ])
     
     csv_content = output.getvalue()
@@ -1041,6 +1073,8 @@ async def export_calls_json(
     has_tool_calls: Optional[bool] = Query(None, description="Filter by tool usage"),
     min_duration: Optional[float] = Query(None, description="Minimum duration in seconds"),
     max_duration: Optional[float] = Query(None, description="Maximum duration in seconds"),
+    call_metadata_key: Optional[str] = Query(None, max_length=64),
+    call_metadata_value: Optional[str] = Query(None, max_length=1024),
 ):
     """
     Export call records as JSON with all filters matching the UI.
@@ -1049,6 +1083,14 @@ async def export_calls_json(
     
     parsed_start = _parse_datetime_param(start_date, end_of_day_if_date_only=False)
     parsed_end = _parse_datetime_param(end_date, end_of_day_if_date_only=True)
+    if (call_metadata_key is None) != (call_metadata_value is None):
+        raise HTTPException(status_code=422, detail="call_metadata_key and call_metadata_value must be provided together")
+    if call_metadata_key is not None:
+        from src.core.call_metadata import CallMetadataValidationError, validate_call_metadata_key
+        try:
+            call_metadata_key = validate_call_metadata_key(call_metadata_key)
+        except CallMetadataValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     
     # Get all matching records (limit to 10000 for safety)
     records = await store.list(
@@ -1065,6 +1107,8 @@ async def export_calls_json(
         has_tool_calls=has_tool_calls,
         min_duration=min_duration,
         max_duration=max_duration,
+        call_metadata_key=call_metadata_key,
+        call_metadata_value=call_metadata_value,
         include_details=True,
     )
     

--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -4,7 +4,7 @@ Tools API endpoints for testing HTTP tools before saving.
 import asyncio
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator, model_validator
 from typing import Dict, Any, Optional, List, Literal
 import httpx
 import json
@@ -1007,8 +1007,8 @@ class ManagedToolParameter(BaseModel):
 class ManagedCallMetadataField(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    persist: bool = False
-    correctable: bool = False
+    persist: StrictBool = False
+    correctable: StrictBool = False
     description: str = ""
     max_length: int = 1024
 

--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -913,6 +913,7 @@ BUILTIN_RESERVED_TOOL_NAMES = frozenset({
     "transfer", "attended_transfer", "cancel_transfer", "hangup_call",
     "leave_voicemail", "check_extension_status",
     "send_email_summary", "request_transcript",
+    "update_call_metadata",
     "google_calendar", "microsoft_calendar",
     # Engine-registered tool names the AI calls (may differ from config keys).
     "transfer_call", "transfer_to_queue", "live_agent_transfer",
@@ -942,6 +943,7 @@ _PASSTHROUGH_FIELDS = (
     "body_template",
     "payload_template",
     "output_variables",
+    "call_metadata_fields",
     "hold_audio_file",
     "hold_audio_threshold_ms",
     "generate_summary",
@@ -1002,6 +1004,23 @@ class ManagedToolParameter(BaseModel):
     required: bool = False
 
 
+class ManagedCallMetadataField(BaseModel):
+    persist: bool = False
+    correctable: bool = False
+    description: str = ""
+    max_length: int = 1024
+
+    @model_validator(mode="after")
+    def validate_policy(self):
+        if self.correctable and not self.persist:
+            raise ValueError("correctable requires persist=true")
+        if len(self.description) > 240:
+            raise ValueError("description must be 240 characters or fewer")
+        if not 1 <= self.max_length <= 1024:
+            raise ValueError("max_length must be between 1 and 1024")
+        return self
+
+
 class ManagedToolWrite(BaseModel):
     """Body for create (POST) and full replace (PUT)."""
     name: Optional[str] = None  # required for POST; taken from path on PUT
@@ -1017,6 +1036,7 @@ class ManagedToolWrite(BaseModel):
     body_template: Optional[str] = None
     payload_template: Optional[str] = None
     output_variables: Optional[Dict[str, str]] = None
+    call_metadata_fields: Optional[Dict[str, ManagedCallMetadataField]] = None
     hold_audio_file: Optional[str] = None
     hold_audio_threshold_ms: Optional[int] = None
     generate_summary: Optional[bool] = None
@@ -1098,6 +1118,7 @@ class ManagedToolPatch(BaseModel):
     body_template: Optional[str] = None
     payload_template: Optional[str] = None
     output_variables: Optional[Dict[str, str]] = None
+    call_metadata_fields: Optional[Dict[str, ManagedCallMetadataField]] = None
     hold_audio_file: Optional[str] = None
     hold_audio_threshold_ms: Optional[int] = None
     generate_summary: Optional[bool] = None
@@ -1343,6 +1364,19 @@ def _build_tool_doc(data: Dict[str, Any], phase: str) -> Dict[str, Any]:
         doc["parameters"] = [
             p if isinstance(p, dict) else p.model_dump() for p in params
         ]
+    raw_metadata_fields = doc.get("call_metadata_fields")
+    if raw_metadata_fields is not None:
+        if phase != "pre_call":
+            raise HTTPException(status_code=422, detail="call_metadata_fields is only valid for pre-call tools")
+        from src.core.call_metadata import CallMetadataValidationError, normalize_call_metadata_policy
+
+        try:
+            doc["call_metadata_fields"] = normalize_call_metadata_policy(
+                raw_metadata_fields,
+                output_variables=doc.get("output_variables") or {},
+            )
+        except CallMetadataValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     return doc
 
 
@@ -1539,6 +1573,20 @@ async def patch_managed_tool(name: str, body: ManagedToolPatch):
     if merged["method"] not in _BODY_CAPABLE_HTTP_METHODS:
         merged.pop("body_template", None)
         merged.pop("payload_template", None)
+
+    raw_metadata_fields = merged.get("call_metadata_fields")
+    if raw_metadata_fields is not None:
+        if new_phase != "pre_call":
+            raise HTTPException(status_code=422, detail="call_metadata_fields is only valid for pre-call tools")
+        from src.core.call_metadata import CallMetadataValidationError, normalize_call_metadata_policy
+
+        try:
+            merged["call_metadata_fields"] = normalize_call_metadata_policy(
+                raw_metadata_fields,
+                output_variables=merged.get("output_variables") or {},
+            )
+        except CallMetadataValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     await _validate_summary_provider_selection(merged)
 

--- a/admin_ui/backend/api/tools.py
+++ b/admin_ui/backend/api/tools.py
@@ -4,7 +4,7 @@ Tools API endpoints for testing HTTP tools before saving.
 import asyncio
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import Dict, Any, Optional, List, Literal
 import httpx
 import json
@@ -1005,6 +1005,8 @@ class ManagedToolParameter(BaseModel):
 
 
 class ManagedCallMetadataField(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     persist: bool = False
     correctable: bool = False
     description: str = ""

--- a/admin_ui/backend/tests/test_calls_agent_aliases.py
+++ b/admin_ui/backend/tests/test_calls_agent_aliases.py
@@ -8,10 +8,18 @@ from api import calls as calls_api
 
 
 def test_csv_cells_neutralize_spreadsheet_formulas():
-    for prefix in ("=", "+", "-", "@", "\t", "\r"):
+    for prefix in ("=", "+", "-", "@", "\t", "\r", "\n"):
         value = f"{prefix}untrusted"
         assert calls_api._csv_safe_cell(value) == f"'{value}"
+    for value in (
+        " =HYPERLINK('https://example.invalid')",
+        "\n=HYPERLINK('https://example.invalid')",
+        " \t\r\n @SUM(1+1)",
+        "\u00a0+SUM(1+1)",
+    ):
+        assert calls_api._csv_safe_cell(value) == f"'{value}"
     assert calls_api._csv_safe_cell("ordinary") == "ordinary"
+    assert calls_api._csv_safe_cell(" ordinary") == " ordinary"
     assert calls_api._csv_safe_cell(42) == 42
 
 

--- a/admin_ui/backend/tests/test_calls_agent_aliases.py
+++ b/admin_ui/backend/tests/test_calls_agent_aliases.py
@@ -7,6 +7,14 @@ from types import SimpleNamespace
 from api import calls as calls_api
 
 
+def test_csv_cells_neutralize_spreadsheet_formulas():
+    for prefix in ("=", "+", "-", "@", "\t", "\r"):
+        value = f"{prefix}untrusted"
+        assert calls_api._csv_safe_cell(value) == f"'{value}"
+    assert calls_api._csv_safe_cell("ordinary") == "ordinary"
+    assert calls_api._csv_safe_cell(42) == 42
+
+
 def _rec(**over):
     base = dict(
         id="r1", call_id="c1", caller_number=None, caller_name=None,

--- a/admin_ui/backend/tests/test_tools_managed_api.py
+++ b/admin_ui/backend/tests/test_tools_managed_api.py
@@ -150,6 +150,23 @@ def test_pre_call_metadata_policy_round_trip_and_validation(client):
     assert orphan.status_code == 422
     assert "not a configured output variable" in orphan.json()["detail"]
 
+    empty_outputs = client.patch("/api/tools/managed/crm_metadata", json={
+        "output_variables": {},
+    })
+    assert empty_outputs.status_code == 422
+    assert "not a configured output variable" in empty_outputs.json()["detail"]
+
+    unknown_policy_key = client.post("/api/tools/managed", json={
+        "name": "typo_metadata", "phase": "pre_call",
+        "url": "https://api.example.com/lookup",
+        "output_variables": {"customer_tier": "contact.tier"},
+        "call_metadata_fields": {
+            "customer_tier": {"persist": True, "max_lenght": 64},
+        },
+    })
+    assert unknown_policy_key.status_code == 422
+    assert "Extra inputs are not permitted" in unknown_policy_key.text
+
     reserved = client.post("/api/tools/managed", json={
         "name": "unsafe_metadata", "phase": "pre_call",
         "url": "https://api.example.com/lookup",

--- a/admin_ui/backend/tests/test_tools_managed_api.py
+++ b/admin_ui/backend/tests/test_tools_managed_api.py
@@ -121,6 +121,45 @@ def test_crud_roundtrip_pre_call(client):
     assert client.get("/api/tools/managed/crm_lookup").status_code == 404
 
 
+def test_pre_call_metadata_policy_round_trip_and_validation(client):
+    response = client.post("/api/tools/managed", json={
+        "name": "crm_metadata", "phase": "pre_call",
+        "url": "https://api.example.com/lookup",
+        "output_variables": {"customer_tier": "contact.tier"},
+        "call_metadata_fields": {
+            "customer_tier": {
+                "persist": True,
+                "correctable": True,
+                "description": "Confirmed tier",
+                "max_length": 64,
+            }
+        },
+    })
+    assert response.status_code == 201, response.text
+    policy = response.json()["config"]["call_metadata_fields"]["customer_tier"]
+    assert policy == {
+        "persist": True,
+        "correctable": True,
+        "description": "Confirmed tier",
+        "max_length": 64,
+    }
+
+    orphan = client.patch("/api/tools/managed/crm_metadata", json={
+        "output_variables": {"account_region": "contact.region"},
+    })
+    assert orphan.status_code == 422
+    assert "not a configured output variable" in orphan.json()["detail"]
+
+    reserved = client.post("/api/tools/managed", json={
+        "name": "unsafe_metadata", "phase": "pre_call",
+        "url": "https://api.example.com/lookup",
+        "output_variables": {"caller_number": "contact.phone"},
+        "call_metadata_fields": {"caller_number": {"persist": True}},
+    })
+    assert reserved.status_code == 422
+    assert "authoritative call state" in reserved.json()["detail"]
+
+
 def test_in_call_tool_goes_to_in_call_block(client):
     r = client.post("/api/tools/managed", json={
         "name": "check_availability", "phase": "in_call",

--- a/admin_ui/backend/tests/test_tools_managed_api.py
+++ b/admin_ui/backend/tests/test_tools_managed_api.py
@@ -167,6 +167,15 @@ def test_pre_call_metadata_policy_round_trip_and_validation(client):
     assert unknown_policy_key.status_code == 422
     assert "Extra inputs are not permitted" in unknown_policy_key.text
 
+    string_flag = client.post("/api/tools/managed", json={
+        "name": "string_flag_metadata", "phase": "pre_call",
+        "url": "https://api.example.com/lookup",
+        "output_variables": {"customer_tier": "contact.tier"},
+        "call_metadata_fields": {"customer_tier": {"persist": "true"}},
+    })
+    assert string_flag.status_code == 422
+    assert "Input should be a valid boolean" in string_flag.text
+
     reserved = client.post("/api/tools/managed", json={
         "name": "unsafe_metadata", "phase": "pre_call",
         "url": "https://api.example.com/lookup",

--- a/admin_ui/frontend/src/components/config/HTTPToolForm.test.tsx
+++ b/admin_ui/frontend/src/components/config/HTTPToolForm.test.tsx
@@ -31,6 +31,48 @@ const expectThemeAwareControl = (control: HTMLElement) => {
 };
 
 describe('HTTPToolForm editor colors', () => {
+    it('keeps persistence opt-in and saves the per-output correction policy', () => {
+        const onChange = vi.fn();
+        render(
+            <HTTPToolForm
+                phase="pre_call"
+                onChange={onChange}
+                config={{
+                    crm_lookup: {
+                        kind: 'generic_http_lookup',
+                        phase: 'pre_call',
+                        enabled: true,
+                        is_global: false,
+                        url: 'https://crm.example.com/contact',
+                        method: 'GET',
+                        headers: {},
+                        output_variables: { customer_tier: 'contact.tier' },
+                    },
+                }}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit crm_lookup' }));
+        const persist = screen.getByRole('checkbox', { name: 'Persist in Call History' });
+        const correct = screen.getByRole('checkbox', { name: 'Allow Agent to correct' });
+        expect(persist).not.toBeChecked();
+        expect(correct).toBeDisabled();
+
+        fireEvent.click(persist);
+        expect(correct).toBeEnabled();
+        fireEvent.click(correct);
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange.mock.calls[0][0].crm_lookup.call_metadata_fields).toEqual({
+            customer_tier: {
+                persist: true,
+                correctable: true,
+                max_length: 1024,
+            },
+        });
+    });
+
     it('styles pre-call header, query, output, and body controls for dark mode', () => {
         renderForm('pre_call');
         fireEvent.click(screen.getByRole('button', { name: 'Add Lookup' }));

--- a/admin_ui/frontend/src/components/config/HTTPToolForm.tsx
+++ b/admin_ui/frontend/src/components/config/HTTPToolForm.tsx
@@ -51,6 +51,10 @@ interface HTTPToolConfig {
     body_template?: string;
     payload_template?: string;
     output_variables?: Record<string, string>;
+    call_metadata_fields?: Record<
+        string,
+        { persist: boolean; correctable: boolean; description?: string; max_length?: number }
+    >;
     hold_audio_file?: string;
     hold_audio_threshold_ms?: number;
     generate_summary?: boolean;
@@ -478,8 +482,35 @@ const HTTPToolForm = ({ config, onChange, phase, contexts }: HTTPToolFormProps) 
 
     const removeOutputVariable = (key: string) => {
         const vars = { ...toolForm.output_variables };
+        const metadataFields = { ...(toolForm.call_metadata_fields || {}) };
         delete vars[key];
-        setToolForm({ ...toolForm, output_variables: vars });
+        delete metadataFields[key];
+        setToolForm({
+            ...toolForm,
+            output_variables: vars,
+            call_metadata_fields: metadataFields,
+        });
+    };
+
+    const updateOutputMetadataPolicy = (
+        key: string,
+        setting: 'persist' | 'correctable',
+        enabled: boolean
+    ) => {
+        const fields = { ...(toolForm.call_metadata_fields || {}) };
+        const current = fields[key] || {
+            persist: false,
+            correctable: false,
+            max_length: 1024,
+        };
+        const next = { ...current, [setting]: enabled };
+        if (setting === 'persist' && !enabled) {
+            delete fields[key];
+        } else {
+            if (setting === 'correctable' && enabled) next.persist = true;
+            fields[key] = next;
+        }
+        setToolForm({ ...toolForm, call_metadata_fields: fields });
     };
 
     const addQueryParam = () => {
@@ -893,21 +924,67 @@ const HTTPToolForm = ({ config, onChange, phase, contexts }: HTTPToolFormProps) 
                                 <FormLabel tooltip="Map JSON response paths to variables for prompt injection. Use dot notation like 'contact.name' or 'contacts[0].email'">
                                     Output Variables
                                 </FormLabel>
+                                <p className="text-xs text-muted-foreground">
+                                    Persistence is off by default. Selected values appear in Call History,
+                                    exports, and backups.
+                                    Correction also requires assigning the Update Call Metadata tool to the Agent.
+                                </p>
                                 <div className="space-y-1">
                                     {Object.entries(toolForm.output_variables || {}).map(
                                         ([k, v]) => (
                                             <div
                                                 key={k}
-                                                className="flex items-center gap-2 text-xs bg-accent/50 px-2 py-1 rounded"
+                                                className="flex flex-wrap items-center gap-3 text-xs bg-accent/50 px-2 py-1.5 rounded"
                                             >
                                                 <span className="font-mono">
                                                     <span className={variableTokenClass}>{k}</span>{' '}
                                                     <span className="text-muted-foreground">←</span>{' '}
                                                     <span>{String(v)}</span>
                                                 </span>
+                                                <label className="ml-auto inline-flex items-center gap-1.5">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={
+                                                            toolForm.call_metadata_fields?.[k]?.persist === true
+                                                        }
+                                                        onChange={e =>
+                                                            updateOutputMetadataPolicy(
+                                                                k,
+                                                                'persist',
+                                                                e.target.checked
+                                                            )
+                                                        }
+                                                    />
+                                                    Persist in Call History
+                                                </label>
+                                                <label
+                                                    className={`inline-flex items-center gap-1.5 ${
+                                                        toolForm.call_metadata_fields?.[k]?.persist === true
+                                                            ? ''
+                                                            : 'opacity-50'
+                                                    }`}
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        disabled={
+                                                            toolForm.call_metadata_fields?.[k]?.persist !== true
+                                                        }
+                                                        checked={
+                                                            toolForm.call_metadata_fields?.[k]?.correctable === true
+                                                        }
+                                                        onChange={e =>
+                                                            updateOutputMetadataPolicy(
+                                                                k,
+                                                                'correctable',
+                                                                e.target.checked
+                                                            )
+                                                        }
+                                                    />
+                                                    Allow Agent to correct
+                                                </label>
                                                 <button
                                                     onClick={() => removeOutputVariable(k)}
-                                                    className="ml-auto text-destructive hover:text-destructive/80"
+                                                    className="text-destructive hover:text-destructive/80"
                                                 >
                                                     <Trash2 className="w-3 h-3" />
                                                 </button>

--- a/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
@@ -51,6 +51,14 @@ const callDetail = {
         session: { agent_user: '9001' },
         events: [],
     },
+    call_metadata: { customer_tier: 'gold' },
+    call_metadata_updates: [
+        {
+            field: 'customer_tier',
+            source: 'agent_correction',
+            updated_at: '2026-07-19T21:16:45+00:00',
+        },
+    ],
 };
 
 const LocationProbe = () => {
@@ -183,5 +191,38 @@ describe('CallHistoryPage deep links', () => {
         expect(screen.getByTestId('full-location')).toHaveTextContent(
             '/env?section=call-history#system'
         );
+    });
+
+    it('shows final metadata provenance and applies an exact-match filter', async () => {
+        render(
+            <MemoryRouter initialEntries={['/history?id=record-1']}>
+                <CallHistoryPage />
+            </MemoryRouter>
+        );
+
+        expect(await screen.findByText('Call Metadata')).toBeInTheDocument();
+        expect(screen.getByText('customer_tier')).toBeInTheDocument();
+        expect(screen.getByText('gold')).toBeInTheDocument();
+        expect(screen.getByText('Updated during call')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTitle('Filters'));
+        fireEvent.change(screen.getByLabelText('Metadata Field'), {
+            target: { value: 'customer_tier' },
+        });
+        fireEvent.change(screen.getByLabelText('Metadata Value (exact)'), {
+            target: { value: 'gold' },
+        });
+
+        await waitFor(() => {
+            const callsRequest = vi.mocked(axios.get).mock.calls
+                .filter(([url]) => url === '/api/calls')
+                .slice(-1)[0];
+            expect(callsRequest?.[1]).toMatchObject({
+                params: {
+                    call_metadata_key: 'customer_tier',
+                    call_metadata_value: 'gold',
+                },
+            });
+        });
     });
 });

--- a/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.test.tsx
@@ -76,7 +76,7 @@ describe('CallHistoryPage deep links', () => {
         vi.clearAllMocks();
         vi.mocked(axios.get).mockImplementation(async url => {
             if (url === '/api/calls') {
-                return { data: { calls: [], total: 0, total_pages: 1 } };
+                return { data: { calls: [callDetail], total: 51, total_pages: 2 } };
             }
             if (url === '/api/calls/stats') return { data: null };
             if (url === '/api/calls/redaction-policy') {
@@ -223,6 +223,34 @@ describe('CallHistoryPage deep links', () => {
                     call_metadata_value: 'gold',
                 },
             });
+        });
+    });
+
+    it('resets to the first page when a metadata filter changes', async () => {
+        render(
+            <MemoryRouter initialEntries={['/history']}>
+                <CallHistoryPage />
+            </MemoryRouter>
+        );
+
+        const pageLabel = await screen.findByText('Page 1 of 2');
+        const pagination = pageLabel.parentElement;
+        const buttons = pagination?.querySelectorAll('button');
+        expect(buttons).toHaveLength(2);
+        fireEvent.click(buttons![1]);
+        expect(await screen.findByText('Page 2 of 2')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTitle('Filters'));
+        fireEvent.change(screen.getByLabelText('Metadata Field'), {
+            target: { value: 'customer_tier' },
+        });
+
+        expect(await screen.findByText('Page 1 of 2')).toBeInTheDocument();
+        await waitFor(() => {
+            const callsRequest = vi.mocked(axios.get).mock.calls
+                .filter(([url]) => url === '/api/calls')
+                .slice(-1)[0];
+            expect(callsRequest?.[1]).toMatchObject({ params: { page: 1 } });
         });
     });
 });

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -961,7 +961,10 @@ const CallHistoryPage = () => {
                                 id="call-metadata-key"
                                 type="text"
                                 value={filters.call_metadata_key}
-                                onChange={(e) => setFilters({ ...filters, call_metadata_key: e.target.value })}
+                                onChange={(e) => {
+                                    setFilters({ ...filters, call_metadata_key: e.target.value });
+                                    setPage(1);
+                                }}
                                 placeholder="e.g. customer_tier"
                                 className="w-full mt-1 px-3 py-2 bg-background border rounded-lg text-sm font-mono"
                             />
@@ -972,7 +975,10 @@ const CallHistoryPage = () => {
                                 id="call-metadata-value"
                                 type="text"
                                 value={filters.call_metadata_value}
-                                onChange={(e) => setFilters({ ...filters, call_metadata_value: e.target.value })}
+                                onChange={(e) => {
+                                    setFilters({ ...filters, call_metadata_value: e.target.value });
+                                    setPage(1);
+                                }}
                                 placeholder="Exact value"
                                 className="w-full mt-1 px-3 py-2 bg-background border rounded-lg text-sm"
                             />

--- a/admin_ui/frontend/src/pages/CallHistoryPage.tsx
+++ b/admin_ui/frontend/src/pages/CallHistoryPage.tsx
@@ -63,6 +63,12 @@ interface CallRecordDetail extends CallRecordSummary {
         session?: Record<string, any>;
         events?: Array<Record<string, any>>;
     };
+    call_metadata: Record<string, string>;
+    call_metadata_updates: Array<{
+        field: string;
+        source: string;
+        updated_at?: string;
+    }>;
 }
 
 interface CallStats {
@@ -227,6 +233,8 @@ const CallHistoryPage = () => {
         outcome: '',
         start_date: '',
         end_date: '',
+        call_metadata_key: '',
+        call_metadata_value: '',
     });
     const [showFilters, setShowFilters] = useState(false);
 
@@ -278,8 +286,13 @@ const CallHistoryPage = () => {
             
             // Add filters
             Object.entries(filters).forEach(([key, value]) => {
+                if (key.startsWith('call_metadata_')) return;
                 if (value) params[key] = value;
             });
+            if (filters.call_metadata_key && filters.call_metadata_value) {
+                params.call_metadata_key = filters.call_metadata_key;
+                params.call_metadata_value = filters.call_metadata_value;
+            }
             if (transcriptSearch) params.transcript_search = transcriptSearch;
 
             const res = await axios.get('/api/calls', { params });
@@ -529,8 +542,13 @@ const CallHistoryPage = () => {
         try {
             const params: Record<string, any> = {};
             Object.entries(filters).forEach(([key, value]) => {
+                if (key.startsWith('call_metadata_')) return;
                 if (value) params[key] = value;
             });
+            if (filters.call_metadata_key && filters.call_metadata_value) {
+                params.call_metadata_key = filters.call_metadata_key;
+                params.call_metadata_value = filters.call_metadata_value;
+            }
             
             const res = await axios.get(`/api/calls/export/${format}`, { 
                 params,
@@ -648,6 +666,8 @@ const CallHistoryPage = () => {
             outcome: '',
             start_date: '',
             end_date: '',
+            call_metadata_key: '',
+            call_metadata_value: '',
         });
     };
 
@@ -844,7 +864,7 @@ const CallHistoryPage = () => {
                             </button>
                         )}
                     </div>
-                    <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
+                    <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-4">
                         <div>
                             <label className="text-sm text-muted-foreground">Caller Number</label>
                             <input
@@ -934,6 +954,34 @@ const CallHistoryPage = () => {
                                 onChange={(e) => setFilters({ ...filters, end_date: e.target.value })}
                                 className="w-full mt-1 px-3 py-2 bg-background border rounded-lg text-sm"
                             />
+                        </div>
+                        <div>
+                            <label htmlFor="call-metadata-key" className="text-sm text-muted-foreground">Metadata Field</label>
+                            <input
+                                id="call-metadata-key"
+                                type="text"
+                                value={filters.call_metadata_key}
+                                onChange={(e) => setFilters({ ...filters, call_metadata_key: e.target.value })}
+                                placeholder="e.g. customer_tier"
+                                className="w-full mt-1 px-3 py-2 bg-background border rounded-lg text-sm font-mono"
+                            />
+                        </div>
+                        <div>
+                            <label htmlFor="call-metadata-value" className="text-sm text-muted-foreground">Metadata Value (exact)</label>
+                            <input
+                                id="call-metadata-value"
+                                type="text"
+                                value={filters.call_metadata_value}
+                                onChange={(e) => setFilters({ ...filters, call_metadata_value: e.target.value })}
+                                placeholder="Exact value"
+                                className="w-full mt-1 px-3 py-2 bg-background border rounded-lg text-sm"
+                            />
+                            {(filters.call_metadata_key && !filters.call_metadata_value) ||
+                            (!filters.call_metadata_key && filters.call_metadata_value) ? (
+                                <div className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                                    Enter both fields to apply this filter.
+                                </div>
+                            ) : null}
                         </div>
                     </div>
                 </div>
@@ -1299,6 +1347,41 @@ const CallHistoryPage = () => {
                                                 </pre>
                                             </details>
                                         )}
+                                    </div>
+                                </div>
+                            )}
+
+                            {selectedCall && Object.keys(selectedCall.call_metadata || {}).length > 0 && (
+                                <div>
+                                    <h3 className="font-semibold mb-2">Call Metadata</h3>
+                                    <div className="rounded-lg border border-border bg-card p-4">
+                                        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+                                            {Object.entries(selectedCall.call_metadata).map(([key, value]) => {
+                                                const update = (selectedCall.call_metadata_updates || [])
+                                                    .filter(item => item.field === key)
+                                                    .slice(-1)[0];
+                                                return (
+                                                    <div key={key} className="rounded-md bg-muted/30 p-3">
+                                                        <div className="flex items-center justify-between gap-2">
+                                                            <span className="font-mono text-xs text-muted-foreground">{key}</span>
+                                                            <span className={`rounded px-1.5 py-0.5 text-[10px] ${
+                                                                update
+                                                                    ? 'bg-blue-500/15 text-blue-600 dark:text-blue-400'
+                                                                    : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+                                                            }`}>
+                                                                {update ? 'Updated during call' : 'Pre-call'}
+                                                            </span>
+                                                        </div>
+                                                        <div className="mt-1 break-words text-sm">{String(value)}</div>
+                                                        {update?.updated_at && (
+                                                            <div className="mt-1 text-[11px] text-muted-foreground">
+                                                                {formatDate(update.updated_at)}
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
                                     </div>
                                 </div>
                             )}

--- a/docs/ADMIN_UI_GUIDE.md
+++ b/docs/ADMIN_UI_GUIDE.md
@@ -68,6 +68,8 @@ Per-call debugging and analytics:
 - Searchable list of all calls with timestamps, duration, and provider
 - Full conversation transcripts
 - Tool call history with parameters and results
+- Opt-in call metadata with pre-call/updated-during-call provenance badges
+- Exact call metadata field/value filtering and CSV/JSON export
 - Call quality metrics
 - A distinct **No input timeout** outcome for calls ended by the inactivity policy
 

--- a/docs/TOOL_CALLING_GUIDE.md
+++ b/docs/TOOL_CALLING_GUIDE.md
@@ -428,7 +428,26 @@ tools:
       customer_name: "contacts[0].firstName"
       customer_email: "contacts[0].email"
       account_type: "contacts[0].customFields.account_type"
+    call_metadata_fields:
+      account_type:
+        persist: true
+        correctable: true
+        description: "Caller-confirmed account type"
+        max_length: 64
 ```
+
+`output_variables` remain prompt-only by default. Under **Tools → Pre-Call HTTP
+Lookups**, enable **Persist in Call History** on an individual output to copy it
+into the bounded `call_metadata` object. Enable **Allow Agent to correct** only
+when the value is safe for the caller to correct, then explicitly assign the
+built-in `update_call_metadata` tool to the Agent. The correction tool is not
+global and is absent from a live call unless that call has at least one selected,
+correctable field.
+
+Call metadata is intentionally non-authoritative: reserved caller, routing,
+consent/DNC, transfer, disposition, provider, and credential-like names are
+rejected. Values are scalar and bounded. Corrections apply only to the active
+call; they do not write back to the CRM or affect another call.
 
 **Variable Substitution**:
 
@@ -590,8 +609,9 @@ contexts:
 In-call HTTP tools have access to three types of variables:
 
 1. **Context variables** (auto-injected): `{caller_number}`, `{called_number}`, `{call_id}`, etc.
-2. **Pre-call variables** (from pre-call HTTP lookups): `{customer_id}`, `{customer_name}`, etc.
-3. **AI parameters** (provided at runtime): Whatever the AI passes when invoking the tool
+2. **Effective call metadata**, when selected: corrected values such as `{customer_id}`
+3. **Pre-call variables** (from pre-call HTTP lookups): `{customer_id}`, `{customer_name}`, etc.
+4. **AI parameters** (provided at runtime): Whatever the AI passes when invoking the tool
 
 This means you can use data fetched by pre-call tools in your in-call tool requests. For example, if a pre-call lookup fetches `customer_id`, you can use `{customer_id}` in the in-call tool's body template.
 
@@ -768,6 +788,13 @@ Existing webhook definitions that enable summaries but omit `summary_provider` k
 | `{provider}` | string | AI provider (deepgram, openai_realtime, etc.) |
 | `{call_direction}` | string | "inbound" or "outbound" |
 | `{call_duration}` | number | Duration in seconds |
+| `{pre_call_results_json}` | JSON string | Original pre-call lookup snapshot; never rewritten by corrections |
+| `{call_metadata_json}` | JSON string | Final selected metadata values after any in-call corrections |
+
+Individual selected metadata fields are also available by name. Their final
+value overrides the same custom pre-call placeholder, while built-in call fields
+always win. Call History supports exact field/value filtering and includes the
+final object in CSV and JSON exports.
 | `{call_outcome}` | string | Outcome (completed, transferred, etc.) |
 | `{call_start_time}` | string | ISO timestamp |
 | `{call_end_time}` | string | ISO timestamp |

--- a/src/core/call_history.py
+++ b/src/core/call_history.py
@@ -60,6 +60,11 @@ class CallRecord:
     external_direction: Optional[str] = None
     external_disposition: Optional[str] = None
     external_metadata: Dict[str, Any] = field(default_factory=dict)
+
+    # Operator-selected enrichment only. Kept separate from external_metadata,
+    # which is owned by VICIdial/external dialer lifecycle integration.
+    call_metadata: Dict[str, str] = field(default_factory=dict)
+    call_metadata_updates: List[Dict[str, Any]] = field(default_factory=list)
     
     # Tool executions (debugging)
     # tool_calls = append-only terminal in-call tool results. Entries retain
@@ -105,8 +110,11 @@ class CallRecord:
                     data[key] = None
         
         # Parse JSON strings for complex fields
-        _list_fields = ['conversation_history', 'tool_calls', 'pre_call_tool_calls', 'post_call_tool_calls']
-        for key in ['pipeline_components', 'external_metadata', *_list_fields]:
+        _list_fields = [
+            'conversation_history', 'tool_calls', 'pre_call_tool_calls',
+            'post_call_tool_calls', 'call_metadata_updates',
+        ]
+        for key in ['pipeline_components', 'external_metadata', 'call_metadata', *_list_fields]:
             if data.get(key) and isinstance(data[key], str):
                 try:
                     data[key] = json.loads(data[key])
@@ -116,6 +124,10 @@ class CallRecord:
                 # NULL columns on pre-migration rows must retain their declared
                 # collection type instead of overriding dataclass defaults with None.
                 data[key] = [] if key in _list_fields else {}
+        if not isinstance(data.get('call_metadata'), dict):
+            data['call_metadata'] = {}
+        if not isinstance(data.get('call_metadata_updates'), list):
+            data['call_metadata_updates'] = []
         
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
@@ -159,6 +171,8 @@ class CallHistoryStore:
         external_direction TEXT,
         external_disposition TEXT,
         external_metadata TEXT,
+        call_metadata TEXT,
+        call_metadata_updates TEXT,
         tool_calls TEXT,
         pre_call_tool_calls TEXT,
         post_call_tool_calls TEXT,
@@ -253,6 +267,8 @@ class CallHistoryStore:
                 "external_direction": "TEXT",
                 "external_disposition": "TEXT",
                 "external_metadata": "TEXT",
+                "call_metadata": "TEXT",
+                "call_metadata_updates": "TEXT",
             }
             for name, sql_type in additive_columns.items():
                 if name not in existing:
@@ -288,6 +304,15 @@ class CallHistoryStore:
             with self._lock:
                 conn = self._get_connection()
                 try:
+                    from src.core.call_metadata import (
+                        normalize_call_metadata_updates,
+                        validate_call_metadata_document,
+                    )
+
+                    call_metadata = validate_call_metadata_document(record.call_metadata or {})
+                    call_metadata_updates = normalize_call_metadata_updates(
+                        record.call_metadata_updates or []
+                    )
                     cursor = conn.cursor()
                     # Check if record with same call_id already exists (prevent duplicates)
                     cursor.execute("SELECT id FROM call_records WHERE call_id = ?", (record.call_id,))
@@ -305,10 +330,11 @@ class CallHistoryStore:
                             conversation_history, outcome, transfer_destination, error_message,
                             external_platform, external_call_id, external_direction,
                             external_disposition, external_metadata,
+                            call_metadata, call_metadata_updates,
                             tool_calls, pre_call_tool_calls, post_call_tool_calls,
                             avg_turn_latency_ms, max_turn_latency_ms, total_turns,
                             caller_audio_format, codec_alignment_ok, barge_in_count, created_at
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """, (
                         record.id,
                         record.call_id,
@@ -336,6 +362,8 @@ class CallHistoryStore:
                         record.external_direction,
                         record.external_disposition,
                         json.dumps(record.external_metadata),
+                        json.dumps(call_metadata),
+                        json.dumps(call_metadata_updates),
                         json.dumps(record.tool_calls),
                         json.dumps(record.pre_call_tool_calls),
                         json.dumps(record.post_call_tool_calls),
@@ -642,6 +670,8 @@ class CallHistoryStore:
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
         transcript_search: Optional[str] = None,
+        call_metadata_key: Optional[str] = None,
+        call_metadata_value: Optional[str] = None,
         order_by: str = "start_time",
         order_dir: str = "DESC",
         include_details: bool = True,
@@ -722,6 +752,11 @@ class CallHistoryStore:
                         escaped = self._escape_like(transcript_search)
                         conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
                         params.append(f"%{escaped}%")
+                    if call_metadata_key is not None and call_metadata_value is not None:
+                        from src.core.call_metadata import call_metadata_json_path
+
+                        conditions.append("CAST(json_extract(call_metadata, ?) AS TEXT) = ?")
+                        params.extend([call_metadata_json_path(call_metadata_key), call_metadata_value])
 
                     # Validate order_by to prevent SQL injection
                     valid_columns = [
@@ -868,6 +903,8 @@ class CallHistoryStore:
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
         transcript_search: Optional[str] = None,
+        call_metadata_key: Optional[str] = None,
+        call_metadata_value: Optional[str] = None,
     ) -> int:
         """Count records matching filters."""
         if not self._enabled:
@@ -921,6 +958,11 @@ class CallHistoryStore:
                         escaped = self._escape_like(transcript_search)
                         conditions.append("LOWER(conversation_history) LIKE LOWER(?) ESCAPE '\\'")
                         params.append(f"%{escaped}%")
+                    if call_metadata_key is not None and call_metadata_value is not None:
+                        from src.core.call_metadata import call_metadata_json_path
+
+                        conditions.append("CAST(json_extract(call_metadata, ?) AS TEXT) = ?")
+                        params.extend([call_metadata_json_path(call_metadata_key), call_metadata_value])
 
                     where_clause = " AND ".join(conditions) if conditions else "1=1"
                     query = f"SELECT COUNT(*) FROM call_records WHERE {where_clause}"

--- a/src/core/call_metadata.py
+++ b/src/core/call_metadata.py
@@ -74,7 +74,12 @@ def validate_call_metadata_key(key: Any) -> str:
         raise CallMetadataValidationError(
             f"'{normalized}' is reserved for authoritative call state"
         )
-    if _CREDENTIAL_RE.search(normalized):
+    # Split camel/Pascal-case boundaries before checking credential tokens so
+    # names such as ``customerAccessToken`` and ``crmPassword`` receive the
+    # same treatment as their snake_case equivalents.
+    credential_key = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", normalized)
+    credential_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", credential_key)
+    if _CREDENTIAL_RE.search(credential_key):
         raise CallMetadataValidationError(
             f"'{normalized}' looks credential-related and cannot be persisted"
         )
@@ -100,7 +105,7 @@ def normalize_call_metadata_policy(
     result: Dict[str, Dict[str, Any]] = {}
     for raw_key, raw_policy in raw.items():
         key = validate_call_metadata_key(raw_key)
-        if known_outputs and key not in known_outputs:
+        if output_variables is not None and key not in known_outputs:
             raise CallMetadataValidationError(
                 f"call metadata field '{key}' is not a configured output variable"
             )

--- a/src/core/call_metadata.py
+++ b/src/core/call_metadata.py
@@ -1,0 +1,217 @@
+"""Bounded, non-authoritative metadata carried by one active call.
+
+Call metadata is deliberately separate from caller identity, routing, consent,
+transfer, disposition, and external-dialer lifecycle state.  Only explicitly
+selected pre-call outputs may enter this namespace.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, Mapping
+
+
+MAX_CALL_METADATA_FIELDS = 32
+MAX_CALL_METADATA_KEY_CHARS = 64
+MAX_CALL_METADATA_VALUE_CHARS = 1024
+MAX_CALL_METADATA_TOTAL_BYTES = 16_384
+MAX_CALL_METADATA_UPDATES = 128
+
+_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_CREDENTIAL_RE = re.compile(
+    r"(?:^|_)(?:api_?key|access_?token|refresh_?token|token|secret|password|"
+    r"authorization|auth|credential|private_?key)(?:$|_)",
+    re.IGNORECASE,
+)
+
+# These names map to authoritative engine/session state or built-in template
+# variables.  Persisting a same-named enrichment value would create ambiguous
+# precedence and could accidentally turn a convenience field into call control.
+RESERVED_CALL_METADATA_KEYS = frozenset(
+    {
+        "call_id",
+        "caller_id",
+        "caller_name",
+        "caller_number",
+        "called_number",
+        "context_name",
+        "call_direction",
+        "campaign_id",
+        "lead_id",
+        "provider",
+        "provider_name",
+        "routing_method",
+        "transfer_destination",
+        "disposition",
+        "external_disposition",
+        "consent",
+        "dnc",
+        "do_not_call",
+        "call_outcome",
+        "status",
+        "current_date",
+        "current_weekday",
+        "current_time",
+        "current_datetime_iso",
+        "today",
+    }
+)
+
+
+class CallMetadataValidationError(ValueError):
+    """Raised when metadata configuration or a value violates its boundary."""
+
+
+def validate_call_metadata_key(key: Any) -> str:
+    normalized = str(key or "").strip()
+    if not _KEY_RE.fullmatch(normalized):
+        raise CallMetadataValidationError(
+            "metadata field names must start with a letter and contain only "
+            f"letters, digits, and underscores ({MAX_CALL_METADATA_KEY_CHARS} characters max)"
+        )
+    if normalized.lower() in RESERVED_CALL_METADATA_KEYS:
+        raise CallMetadataValidationError(
+            f"'{normalized}' is reserved for authoritative call state"
+        )
+    if _CREDENTIAL_RE.search(normalized):
+        raise CallMetadataValidationError(
+            f"'{normalized}' looks credential-related and cannot be persisted"
+        )
+    return normalized
+
+
+def normalize_call_metadata_policy(
+    raw: Any,
+    *,
+    output_variables: Mapping[str, Any] | None = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Validate the per-output persistence/correction policy from tool config."""
+    if raw in (None, ""):
+        return {}
+    if not isinstance(raw, Mapping):
+        raise CallMetadataValidationError("call_metadata_fields must be an object")
+    if len(raw) > MAX_CALL_METADATA_FIELDS:
+        raise CallMetadataValidationError(
+            f"call_metadata_fields supports at most {MAX_CALL_METADATA_FIELDS} fields"
+        )
+
+    known_outputs = set(output_variables or {})
+    result: Dict[str, Dict[str, Any]] = {}
+    for raw_key, raw_policy in raw.items():
+        key = validate_call_metadata_key(raw_key)
+        if known_outputs and key not in known_outputs:
+            raise CallMetadataValidationError(
+                f"call metadata field '{key}' is not a configured output variable"
+            )
+        if not isinstance(raw_policy, Mapping):
+            raise CallMetadataValidationError(
+                f"call metadata policy for '{key}' must be an object"
+            )
+        unknown = set(raw_policy) - {"persist", "correctable", "description", "max_length"}
+        if unknown:
+            raise CallMetadataValidationError(
+                f"unsupported policy field(s) for '{key}': {', '.join(sorted(unknown))}"
+            )
+        persist = bool(raw_policy.get("persist", False))
+        correctable = bool(raw_policy.get("correctable", False))
+        if correctable and not persist:
+            raise CallMetadataValidationError(
+                f"'{key}' cannot be correctable unless persistence is enabled"
+            )
+        if not persist:
+            continue
+        description = str(raw_policy.get("description") or "").strip()
+        if len(description) > 240:
+            raise CallMetadataValidationError(
+                f"description for '{key}' must be 240 characters or fewer"
+            )
+        raw_max = raw_policy.get("max_length", MAX_CALL_METADATA_VALUE_CHARS)
+        try:
+            max_length = int(raw_max)
+        except (TypeError, ValueError) as exc:
+            raise CallMetadataValidationError(
+                f"max_length for '{key}' must be an integer"
+            ) from exc
+        if max_length < 1 or max_length > MAX_CALL_METADATA_VALUE_CHARS:
+            raise CallMetadataValidationError(
+                f"max_length for '{key}' must be between 1 and {MAX_CALL_METADATA_VALUE_CHARS}"
+            )
+        result[key] = {
+            "persist": True,
+            "correctable": correctable,
+            "description": description,
+            "max_length": max_length,
+        }
+    return result
+
+
+def normalize_call_metadata_value(value: Any, *, max_length: int) -> str:
+    """Return a bounded scalar string; reject containers and oversized values."""
+    if isinstance(value, (dict, list, tuple, set)):
+        raise CallMetadataValidationError("call metadata values must be scalar")
+    if value is None:
+        normalized = ""
+    elif isinstance(value, (str, int, float, bool)):
+        normalized = str(value)
+    else:
+        raise CallMetadataValidationError("call metadata values must be scalar")
+    if len(normalized) > max_length:
+        raise CallMetadataValidationError(
+            f"call metadata value exceeds the {max_length}-character limit"
+        )
+    return normalized
+
+
+def validate_call_metadata_document(values: Mapping[str, Any]) -> Dict[str, str]:
+    """Validate the complete persisted object and enforce its aggregate bound."""
+    if not isinstance(values, Mapping):
+        raise CallMetadataValidationError("call metadata must be an object")
+    if len(values) > MAX_CALL_METADATA_FIELDS:
+        raise CallMetadataValidationError(
+            f"call metadata supports at most {MAX_CALL_METADATA_FIELDS} fields"
+        )
+    normalized: Dict[str, str] = {}
+    for raw_key, value in values.items():
+        key = validate_call_metadata_key(raw_key)
+        normalized[key] = normalize_call_metadata_value(
+            value,
+            max_length=MAX_CALL_METADATA_VALUE_CHARS,
+        )
+    encoded = json.dumps(normalized, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_CALL_METADATA_TOTAL_BYTES:
+        raise CallMetadataValidationError(
+            f"call metadata exceeds the {MAX_CALL_METADATA_TOTAL_BYTES}-byte total limit"
+        )
+    return normalized
+
+
+def normalize_call_metadata_updates(raw: Any) -> list[Dict[str, str]]:
+    """Validate the value-free provenance audit stored with Call History."""
+    if raw in (None, ""):
+        return []
+    if not isinstance(raw, list):
+        raise CallMetadataValidationError("call metadata updates must be an array")
+    normalized: list[Dict[str, str]] = []
+    for entry in raw[-MAX_CALL_METADATA_UPDATES:]:
+        if not isinstance(entry, Mapping):
+            raise CallMetadataValidationError("call metadata update entries must be objects")
+        if set(entry) - {"field", "source", "updated_at"}:
+            raise CallMetadataValidationError("call metadata update entries contain unsupported fields")
+        field = validate_call_metadata_key(entry.get("field"))
+        source = str(entry.get("source") or "").strip()
+        if source != "agent_correction":
+            raise CallMetadataValidationError("unsupported call metadata update source")
+        updated_at = str(entry.get("updated_at") or "").strip()
+        if len(updated_at) > 64:
+            raise CallMetadataValidationError("call metadata update timestamp is too long")
+        item = {"field": field, "source": source}
+        if updated_at:
+            item["updated_at"] = updated_at
+        normalized.append(item)
+    return normalized
+
+
+def call_metadata_json_path(key: Any) -> str:
+    """Return a safe SQLite JSON path for a previously validated field name."""
+    return f"$.{validate_call_metadata_key(key)}"

--- a/src/core/call_metadata.py
+++ b/src/core/call_metadata.py
@@ -63,6 +63,23 @@ class CallMetadataValidationError(ValueError):
     """Raised when metadata configuration or a value violates its boundary."""
 
 
+def _tokenize_camel_case(value: str) -> str:
+    """Insert separators at camel/Pascal-case boundaries in linear time."""
+    tokenized: list[str] = []
+    for index, character in enumerate(value):
+        previous = value[index - 1] if index else ""
+        following = value[index + 1] if index + 1 < len(value) else ""
+        starts_word = character.isupper() and (
+            previous.islower()
+            or previous.isdigit()
+            or (previous.isupper() and following.islower())
+        )
+        if tokenized and starts_word:
+            tokenized.append("_")
+        tokenized.append(character)
+    return "".join(tokenized)
+
+
 def validate_call_metadata_key(key: Any) -> str:
     normalized = str(key or "").strip()
     if not _KEY_RE.fullmatch(normalized):
@@ -77,8 +94,7 @@ def validate_call_metadata_key(key: Any) -> str:
     # Split camel/Pascal-case boundaries before checking credential tokens so
     # names such as ``customerAccessToken`` and ``crmPassword`` receive the
     # same treatment as their snake_case equivalents.
-    credential_key = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", normalized)
-    credential_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", credential_key)
+    credential_key = _tokenize_camel_case(normalized)
     if _CREDENTIAL_RE.search(credential_key):
         raise CallMetadataValidationError(
             f"'{normalized}' looks credential-related and cannot be persisted"
@@ -118,8 +134,13 @@ def normalize_call_metadata_policy(
             raise CallMetadataValidationError(
                 f"unsupported policy field(s) for '{key}': {', '.join(sorted(unknown))}"
             )
-        persist = bool(raw_policy.get("persist", False))
-        correctable = bool(raw_policy.get("correctable", False))
+        for flag_name in ("persist", "correctable"):
+            if flag_name in raw_policy and not isinstance(raw_policy[flag_name], bool):
+                raise CallMetadataValidationError(
+                    f"'{flag_name}' for '{key}' must be a boolean"
+                )
+        persist = raw_policy.get("persist", False)
+        correctable = raw_policy.get("correctable", False)
         if correctable and not persist:
             raise CallMetadataValidationError(
                 f"'{key}' cannot be correctable unless persistence is enabled"

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -195,6 +195,14 @@ class CallSession:
     # Pre-call tool results (Milestone 24) - CRM lookup data injected into prompts
     pre_call_results: Dict[str, str] = field(default_factory=dict)  # {variable_name: value}
 
+    # Opt-in, bounded enrichment fields. These never control caller identity,
+    # routing, consent, transfer, disposition, or external-dialer state.
+    call_metadata: Dict[str, str] = field(default_factory=dict)
+    call_metadata_policy: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # Audit contains field/source/timestamp only; values remain in the bounded
+    # final metadata object and are not duplicated into tool diagnostics.
+    call_metadata_updates: List[Dict[str, Any]] = field(default_factory=list)
+
     # Pre-call tool execution metadata for the call history UI.
     # Same per-entry shape as the post_call_tool_calls JSON column on CallRecord.
     pre_call_tool_calls: List[Dict[str, Any]] = field(default_factory=list)

--- a/src/core/session_store.py
+++ b/src/core/session_store.py
@@ -7,7 +7,8 @@ with a single, thread-safe store that enforces invariants.
 
 import asyncio
 import time
-from typing import Optional, Dict, Set, List
+from datetime import datetime, timezone
+from typing import Any, Optional, Dict, Set, List
 import structlog
 
 from src.core.models import CallSession, PlaybackRef, ProviderSession
@@ -79,6 +80,81 @@ class SessionStore:
                 session.tool_calls = []
             session.tool_calls.append(record)
             return True
+
+    async def update_call_metadata(
+        self,
+        call_id: str,
+        field_name: str,
+        value: Any,
+    ) -> Dict[str, Any]:
+        """Atomically correct one explicitly allowed metadata field.
+
+        The active-session lookup, lifecycle gate, policy check, size check, and
+        mutation all happen under the same lock. A late tool result therefore
+        cannot resurrect a removed call or race cleanup.
+        """
+        from src.core.call_metadata import (
+            CallMetadataValidationError,
+            MAX_CALL_METADATA_UPDATES,
+            normalize_call_metadata_value,
+            validate_call_metadata_document,
+            validate_call_metadata_key,
+        )
+
+        async with self._lock:
+            session = self._sessions_by_call_id.get(call_id)
+            if session is None:
+                return {"status": "error", "message": "The call is no longer active."}
+            if bool(getattr(session, "cleanup_in_progress", False)) or bool(
+                getattr(session, "cleanup_completed", False)
+            ):
+                return {"status": "error", "message": "The call is ending; metadata can no longer be changed."}
+
+            try:
+                field = validate_call_metadata_key(field_name)
+            except CallMetadataValidationError as exc:
+                return {"status": "error", "message": str(exc)}
+            policy = dict((getattr(session, "call_metadata_policy", {}) or {}).get(field) or {})
+            if not policy or not bool(policy.get("correctable", False)):
+                return {"status": "error", "message": f"'{field}' is not an allowed correctable field."}
+
+            try:
+                normalized = normalize_call_metadata_value(
+                    value,
+                    max_length=int(policy.get("max_length") or 1024),
+                )
+                current = dict(getattr(session, "call_metadata", {}) or {})
+                previous = current.get(field)
+                current[field] = normalized
+                current = validate_call_metadata_document(current)
+            except CallMetadataValidationError as exc:
+                return {"status": "error", "message": str(exc)}
+
+            if previous == normalized:
+                return {
+                    "status": "success",
+                    "message": f"'{field}' already has that value.",
+                    "field": field,
+                    "changed": False,
+                }
+
+            session.call_metadata = current
+            updates = list(getattr(session, "call_metadata_updates", []) or [])
+            updates.append(
+                {
+                    "field": field,
+                    "source": "agent_correction",
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+            # The values are bounded above; keep the audit bounded as well.
+            session.call_metadata_updates = updates[-MAX_CALL_METADATA_UPDATES:]
+            return {
+                "status": "success",
+                "message": f"Updated '{field}' for this call.",
+                "field": field,
+                "changed": True,
+            }
     
     async def get_by_channel_id(self, channel_id: str) -> Optional[CallSession]:
         """Get session by any channel_id (caller, local, external_media)."""

--- a/src/engine.py
+++ b/src/engine.py
@@ -7206,6 +7206,7 @@ class Engine:
             "current_datetime_iso": _now_utc.isoformat(timespec="seconds"),
             "today": _now_local.strftime("%A, %B %d, %Y"),
         }
+        built_in_substitution_keys = set(substitutions)
         
         # Add pre-call tool results (Milestone 24 - CRM enrichment variables)
         pre_call_results = getattr(session, 'pre_call_results', None) or {}
@@ -7214,11 +7215,19 @@ class Engine:
             if key not in substitutions:
                 substitutions[key] = str(value) if value else ""
 
+        # Selected call metadata is the effective enrichment layer. It may
+        # replace an initial pre-call value but never a built-in variable.
+        call_metadata = getattr(session, 'call_metadata', None) or {}
+        for key, value in call_metadata.items():
+            if key not in built_in_substitution_keys:
+                substitutions[key] = str(value) if value is not None else ""
+
         # Avoid awkward optional-enrichment output such as "from ," when a
         # lookup succeeds but does not return a mapped value. This deliberately
         # handles only a small phrase immediately preceding an empty pre-call
         # placeholder; unknown placeholders remain untouched.
-        for key, value in pre_call_results.items():
+        effective_enrichment = {**pre_call_results, **call_metadata}
+        for key, value in effective_enrichment.items():
             if value not in (None, ""):
                 continue
             escaped = re.escape(str(key))
@@ -9811,6 +9820,8 @@ class Engine:
                 error_message=session.error_message,
                 tool_calls=getattr(session, 'tool_calls', []) or [],
                 pre_call_tool_calls=getattr(session, 'pre_call_tool_calls', []) or [],
+                call_metadata=dict(getattr(session, 'call_metadata', {}) or {}),
+                call_metadata_updates=list(getattr(session, 'call_metadata_updates', []) or []),
                 # post_call_tool_calls is populated AFTER this initial save by the
                 # post-call dispatch loop, via CallHistoryStore.append/update_phase_tool.
                 post_call_tool_calls=[],
@@ -17773,6 +17784,30 @@ class Engine:
             },
         )
 
+    async def _configure_call_metadata_tool_runtime(self, session: CallSession) -> CallSession:
+        """Install a per-call schema containing only its correctable fields."""
+        from src.tools.business.update_call_metadata import UpdateCallMetadataTool
+
+        latest = await self.session_store.get_by_call_id(session.call_id)
+        if latest is not None:
+            session = latest
+        registry = self._tool_registry_for_session(session).clone()
+        policies = dict(getattr(session, "call_metadata_policy", {}) or {})
+        correctable = {
+            key: value
+            for key, value in policies.items()
+            if isinstance(value, dict) and bool(value.get("correctable", False))
+        }
+        if correctable:
+            registry.register_instance(UpdateCallMetadataTool(correctable))
+        else:
+            # An Agent assignment alone is insufficient when this call has no
+            # selected correctable pre-call fields.
+            registry.unregister("update_call_metadata")
+        session.tool_runtime_registry = registry
+        await self._save_session(session)
+        return session
+
     def _compute_config_state(self) -> dict:
         """Compare the running (loaded) config against what's on disk.
 
@@ -19024,6 +19059,29 @@ class Engine:
                     )
             except Exception:
                 logger.debug("Pre-call tool execution failed", call_id=call_id, exc_info=True)
+
+            # The selected pre-call outputs determine the call-local correction
+            # schema. Always configure it, including when no lookup succeeded,
+            # so the generic catalog definition is never exposed to a live Agent.
+            try:
+                session = await self._configure_call_metadata_tool_runtime(session)
+            except Exception:
+                logger.warning(
+                    "Failed to configure call metadata tool; disabling it for this call",
+                    call_id=call_id,
+                    exc_info=True,
+                )
+                try:
+                    registry = self._tool_registry_for_session(session).clone()
+                    registry.unregister("update_call_metadata")
+                    session.tool_runtime_registry = registry
+                    await self._save_session(session)
+                except Exception:
+                    logger.debug(
+                        "Failed to remove metadata tool after setup error",
+                        call_id=call_id,
+                        exc_info=True,
+                    )
 
             # Preserve any per-call override previously applied. Only assign a pipeline
             # here if one has already been selected (e.g., via AI_PROVIDER or active_pipeline)
@@ -20445,7 +20503,9 @@ class Engine:
             tool_tasks = [run_tool_with_timeout(tool) for tool in tools_to_run]
             tool_outputs = await asyncio.gather(*tool_tasks, return_exceptions=True)
             
-            # Merge results
+            # Merge results and seed only explicitly selected metadata fields.
+            metadata_values: Dict[str, str] = {}
+            metadata_policy: Dict[str, Dict[str, Any]] = {}
             for i, output in enumerate(tool_outputs):
                 if isinstance(output, Exception):
                     logger.error("Pre-call tool raised exception",
@@ -20455,9 +20515,41 @@ class Engine:
                     continue
                 if isinstance(output, dict):
                     results.update(output)
+                    raw_policy = getattr(
+                        getattr(tools_to_run[i], "config", None),
+                        "call_metadata_fields",
+                        {},
+                    ) or {}
+                    if isinstance(raw_policy, dict):
+                        from src.core.call_metadata import normalize_call_metadata_value
+
+                        for field_name, field_policy in raw_policy.items():
+                            if field_name not in output or not isinstance(field_policy, dict):
+                                continue
+                            try:
+                                metadata_values[field_name] = normalize_call_metadata_value(
+                                    output[field_name],
+                                    max_length=int(field_policy.get("max_length") or 1024),
+                                )
+                                metadata_policy[field_name] = {
+                                    **field_policy,
+                                    "source_tool": tools_to_run[i].definition.name,
+                                }
+                            except Exception:
+                                logger.warning(
+                                    "Rejected invalid pre-call metadata value",
+                                    call_id=call_id,
+                                    tool=tools_to_run[i].definition.name,
+                                    field=field_name,
+                                )
             
             # Store pre-call results in session for debugging and in-call access
             session.pre_call_results = results
+            from src.core.call_metadata import validate_call_metadata_document
+
+            session.call_metadata = validate_call_metadata_document(metadata_values)
+            session.call_metadata_policy = metadata_policy
+            session.call_metadata_updates = []
             # Execution metadata for the call history UI (one entry per tool).
             session.pre_call_tool_calls = tool_call_records
             await self._save_session(session)
@@ -20545,6 +20637,7 @@ class Engine:
                 summary=getattr(session, 'summary', None),
                 tool_calls=list(getattr(session, 'tool_calls', []) or []),
                 pre_call_results=dict(getattr(session, 'pre_call_results', {}) or {}),
+                call_metadata=dict(getattr(session, 'call_metadata', {}) or {}),
                 campaign_id=getattr(session, 'outbound_campaign_id', None),
                 lead_id=getattr(session, 'outbound_lead_id', None),
                 config=self._tool_config_for_session(session),

--- a/src/tools/business/update_call_metadata.py
+++ b/src/tools/business/update_call_metadata.py
@@ -1,0 +1,72 @@
+"""Provider-independent correction of selected call enrichment metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from src.tools.base import Tool, ToolCategory, ToolDefinition, ToolParameter
+from src.tools.context import ToolExecutionContext
+
+
+class UpdateCallMetadataTool(Tool):
+    """Update only call-local fields selected and marked correctable by an operator."""
+
+    def __init__(self, field_policies: Mapping[str, Mapping[str, Any]] | None = None):
+        self._field_policies = {
+            str(key): dict(policy)
+            for key, policy in (field_policies or {}).items()
+            if isinstance(policy, Mapping) and bool(policy.get("correctable", False))
+        }
+
+    @property
+    def definition(self) -> ToolDefinition:
+        field_names = sorted(self._field_policies)
+        descriptions = [
+            f"{name}: {self._field_policies[name].get('description')}"
+            for name in field_names
+            if self._field_policies[name].get("description")
+        ]
+        description = (
+            "Correct one operator-approved, non-authoritative metadata value for this call. "
+            "This does not update a CRM, caller identity, routing, consent, transfer, or disposition."
+        )
+        if descriptions:
+            description += " Allowed fields: " + "; ".join(descriptions)
+        return ToolDefinition(
+            name="update_call_metadata",
+            description=description,
+            category=ToolCategory.BUSINESS,
+            parameters=[
+                ToolParameter(
+                    name="field",
+                    type="string",
+                    description="The metadata field to correct.",
+                    required=True,
+                    enum=field_names,
+                ),
+                ToolParameter(
+                    name="value",
+                    type="string",
+                    description="The caller-confirmed replacement value.",
+                    required=True,
+                ),
+            ],
+        )
+
+    async def execute(
+        self,
+        parameters: Dict[str, Any],
+        context: ToolExecutionContext,
+    ) -> Dict[str, Any]:
+        if not context.session_store:
+            return {"status": "error", "message": "Call state is unavailable."}
+        field = str(parameters.get("field") or "").strip()
+        if field not in self._field_policies:
+            return {"status": "error", "message": f"'{field}' is not an allowed correctable field."}
+        if "value" not in parameters:
+            return {"status": "error", "message": "A replacement value is required."}
+        return await context.session_store.update_call_metadata(
+            context.call_id,
+            field,
+            parameters.get("value"),
+        )

--- a/src/tools/context.py
+++ b/src/tools/context.py
@@ -294,6 +294,7 @@ class PostCallContext:
     # Tool execution data
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)  # In-call tool executions
     pre_call_results: Dict[str, str] = field(default_factory=dict)  # Data from pre-call tools
+    call_metadata: Dict[str, str] = field(default_factory=dict)  # Final effective selected values
     
     # Outbound-specific
     campaign_id: Optional[str] = None
@@ -329,6 +330,7 @@ class PostCallContext:
             "summary": self.summary or "",
             "tool_calls_json": json.dumps(self.tool_calls),
             "pre_call_results_json": json.dumps(self.pre_call_results),
+            "call_metadata_json": json.dumps(self.call_metadata),
             "campaign_id": self.campaign_id or "",
             "lead_id": self.lead_id or "",
         }
@@ -339,4 +341,17 @@ class PostCallContext:
         for key, value in (self.pre_call_results or {}).items():
             if key not in payload:
                 payload[key] = str(value) if value else ""
+        # Corrected metadata becomes the effective value for individual custom
+        # placeholders. Built-ins above always retain precedence, while
+        # pre_call_results_json remains the immutable initial lookup snapshot.
+        built_in_keys = {
+            "call_id", "caller_number", "called_number", "caller_name",
+            "context_name", "provider", "call_direction", "call_duration",
+            "call_outcome", "call_start_time", "call_end_time", "transcript_json",
+            "summary", "tool_calls_json", "pre_call_results_json",
+            "call_metadata_json", "campaign_id", "lead_id",
+        }
+        for key, value in (self.call_metadata or {}).items():
+            if key not in built_in_keys:
+                payload[key] = str(value) if value is not None else ""
         return payload

--- a/src/tools/context.py
+++ b/src/tools/context.py
@@ -294,7 +294,6 @@ class PostCallContext:
     # Tool execution data
     tool_calls: List[Dict[str, Any]] = field(default_factory=list)  # In-call tool executions
     pre_call_results: Dict[str, str] = field(default_factory=dict)  # Data from pre-call tools
-    call_metadata: Dict[str, str] = field(default_factory=dict)  # Final effective selected values
     
     # Outbound-specific
     campaign_id: Optional[str] = None
@@ -305,6 +304,9 @@ class PostCallContext:
     # Internal service callback used by post-call tools. It is deliberately
     # excluded from ``to_payload_dict`` so no runtime object leaks to webhooks.
     summary_generator: Optional[Callable[..., Any]] = None
+    # Appended to preserve the positional constructor contract of all existing
+    # fields while exposing final selected values to post-call tools.
+    call_metadata: Dict[str, str] = field(default_factory=dict)
     
     def to_payload_dict(self) -> Dict[str, Any]:
         """

--- a/src/tools/http/generic_lookup.py
+++ b/src/tools/http/generic_lookup.py
@@ -54,6 +54,9 @@ class HTTPLookupConfig:
     
     # Response mapping (JMESPath-like simple dot notation for MVP)
     output_variables: Dict[str, str] = field(default_factory=dict)
+    # Selected output fields to copy into bounded Call History metadata.
+    # Keys must also exist in output_variables; omitted means fully disabled.
+    call_metadata_fields: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     
     # Response limits
     max_response_size_bytes: int = 65536  # 64KB max
@@ -88,6 +91,12 @@ class GenericHTTPLookupTool(PreCallTool):
     """
     
     def __init__(self, config: HTTPLookupConfig):
+        from src.core.call_metadata import normalize_call_metadata_policy
+
+        config.call_metadata_fields = normalize_call_metadata_policy(
+            config.call_metadata_fields,
+            output_variables=config.output_variables,
+        )
         self.config = config
         self._definition = ToolDefinition(
             name=config.name,
@@ -647,6 +656,7 @@ def create_http_lookup_tool(name: str, config_dict: Dict[str, Any]) -> GenericHT
         query_params=config_dict.get('query_params', {}),
         body_template=config_dict.get('body_template'),
         output_variables=config_dict.get('output_variables', {}),
+        call_metadata_fields=config_dict.get('call_metadata_fields', {}),
         max_response_size_bytes=config_dict.get('max_response_size_bytes', 65536),
         response_body_max_chars=config_dict.get('response_body_max_chars'),
     )

--- a/src/tools/http/in_call_lookup.py
+++ b/src/tools/http/in_call_lookup.py
@@ -481,8 +481,16 @@ class InCallHTTPTool(Tool):
                             f"Added pre-call variables to in-call tool context: {list(pre_call_results.keys())}",
                             extra={"tool": self.config.name, "call_id": context.call_id}
                         )
+                    call_metadata = getattr(session, 'call_metadata', None) or {}
+                    built_in_keys = {
+                        "caller_number", "called_number", "caller_name",
+                        "context_name", "call_id",
+                    }
+                    for key, value in call_metadata.items():
+                        if key not in built_in_keys:
+                            sub[key] = str(value) if value is not None else ""
         except Exception as e:
-            logger.warning(f"Failed to load pre-call results for in-call tool: {e}")
+            logger.warning(f"Failed to load call enrichment for in-call tool: {e}")
         
         # Add AI-provided parameters (these override pre-call vars if same name)
         for key, value in ai_params.items():

--- a/src/tools/registry.py
+++ b/src/tools/registry.py
@@ -629,6 +629,12 @@ Tool Definitions:
             self.register(RequestTranscriptTool)
         except ImportError as e:
             logger.warning(f"Could not import RequestTranscriptTool: {e}")
+
+        try:
+            from src.tools.business.update_call_metadata import UpdateCallMetadataTool
+            self.register(UpdateCallMetadataTool)
+        except ImportError as e:
+            logger.warning(f"Could not import UpdateCallMetadataTool: {e}")
         
         try:
             from src.tools.business.gcal_tool import GCalendarTool

--- a/tests/test_call_metadata.py
+++ b/tests/test_call_metadata.py
@@ -1,0 +1,277 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def test_call_metadata_policy_is_opt_in_and_rejects_authoritative_or_secret_fields():
+    from src.core.call_metadata import (
+        CallMetadataValidationError,
+        normalize_call_metadata_policy,
+    )
+
+    policy = normalize_call_metadata_policy(
+        {
+            "customer_tier": {"persist": True, "correctable": True},
+            "ignored": {"persist": False},
+        },
+        output_variables={"customer_tier": "contact.tier", "ignored": "contact.ignored"},
+    )
+    assert set(policy) == {"customer_tier"}
+    assert policy["customer_tier"]["correctable"] is True
+
+    with pytest.raises(CallMetadataValidationError, match="authoritative call state"):
+        normalize_call_metadata_policy(
+            {"caller_number": {"persist": True}},
+            output_variables={"caller_number": "contact.phone"},
+        )
+    with pytest.raises(CallMetadataValidationError, match="credential-related"):
+        normalize_call_metadata_policy(
+            {"access_token": {"persist": True}},
+            output_variables={"access_token": "auth.token"},
+        )
+
+
+def test_update_tool_schema_contains_only_call_local_correctable_fields():
+    from src.tools.business.update_call_metadata import UpdateCallMetadataTool
+
+    tool = UpdateCallMetadataTool(
+        {
+            "customer_tier": {"correctable": True, "description": "Confirmed service tier"},
+            "account_region": {"correctable": False},
+        }
+    )
+    field = next(param for param in tool.definition.parameters if param.name == "field")
+    assert field.enum == ["customer_tier"]
+
+
+@pytest.mark.asyncio
+async def test_session_metadata_update_is_atomic_idempotent_and_fails_after_cleanup():
+    from src.core.models import CallSession
+    from src.core.session_store import SessionStore
+
+    store = SessionStore()
+    session = CallSession(call_id="metadata-call", caller_channel_id="metadata-call")
+    session.call_metadata = {"customer_tier": "silver"}
+    session.call_metadata_policy = {
+        "customer_tier": {"correctable": True, "max_length": 32},
+        "immutable_note": {"correctable": False, "max_length": 32},
+    }
+    await store.upsert_call(session)
+
+    changed = await store.update_call_metadata("metadata-call", "customer_tier", "gold")
+    assert changed == {
+        "status": "success",
+        "message": "Updated 'customer_tier' for this call.",
+        "field": "customer_tier",
+        "changed": True,
+    }
+    unchanged = await store.update_call_metadata("metadata-call", "customer_tier", "gold")
+    assert unchanged["changed"] is False
+    assert len(session.call_metadata_updates) == 1
+
+    denied = await store.update_call_metadata("metadata-call", "immutable_note", "new")
+    assert denied["status"] == "error"
+    session.cleanup_in_progress = True
+    late = await store.update_call_metadata("metadata-call", "customer_tier", "platinum")
+    assert late["status"] == "error"
+    assert session.call_metadata["customer_tier"] == "gold"
+
+    await store.remove_call("metadata-call")
+    missing = await store.update_call_metadata("metadata-call", "customer_tier", "bronze")
+    assert missing["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_call_history_metadata_round_trip_and_exact_filter(tmp_path, monkeypatch):
+    monkeypatch.setenv("CALL_HISTORY_ENABLED", "true")
+    from src.core.call_history import CallHistoryStore, CallRecord
+
+    store = CallHistoryStore(db_path=str(tmp_path / "call_metadata.db"))
+    now = datetime.now(timezone.utc)
+    for index, tier in enumerate(("gold", "golden")):
+        assert await store.save(
+            CallRecord(
+                call_id=f"metadata-{index}",
+                start_time=now + timedelta(seconds=index),
+                end_time=now + timedelta(seconds=index + 1),
+                call_metadata={"customer_tier": tier},
+                call_metadata_updates=(
+                    [{"field": "customer_tier", "source": "agent_correction"}]
+                    if index == 0
+                    else []
+                ),
+            )
+        )
+
+    rows = await store.list(
+        call_metadata_key="customer_tier",
+        call_metadata_value="gold",
+    )
+    assert [row.call_id for row in rows] == ["metadata-0"]
+    assert rows[0].call_metadata == {"customer_tier": "gold"}
+    assert rows[0].call_metadata_updates[0]["source"] == "agent_correction"
+    assert await store.count(
+        call_metadata_key="customer_tier",
+        call_metadata_value="gold",
+    ) == 1
+
+
+def test_post_call_payload_keeps_initial_snapshot_and_uses_final_effective_value():
+    from src.tools.context import PostCallContext
+
+    payload = PostCallContext(
+        call_id="post-call",
+        caller_number="1001",
+        pre_call_results={"customer_tier": "silver"},
+        call_metadata={"customer_tier": "gold"},
+    ).to_payload_dict()
+
+    assert payload["customer_tier"] == "gold"
+    assert '"customer_tier": "silver"' in payload["pre_call_results_json"]
+    assert '"customer_tier": "gold"' in payload["call_metadata_json"]
+
+
+def test_prompt_substitution_uses_final_metadata_without_overriding_builtins():
+    from src.core.models import CallSession
+    from src.engine import Engine
+
+    session = CallSession(
+        call_id="prompt-call",
+        caller_channel_id="prompt-call",
+        caller_number="1001",
+    )
+    session.pre_call_results = {
+        "customer_tier": "silver",
+        "caller_number": "untrusted",
+    }
+    session.call_metadata = {"customer_tier": "gold"}
+
+    rendered = Engine.__new__(Engine)._apply_prompt_template_substitution(
+        "tier={customer_tier}; caller={caller_number}",
+        session,
+    )
+    assert rendered == "tier=gold; caller=1001"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_execution_seeds_only_selected_metadata():
+    from src.core.models import CallSession
+    from src.engine import Engine
+
+    engine = Engine.__new__(Engine)
+    session = CallSession(call_id="pre-call-metadata", caller_channel_id="pre-call-metadata")
+    session.context_name = "support"
+    tool = SimpleNamespace(
+        definition=SimpleNamespace(
+            name="crm_lookup",
+            timeout_ms=1000,
+            hold_audio_file=None,
+            hold_audio_threshold_ms=500,
+            output_variables=["customer_tier", "internal_note"],
+        ),
+        config=SimpleNamespace(
+            call_metadata_fields={
+                "customer_tier": {
+                    "persist": True,
+                    "correctable": True,
+                    "description": "Confirmed tier",
+                    "max_length": 32,
+                }
+            }
+        ),
+        execute=AsyncMock(return_value={"customer_tier": "gold", "internal_note": "prompt only"}),
+    )
+    session.tool_runtime_registry = SimpleNamespace(
+        get_tools_for_context=lambda **_kwargs: [tool]
+    )
+    engine.transport_orchestrator = SimpleNamespace(
+        get_context_config=lambda *_args: SimpleNamespace(
+            pre_call_tools=["crm_lookup"],
+            disable_global_pre_call_tools=[],
+        )
+    )
+    engine.config = SimpleNamespace()
+    engine.ari_client = None
+    engine._save_session = AsyncMock()
+
+    result = await engine._execute_pre_call_tools(session.call_id, session)
+
+    assert result == {"customer_tier": "gold", "internal_note": "prompt only"}
+    assert session.pre_call_results == result
+    assert session.call_metadata == {"customer_tier": "gold"}
+    assert session.call_metadata_policy["customer_tier"]["source_tool"] == "crm_lookup"
+    assert "internal_note" not in session.call_metadata
+
+
+@pytest.mark.asyncio
+async def test_in_call_http_substitution_prefers_final_metadata_then_ai_parameters():
+    from src.core.models import CallSession
+    from src.core.session_store import SessionStore
+    from src.tools.context import ToolExecutionContext
+    from src.tools.http.in_call_lookup import InCallHTTPConfig, InCallHTTPTool
+
+    store = SessionStore()
+    session = CallSession(call_id="in-call-metadata", caller_channel_id="in-call-metadata")
+    session.pre_call_results = {"customer_tier": "silver"}
+    session.call_metadata = {"customer_tier": "gold"}
+    await store.upsert_call(session)
+    tool = InCallHTTPTool(InCallHTTPConfig(name="lookup"))
+    context = ToolExecutionContext(
+        call_id=session.call_id,
+        caller_number="1001",
+        session_store=store,
+    )
+
+    effective = await tool._build_substitution_context({}, context)
+    assert effective["customer_tier"] == "gold"
+    ai_override = await tool._build_substitution_context(
+        {"customer_tier": "explicit-tool-parameter"},
+        context,
+    )
+    assert ai_override["customer_tier"] == "explicit-tool-parameter"
+
+
+@pytest.mark.asyncio
+async def test_call_local_registry_removes_tool_without_fields_and_installs_bounded_schema():
+    from src.core.models import CallSession
+    from src.core.session_store import SessionStore
+    from src.engine import Engine
+
+    class FakeRegistry:
+        def __init__(self):
+            self.registered = None
+            self.removed = []
+
+        def clone(self):
+            return FakeRegistry()
+
+        def register_instance(self, tool):
+            self.registered = tool
+
+        def unregister(self, name):
+            self.removed.append(name)
+
+    store = SessionStore()
+    session = CallSession(call_id="schema-call", caller_channel_id="schema-call")
+    session.tool_runtime_registry = FakeRegistry()
+    session.call_metadata_policy = {
+        "customer_tier": {"correctable": True, "max_length": 32},
+        "immutable_note": {"correctable": False, "max_length": 32},
+    }
+    await store.upsert_call(session)
+    engine = Engine.__new__(Engine)
+    engine.session_store = store
+    engine._save_session = AsyncMock()
+
+    configured = await engine._configure_call_metadata_tool_runtime(session)
+    tool = configured.tool_runtime_registry.registered
+    field = next(param for param in tool.definition.parameters if param.name == "field")
+    assert field.enum == ["customer_tier"]
+
+    configured.call_metadata_policy = {}
+    configured.tool_runtime_registry = FakeRegistry()
+    configured = await engine._configure_call_metadata_tool_runtime(configured)
+    assert configured.tool_runtime_registry.registered is None
+    assert configured.tool_runtime_registry.removed == ["update_call_metadata"]

--- a/tests/test_call_metadata.py
+++ b/tests/test_call_metadata.py
@@ -31,6 +31,17 @@ def test_call_metadata_policy_is_opt_in_and_rejects_authoritative_or_secret_fiel
             {"access_token": {"persist": True}},
             output_variables={"access_token": "auth.token"},
         )
+    for credential_field in ("customerAccessToken", "crmPassword"):
+        with pytest.raises(CallMetadataValidationError, match="credential-related"):
+            normalize_call_metadata_policy(
+                {credential_field: {"persist": True}},
+                output_variables={credential_field: "contact.value"},
+            )
+    with pytest.raises(CallMetadataValidationError, match="not a configured output variable"):
+        normalize_call_metadata_policy(
+            {"customer_tier": {"persist": True}},
+            output_variables={},
+        )
 
 
 def test_update_tool_schema_contains_only_call_local_correctable_fields():
@@ -131,6 +142,38 @@ def test_post_call_payload_keeps_initial_snapshot_and_uses_final_effective_value
     assert payload["customer_tier"] == "gold"
     assert '"customer_tier": "silver"' in payload["pre_call_results_json"]
     assert '"customer_tier": "gold"' in payload["call_metadata_json"]
+
+
+def test_post_call_context_preserves_existing_positional_field_order():
+    from src.tools.context import PostCallContext
+
+    summary_generator = object()
+    context = PostCallContext(
+        "post-call",
+        "1001",
+        None,
+        None,
+        "support",
+        "deepgram",
+        "inbound",
+        12,
+        "completed",
+        None,
+        None,
+        [],
+        None,
+        [],
+        {},
+        "campaign-1",
+        "lead-1",
+        {"tools": {}},
+        summary_generator,
+    )
+
+    assert context.campaign_id == "campaign-1"
+    assert context.config == {"tools": {}}
+    assert context.summary_generator is summary_generator
+    assert context.call_metadata == {}
 
 
 def test_prompt_substitution_uses_final_metadata_without_overriding_builtins():

--- a/tests/test_call_metadata.py
+++ b/tests/test_call_metadata.py
@@ -42,6 +42,12 @@ def test_call_metadata_policy_is_opt_in_and_rejects_authoritative_or_secret_fiel
             {"customer_tier": {"persist": True}},
             output_variables={},
         )
+    for invalid_flag in ("true", 1, [], None):
+        with pytest.raises(CallMetadataValidationError, match="must be a boolean"):
+            normalize_call_metadata_policy(
+                {"customer_tier": {"persist": invalid_flag}},
+                output_variables={"customer_tier": "contact.tier"},
+            )
 
 
 def test_update_tool_schema_contains_only_call_local_correctable_fields():


### PR DESCRIPTION
## Summary

- Add opt-in persistence for selected pre-call HTTP lookup outputs in a bounded, non-authoritative `call_metadata` namespace.
- Add a call-local `update_call_metadata` tool limited to fields explicitly marked correctable and separately assigned to the Agent.
- Expose final metadata, value-free correction provenance, exact filtering, and CSV/JSON export through Call History.
- Add Admin UI controls for persistence/correction plus Call History filters and provenance badges.
- Keep original pre-call results immutable and keep caller, routing, consent/DNC, transfer, disposition, credentials, and external-dialer state outside this enhancement.

## Related Issue(s)

- Closes #625
- Closes #627

## Implementation Notes

- Core lifecycle and bounds: `src/core/call_metadata.py`, `src/core/session_store.py`, `src/engine.py`
- Call-local tool: `src/tools/business/update_call_metadata.py`
- Storage, filters, and exports: `src/core/call_history.py`, `admin_ui/backend/api/calls.py`
- Admin configuration and history UI: `admin_ui/frontend/src/components/config/HTTPToolForm.tsx`, `admin_ui/frontend/src/pages/CallHistoryPage.tsx`
- Metadata remains opt-in, scalar, bounded, and separate from authoritative call and external-dialer state.
- Correctable field configuration defines the call-local schema but does not automatically grant the Agent permission to invoke the correction tool.

## Testing

- [x] Core Python suite: 2,337 passed, 11 skipped
- [x] Admin backend suite: 585 passed
- [x] Frontend suite: 301 passed
- [x] Frontend lint completed with zero errors and within the existing warning budget
- [x] Production Admin UI Docker build passed on Node 20
- [x] Targeted metadata, API-validation, CSV-safety, pagination, and UI regressions passed
- [x] voiprnd runtime verification completed on final head `5cb35a283a983d96a05ec27f6290f65578815a14`, including the deployed CSV neutralization check
- [x] Verified engine `/live`, `/ready`, and `/health`; ARI; AudioSocket; providers; all configured pipelines; Admin UI `/health`; SQLite migration; tool catalog; metadata filter behavior; and authenticated UI flow

No test call was placed because the enhancement is opt-in and voiprnd has no production metadata policy configured. Runtime lifecycle, correction, persistence, and cleanup paths are covered by automated tests; UI verification did not save production configuration.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [x] Review fixes were pushed as cohesive batches
- [x] CodeRabbit full and incremental reviews were assessed
- [x] All actionable conversations were resolved
- [x] Final CI gate passed on the reviewed and deployed head

## Documentation

- [x] `CHANGELOG.md` — Unreleased feature note, additive schema behavior, and disable/rollback behavior
- [x] `docs/TOOL_CALLING_GUIDE.md` — configuration, correction authorization, precedence, webhook, filter, and export behavior
- [x] `docs/ADMIN_UI_GUIDE.md` — Call History metadata, provenance, and exact filtering
- [x] No migration-guide update required: the two SQLite columns are additive and created automatically; existing records deserialize with empty metadata

## Safety Boundary

Metadata is opt-in, scalar, field-count/value/aggregate bounded, and stored separately from VICIdial `external_metadata`. Corrections are atomic, idempotent, active-call-only, fail closed during cleanup, and do not write back to a CRM or mutate authoritative call state.
