### PR TITLE
fix(admin-ui): honor api_key_file/api_key_env in google_live test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Opt-in call metadata persistence and call-local correction** ([#625](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/625), [#627](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/627)): individual pre-call HTTP lookup outputs can be selected for bounded, non-authoritative persistence in Call History, exposed to prompts and post-call webhooks, filtered by exact field/value, and included in CSV/JSON exports. Fields explicitly marked correctable can be changed during the active call only when the Agent is separately granted `update_call_metadata`; corrections preserve the original pre-call snapshot and never write back to the CRM or mutate caller identity, routing, consent/DNC, transfer, disposition, provider, or external-dialer state. The Admin UI adds per-output persistence/correction controls plus metadata provenance in Call History. Existing databases receive two additive SQLite columns automatically; existing records remain valid with empty metadata, and disabling the policy stops future persistence without removing historical values.
 
+### Fixed
+
+- **Google Live "Test Connection" honors managed API key files/env references** ([#633](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/633)): the Admin UI's provider connection test now uses the already-resolved `api_key_file`/`api_key_env` secret before falling back to `GOOGLE_API_KEY` in `.env`. Previously the test ignored resolved credentials and reported a broken provider even while `ai_engine` was placing live calls on that same key.
+
 ## [7.5.6] - 2026-08-26
 
 ### Added

--- a/admin_ui/backend/api/config.py
+++ b/admin_ui/backend/api/config.py
@@ -1964,9 +1964,9 @@ async def test_provider_connection(request: ProviderTestRequest):
                 
         elif 'google_live' in provider_config or ('llm_model' in provider_config and 'gemini' in provider_config.get('llm_model', '')):
             # Google Live
-            api_key = get_env_key('GOOGLE_API_KEY')
+            api_key = provider_config.get('api_key') or get_env_key('GOOGLE_API_KEY')
             if not api_key:
-                return {"success": False, "message": "GOOGLE_API_KEY not set in .env file"}
+                return {"success": False, "message": "No Google API key configured (checked api_key_file/api_key_env and GOOGLE_API_KEY in .env)"}
             async with httpx.AsyncClient() as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",

--- a/admin_ui/backend/tests/test_google_live_provider_test_connection.py
+++ b/admin_ui/backend/tests/test_google_live_provider_test_connection.py
@@ -1,0 +1,131 @@
+"""Regression tests for #633: Google Live "Test Connection" ignoring managed secrets.
+
+test_provider_connection() resolves api_key_file / api_key_env into
+provider_config["api_key"] before it decides which provider branch to run,
+but the google_live branch used to ignore that and read GOOGLE_API_KEY
+straight out of .env. These tests pin the fixed behavior: a resolved key
+(from either source) is what gets sent to Google, the .env fallback still
+works when no managed secret is configured, and the endpoint fails fast
+with no network call when nothing resolves.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from api import config  # noqa: E402
+
+
+def _fake_google_models_client(captured):
+    """A fake httpx.AsyncClient whose GET records the URL it was called with."""
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+
+    async def fake_get(url, timeout=None):
+        captured["url"] = url
+        return fake_resp
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+    return fake_client
+
+
+def _google_live_request(**extra_config):
+    return config.ProviderTestRequest(
+        name="google_live",
+        config={
+            "type": "google_live",
+            "llm_model": "gemini-2.5-flash-native-audio-latest",
+            **extra_config,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_uses_resolved_key_from_api_key_file(monkeypatch, tmp_path):
+    """A key delivered through api_key_file is what reaches Google, not .env."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("GOOGLE_API_KEY=\n", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+    monkeypatch.setattr(
+        config,
+        "_provider_instances_module",
+        lambda: {"resolve_secret_value": lambda *a, **k: "key-from-file"},
+    )
+
+    request = _google_live_request(api_key_file="/app/project/secrets/providers/google_live/api-key")
+    captured = {}
+
+    with patch("httpx.AsyncClient", return_value=_fake_google_models_client(captured)):
+        result = await config.test_provider_connection(request)
+
+    assert result["success"] is True
+    assert "key=key-from-file" in captured["url"]
+
+
+@pytest.mark.asyncio
+async def test_uses_resolved_key_from_api_key_env(monkeypatch, tmp_path):
+    """A key delivered through api_key_env is what reaches Google, not .env."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("GOOGLE_API_KEY=\n", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+    monkeypatch.setattr(
+        config,
+        "_provider_instances_module",
+        lambda: {"resolve_secret_value": lambda *a, **k: "key-from-env-ref"},
+    )
+
+    request = _google_live_request(api_key_env="MY_GOOGLE_KEY_REF")
+    captured = {}
+
+    with patch("httpx.AsyncClient", return_value=_fake_google_models_client(captured)):
+        result = await config.test_provider_connection(request)
+
+    assert result["success"] is True
+    assert "key=key-from-env-ref" in captured["url"]
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_dotenv_when_no_managed_secret_configured(monkeypatch, tmp_path):
+    """No api_key_file or api_key_env set: the plain .env GOOGLE_API_KEY still works."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("GOOGLE_API_KEY=dotenv-key\n", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+
+    request = _google_live_request()
+    captured = {}
+
+    with patch("httpx.AsyncClient", return_value=_fake_google_models_client(captured)):
+        result = await config.test_provider_connection(request)
+
+    assert result["success"] is True
+    assert "key=dotenv-key" in captured["url"]
+
+
+@pytest.mark.asyncio
+async def test_reports_missing_key_without_calling_google(monkeypatch, tmp_path):
+    """Nothing resolves anywhere: fail with the new message, never touch the network."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("", encoding="utf-8")
+    monkeypatch.setattr(config.settings, "ENV_PATH", str(env_path))
+
+    request = _google_live_request()
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        result = await config.test_provider_connection(request)
+
+    mock_client_cls.assert_not_called()
+    assert result == {
+        "success": False,
+        "message": "No Google API key configured (checked api_key_file/api_key_env and GOOGLE_API_KEY in .env)",
+    }


### PR DESCRIPTION
## Summary

Test Connection on the Providers page fails for `google_live` whenever the key lives anywhere other than `.env`. `test_provider_connection()` resolves managed secrets into `provider_config["api_key"]` at the top of the function, and the `google_live` branch then ignores that value and calls `get_env_key('GOOGLE_API_KEY')` on its own. A deployment backed by `api_key_file` or `api_key_env` gets `GOOGLE_API_KEY not set in .env file` from the UI while `ai_engine` is placing live calls on the same credential.

## Related Issue(s)

- Closes #633

## Implementation Notes

- Key files touched: `admin_ui/backend/api/config.py`, inside the `google_live` branch of `test_provider_connection()`
- The resolved key wins, `.env` stays as the fallback, and the failure message names both sources it checked:

```diff
-            api_key = get_env_key('GOOGLE_API_KEY')
+            api_key = provider_config.get('api_key') or get_env_key('GOOGLE_API_KEY')
             if not api_key:
-                return {"success": False, "message": "GOOGLE_API_KEY not set in .env file"}
+                return {"success": False, "message": "No Google API key configured (checked api_key_file/api_key_env and GOOGLE_API_KEY in .env)"}
```

Nothing below the branch changes. The `httpx` GET to `generativelanguage.googleapis.com/v1beta/models` and the whole success path are untouched.

## Testing

- [ ] Unit tests: none exist for `test_provider_connection()`'s `google_live` branch, so none were run. Happy to add coverage if maintainers want it.
- [x] Integration / manual tests: verified on a Docker deployment where the key is stored through `api_key_file` with `GOOGLE_API_KEY` empty in `.env`. Test Connection returned failure before this change and success after.
- [ ] `agent check`
- [ ] `agent rca`
- [ ] `./scripts/rca_collect.sh` (if applicable)

Not a telephony change, no test calls involved.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [ ] Review fixes were pushed as a cohesive batch
- [ ] Final head is frozen, the PR is ready, and the final CI gate has passed
- [ ] `@coderabbitai full review` completed on the frozen head
- [ ] Optional `codex-review` label/manual workflow completed on the frozen head, if requested
- [ ] All actionable conversations are resolved

## Documentation

No docs updated. This fixes an internal validation bug in the Admin UI test endpoint, it doesn't change any documented config schema or behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Live provider connection tests now use the configured API key when available, with a fallback to the environment setting.
  * Improved the error message shown when no API key is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->