### PR TITLE
fix(a11y): restore <select> option contrast in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Google Live "Test Connection" honors managed API key files/env references** ([#633](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/633)): the Admin UI's provider connection test now uses the already-resolved `api_key_file`/`api_key_env` secret before falling back to `GOOGLE_API_KEY` in `.env`. Previously the test ignored resolved credentials and reported a broken provider even while `ai_engine` was placing live calls on that same key.
+- **Dark-theme `<select>` options are readable again** ([#635](https://github.com/hkjarral/AVA-AI-Voice-Agent-for-Asterisk/issues/635)): option text rendered near-white on the browser's white popup canvas in dark mode, measured at 1.04:1 and unreadable unless a row was hovered. Tailwind Preflight sets `color: inherit` on `select`, which overrides the browser default `select { color: FieldText }`, and options inherit from the select; nothing declared `color-scheme`, so the popup kept the light canvas. Both themes now declare `color-scheme`, and options paint from the `--popover` tokens: 19.06:1 in dark, 19.90:1 in light. Disabled options get a consistent theme-aware muted colour, where Chromium previously drew them the same as enabled options.
 
 ## [7.5.6] - 2026-08-26
 

--- a/admin_ui/frontend/src/index.css
+++ b/admin_ui/frontend/src/index.css
@@ -26,6 +26,13 @@
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 10%;
     --radius: 0.5rem;
+    /*
+     * Native form controls (select popups, checkboxes, date inputs,
+     * scrollbars) are drawn by the browser using color-scheme, not by
+     * this file's custom properties. Nothing set it before, so those
+     * controls stayed light even after the rest of the UI went dark.
+     */
+    color-scheme: light;
   }
 
   .dark {
@@ -48,6 +55,8 @@
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
+
+    color-scheme: dark;
   }
 }
 
@@ -58,5 +67,22 @@
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  /*
+   * Preflight's `color: inherit` on select beats UA `select { color:
+   * FieldText }`, so select computes --foreground and options inherit that.
+   * background-color skips option, and select's bg skips the popup, so it
+   * kept the light UA canvas: 1.04:1. Chromium paints disabled options the
+   * same as enabled, so this rule pins both engines to one token.
+   */
+  option,
+  optgroup {
+    background-color: hsl(var(--popover));
+    color: hsl(var(--popover-foreground));
+  }
+
+  option:disabled {
+    color: hsl(var(--muted-foreground));
   }
 }

--- a/admin_ui/frontend/src/index.css.colorScheme.test.ts
+++ b/admin_ui/frontend/src/index.css.colorScheme.test.ts
@@ -1,0 +1,50 @@
+// @ts-expect-error - no @types/node in this project; vitest runs this file in node
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Dark-mode dropdown contrast regression (WCAG 1.4.3).
+ *
+ * Tailwind Preflight sets `color: inherit` on `select`, overriding the
+ * browser default `select { color: FieldText }`. The select resolves to
+ * `--foreground`, and options inherit that, landing near-white in dark mode.
+ * `background-color` does not inherit into `option`, and a select's own
+ * background does not paint the popup listbox, so the popup falls back to
+ * the user-agent canvas. With no `color-scheme` declared, that canvas is
+ * white: near-white text on white, measured at 1.04:1.
+ *
+ * jsdom resolves neither system colours nor `color-scheme`, so this guards
+ * the declarations rather than the rendering. Rendered contrast after the
+ * fix was measured in Chromium and Firefox: 19.06:1 dark, 19.90:1 light.
+ */
+
+const css = readFileSync(new URL('./index.css', import.meta.url), 'utf8');
+
+/** Returns the declaration body of the first rule whose selector matches `head`. */
+const declarations = (head: RegExp): string => {
+    const match = css.match(new RegExp(`${head.source}\\s*\\{([^}]*)\\}`));
+    if (!match) throw new Error(`index.css has no rule matching ${head}`);
+    return match[1];
+};
+
+describe('index.css — native control colour scheme', () => {
+    it('opts the light theme into the light colour scheme', () => {
+        expect(declarations(/:root/)).toMatch(/color-scheme:\s*light/);
+    });
+
+    it('opts the dark theme into the dark colour scheme', () => {
+        expect(declarations(/\.dark/)).toMatch(/color-scheme:\s*dark/);
+    });
+
+    it('paints option and optgroup from the popover tokens', () => {
+        const body = declarations(/option,\s*optgroup/);
+        expect(body).toMatch(/background-color:\s*hsl\(var\(--popover\)\)/);
+        expect(body).toMatch(/color:\s*hsl\(var\(--popover-foreground\)\)/);
+    });
+
+    it('keeps disabled options visually distinct', () => {
+        expect(declarations(/option:disabled/)).toMatch(
+            /color:\s*hsl\(var\(--muted-foreground\)\)/
+        );
+    });
+});


### PR DESCRIPTION
## Summary
Tailwind Preflight sets `color: inherit` on `select`, overriding the browser default (`select { color: FieldText }`). `<option>` has no user-agent color rule, so it inherits `--foreground`, near-white in dark mode. `background-color` doesn't inherit into `option`, and a select's background doesn't paint its popup listbox, which fell back to the light UA canvas because nothing declared `color-scheme`. Result: 1.04:1 contrast in dark mode, unreadable except on a hovered or selected row, across every `<select>` in the app.

Fix: add `color-scheme: light` / `dark` to the existing `:root` and `.dark` token blocks, and style `option`, `optgroup`, and `option:disabled` against `--popover`, `--popover-foreground`, and `--muted-foreground`.

## Scope
- `admin_ui/frontend/src/index.css`: color-scheme declarations, option/optgroup rules
- `admin_ui/frontend/src/index.css.colorScheme.test.ts`: new, 4 assertions
- `CHANGELOG.md`: one line under `[Unreleased]`

`color-scheme` also governs checkboxes, radios, date/time inputs, and scrollbars, so those now follow the active theme too. That is broader than the reported bug, and it is intentional.

## Tests / CI
- vitest: 305 passing across 42 files, up from 301 across 41
- `npm run build`: clean
- `npm run lint`: clean, 0 errors
- `tsc --noEmit`: unchanged at 57 pre-existing errors (a clean clone already has them; CI doesn't run tsc)

The new test asserts the CSS declarations exist, not that they render. jsdom resolves neither system colors nor `color-scheme`, so it guards against the lines being deleted, not against a rendering regression. It imports `node:fs` behind a `@ts-expect-error`, since the project has no `@types/node`; adding that dependency felt like more than this fix warrants.

## Verification
Measured against the built stylesheet (baseline: clean clone at `b12812e0`, fixed: this branch) in Chromium 151 and Firefox 153. Both engines agreed exactly.

| | dark | light |
|---|---|---|
| before | 1.04:1 | 19.90:1 |
| after | 19.06:1 | 19.90:1 |
| disabled option (after) | 7.76:1 | 4.83:1 |

Also deployed to a production FreePBX 17 host running AVA 7.5.6 and re-measured against the stylesheet served over the wire. Same figures.

`OpenAIProviderForm.tsx` has a `<select multiple>` whose inline listbox rows this rule also paints. That is harmless while `--popover` and `--background` hold the same values in both themes, but it matters if they ever diverge.

Fixes #635


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-theme dropdown readability by ensuring options use appropriate theme colors.
  * Updated disabled dropdown options with consistent, theme-aware muted colors.
  * Native controls, including checkboxes, date inputs, and scrollbars, now better follow the selected light or dark theme.

* **Tests**
  * Added regression coverage for theme-aware native control and dropdown styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->