### PR TITLE
feat(tts): Fish Audio realtime transport, and a streaming text interface for TTS adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,8 @@ DEEPGRAM_API_KEY=
 GOOGLE_API_KEY=
 ELEVENLABS_API_KEY=
 CAMB_API_KEY=
+# Fish Audio TTS (https://fish.audio) - streams PCM at the call sample rate
+FISH_AUDIO_API_KEY=
 
 # xAI Grok Voice Agent (full-agent realtime provider, NEW in v6.5.2)
 # Get an API key at: https://x.ai/api  (console)

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -567,6 +567,7 @@ providers:
     normalize: true
     temperature: 0.7
     top_p: 0.7
+    request_timeout_sec: 15
   openai_stt:
     enabled: false
     capabilities:

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -558,6 +558,7 @@ providers:
     capabilities:
     - tts
     enabled: false
+    transport: http        # http or websocket (realtime session)
     model: s2.1-pro
     reference_id: null
     audio_format: pcm

--- a/config/ai-agent.yaml
+++ b/config/ai-agent.yaml
@@ -119,6 +119,25 @@ pipelines:
     tts: local_tts
   # Local STT + OpenAI LLM + ElevenLabs TTS (premium voice quality)
   # Requires: ELEVENLABS_API_KEY + OPENAI_API_KEY in .env
+  hybrid_fishaudio:
+    stt: local_stt
+    llm: openai_llm
+    tts: fishaudio_tts
+    options:
+      stt:
+        chunk_ms: 160
+        mode: stt
+        streaming: true
+        stream_format: pcm16_16k
+      llm:
+        base_url: https://api.openai.com/v1
+        model: gpt-4o-mini
+        temperature: 0.7
+        max_tokens: 200
+      tts:
+        format:
+          encoding: mulaw
+          sample_rate: 8000
   hybrid_elevenlabs:
     stt: local_stt
     llm: openai_llm
@@ -534,6 +553,20 @@ providers:
     similarity_boost: 0.75
     style: 0.0
     use_speaker_boost: true
+  fishaudio_tts:
+    type: fishaudio
+    capabilities:
+    - tts
+    enabled: false
+    model: s2.1-pro
+    reference_id: null
+    audio_format: pcm
+    sample_rate: null
+    latency: low
+    chunk_length: 200
+    normalize: true
+    temperature: 0.7
+    top_p: 0.7
   openai_stt:
     enabled: false
     capabilities:

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -801,3 +801,81 @@ By default, the Admin UI blocks test requests to localhost/private targets to re
 MCP-backed tools (Model Context Protocol) can be exposed through the existing tool calling system.
 
 - Design + configuration guide: `docs/MCP_INTEGRATION.md`
+
+## Fish Audio TTS (`fishaudio_tts`)
+
+Native support for [Fish Audio](https://fish.audio) speech models (S1, S2 and the
+drama preview). Fish Audio returns raw PCM over a chunked HTTP response, at a
+sample rate you choose, so the adapter asks for the call's own rate: on a
+telephone call the audio is produced at 8 kHz, converted to µ-law chunk by chunk
+and forwarded while the sentence is still being synthesised.
+
+### Credentials
+
+```bash
+# .env
+FISH_AUDIO_API_KEY=your-api-key
+```
+
+The provider is skipped (with a warning) when the key is missing, so a pipeline
+referencing it falls back to a placeholder adapter instead of failing the call.
+
+### Provider configuration
+
+```yaml
+providers:
+  fishaudio_tts:
+    type: fishaudio
+    capabilities:
+      - tts
+    enabled: true
+    model: s2.1-pro        # s1, s2-pro, s2.1-pro, drama-3-preview
+    reference_id: null     # voice model id from your Fish Audio library
+    audio_format: pcm      # pcm (streamed) or wav (buffered)
+    sample_rate: null      # null follows the call: 8 kHz telephony, 16 kHz wideband
+    latency: low           # low, normal, balanced
+    chunk_length: 200      # 100-300, provider-side synthesis granularity
+    normalize: true
+    temperature: 0.7
+    top_p: 0.7
+    speed: null            # prosody.speed override
+    volume: null           # prosody.volume override
+    output_resampler: inherit
+```
+
+| Key | Purpose |
+|---|---|
+| `model` | Sent as the `model` HTTP header, which is how Fish Audio selects the speech model. |
+| `reference_id` | Voice model id (a voice from the Fish Audio library, or one you cloned). Omit to use the account default. |
+| `audio_format` | `pcm` streams chunk by chunk and is recommended for calls; `wav` is read in full, then decoded. |
+| `sample_rate` | Leave `null` to follow the negotiated transport. A rate Fish Audio cannot emit falls back to 16 kHz and is resampled locally. |
+| `latency` | `low` favours time to first audio, which is what a phone call needs. |
+| `speed`, `volume` | Sent as `prosody`; leave `null` to keep the model default. |
+
+Every key can also be set per pipeline under `options.tts`, and overridden per
+request at runtime.
+
+### Example pipeline
+
+```yaml
+pipelines:
+  hybrid_fishaudio:
+    stt: local_stt
+    llm: openai_llm
+    tts: fishaudio_tts
+    options:
+      tts:
+        format:
+          encoding: mulaw
+          sample_rate: 8000
+```
+
+### Tests
+
+```bash
+pytest tests/test_pipeline_fish_audio_adapters.py          # mocked HTTP
+FISH_AUDIO_API_KEY=... pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+```
+
+The integration test is skipped unless `FISH_AUDIO_API_KEY` is set; set
+`FISH_AUDIO_REFERENCE_ID` as well to synthesise with a specific voice.

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -831,6 +831,7 @@ providers:
     capabilities:
       - tts
     enabled: true
+    transport: http        # http, or websocket for the realtime session
     model: s2.1-pro        # s1, s2-pro, s2.1-pro, drama-3-preview
     reference_id: null     # voice model id from your Fish Audio library
     audio_format: pcm      # pcm (streamed) or wav (buffered)
@@ -855,6 +856,8 @@ providers:
 | `latency` | `low` favours time to first audio, which is what a phone call needs. |
 | `speed`, `volume` | Sent as `prosody`; leave `null` to keep the model default. |
 | `request_timeout_sec` | Whole-request budget, streamed body included. A hung provider fails the turn instead of holding it open. |
+| `transport` | `http` posts one request per fragment. `websocket` opens one realtime session per turn and receives the text as the engine produces it (needs `msgpack`). |
+| `ws_base_url` | Realtime endpoint; defaults to `base_url` with a `ws`/`wss` scheme. Point it at the mock to test locally. |
 
 Every key can also be set per pipeline under `options.tts`, and overridden per
 request at runtime.

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -877,5 +877,21 @@ pytest tests/test_pipeline_fish_audio_adapters.py          # mocked HTTP
 FISH_AUDIO_API_KEY=... pytest -m integration tests/test_pipeline_fish_audio_adapters.py
 ```
 
+Without an account, `scripts/fish_audio_mock.py` answers like the service does
+(Bearer auth, `model` header, body validation, chunked audio) so the whole path
+can be exercised, including a call end to end:
+
+```bash
+python scripts/fish_audio_mock.py &
+FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_BASE_URL=http://127.0.0.1:8788/v1 \
+    pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+```
+
+Set `base_url: http://127.0.0.1:8788/v1` on the provider to route a real call
+through the mock. It serves a generated tone by default; set
+`FISH_MOCK_LOCAL_WS=ws://127.0.0.1:8765` to hear speech from a local AI server
+instead. The request text also carries hooks — `FISH_MOCK_401`,
+`FISH_MOCK_SLOW`, `FISH_MOCK_EMPTY` — to check how failures are handled.
+
 The integration test is skipped unless `FISH_AUDIO_API_KEY` is set; set
 `FISH_AUDIO_REFERENCE_ID` as well to synthesise with a specific voice.

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -842,6 +842,7 @@ providers:
     top_p: 0.7
     speed: null            # prosody.speed override
     volume: null           # prosody.volume override
+    request_timeout_sec: 15
     output_resampler: inherit
 ```
 
@@ -853,6 +854,7 @@ providers:
 | `sample_rate` | Leave `null` to follow the negotiated transport. A rate Fish Audio cannot emit falls back to 16 kHz and is resampled locally. |
 | `latency` | `low` favours time to first audio, which is what a phone call needs. |
 | `speed`, `volume` | Sent as `prosody`; leave `null` to keep the model default. |
+| `request_timeout_sec` | Whole-request budget, streamed body included. A hung provider fails the turn instead of holding it open. |
 
 Every key can also be set per pipeline under `options.tts`, and overridden per
 request at runtime.

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -848,7 +848,7 @@ providers:
 
 | Key | Purpose |
 |---|---|
-| `model` | Sent as the `model` HTTP header, which is how Fish Audio selects the speech model. |
+| `model` | Sent as the `model` HTTP header, which is how Fish Audio selects the speech model. `s2.1-pro-free` needs no API credit, which is handy for a live check. |
 | `reference_id` | Voice model id (a voice from the Fish Audio library, or one you cloned). Omit to use the account default. |
 | `audio_format` | `pcm` streams chunk by chunk and is recommended for calls; `wav` is read in full, then decoded. |
 | `sample_rate` | Leave `null` to follow the negotiated transport. A rate Fish Audio cannot emit falls back to 16 kHz and is resampled locally. |

--- a/docs/Configuration-Reference.md
+++ b/docs/Configuration-Reference.md
@@ -804,6 +804,8 @@ MCP-backed tools (Model Context Protocol) can be exposed through the existing to
 
 ## Fish Audio TTS (`fishaudio_tts`)
 
+Full setup walkthrough: [Provider-FishAudio-Setup.md](Provider-FishAudio-Setup.md).
+
 Native support for [Fish Audio](https://fish.audio) speech models (S1, S2 and the
 drama preview). Fish Audio returns raw PCM over a chunked HTTP response, at a
 sample rate you choose, so the adapter asks for the call's own rate: on a

--- a/docs/Provider-FishAudio-Setup.md
+++ b/docs/Provider-FishAudio-Setup.md
@@ -16,7 +16,7 @@ resample, no waiting for the full sentence.
 |---|---|
 | Capability | TTS (pipeline adapter) |
 | Provider key | `fishaudio_tts` |
-| Models | `s1`, `s2-pro`, `s2.1-pro` (default), `drama-3-preview` |
+| Models | `s1`, `s2-pro`, `s2.1-pro` (default), `drama-3-preview`, `s2.1-pro-free` (no API credit needed, for testing) |
 | Output used | `pcm` (streamed) or `wav` (buffered) |
 | Pricing | Per character, see [fish.audio](https://fish.audio) — a free tier is available for testing |
 | Per-agent voice | Not applicable (modular adapter); the voice is set on the provider or pipeline |
@@ -128,6 +128,21 @@ the provider. The mock serves a generated tone by default; point
 `FISH_MOCK_LOCAL_WS=ws://127.0.0.1:8765` at a local AI server to hear speech
 instead. Three hooks in the request text exercise failure handling:
 `FISH_MOCK_401`, `FISH_MOCK_SLOW` and `FISH_MOCK_EMPTY`.
+
+## Checking against the live service for free
+
+The `s2.1-pro-free` model answers without API credit, so the live endpoint can
+be exercised at no cost:
+
+```bash
+FISH_AUDIO_API_KEY=... FISH_AUDIO_MODEL=s2.1-pro-free \
+    FISH_AUDIO_REFERENCE_ID=<a voice id from the library> \
+    pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+```
+
+Worth knowing before you top up: API credit is billed separately from the
+platform credit shown in the web app. An account with platform credits but no
+developer balance gets `402 Payment Required` from the paid models.
 
 ## Troubleshooting
 

--- a/docs/Provider-FishAudio-Setup.md
+++ b/docs/Provider-FishAudio-Setup.md
@@ -1,0 +1,150 @@
+# Fish Audio Provider Setup Guide
+
+## Overview
+
+[Fish Audio](https://fish.audio) is a text-to-speech service built on the S1/S2
+speech models, with a large public voice library and voice cloning. It is a
+pipeline TTS adapter in AVA: pair it with any STT and LLM provider.
+
+It suits telephony for one specific reason: the API returns **raw PCM at a sample
+rate you choose**, streamed over a chunked HTTP response. AVA asks for the call's
+own rate, so an 8 kHz call is synthesised at 8 kHz, converted to µ-law chunk by
+chunk, and played while the sentence is still being generated — no intermediate
+resample, no waiting for the full sentence.
+
+| | |
+|---|---|
+| Capability | TTS (pipeline adapter) |
+| Provider key | `fishaudio_tts` |
+| Models | `s1`, `s2-pro`, `s2.1-pro` (default), `drama-3-preview` |
+| Output used | `pcm` (streamed) or `wav` (buffered) |
+| Pricing | Per character, see [fish.audio](https://fish.audio) — a free tier is available for testing |
+| Per-agent voice | Not applicable (modular adapter); the voice is set on the provider or pipeline |
+
+## Quick Start
+
+### 1. Get an API key
+
+1. Create an account on [fish.audio](https://fish.audio).
+2. Open the API keys page and create a key.
+3. Optional: browse the voice library and copy the id of the voice you want.
+   That id is the `reference_id` below; leave it empty to use your account
+   default.
+
+### 2. Configure the environment variable
+
+```bash
+# .env
+FISH_AUDIO_API_KEY=your-api-key
+```
+
+The adapter is not registered when the key is missing: a pipeline referencing it
+falls back to a placeholder adapter and logs a warning, instead of failing calls.
+
+### 3. Configure the provider
+
+```yaml
+providers:
+  fishaudio_tts:
+    type: fishaudio
+    capabilities:
+      - tts
+    enabled: true
+    model: s2.1-pro        # s1, s2-pro, s2.1-pro, drama-3-preview
+    reference_id: null     # voice id from your Fish Audio library
+    audio_format: pcm      # pcm (streamed) or wav (buffered)
+    sample_rate: null      # null follows the call: 8 kHz telephony, 16 kHz wideband
+    latency: low           # low, normal, balanced
+    chunk_length: 200      # 100-300, provider-side synthesis granularity
+    normalize: true
+    temperature: 0.7
+    top_p: 0.7
+    speed: null            # prosody.speed override
+    volume: null           # prosody.volume override
+    output_resampler: inherit
+```
+
+`latency: low` favours time to first audio, which is what a phone call needs.
+Leave `sample_rate` at `null` unless you have a reason to force a rate: a rate
+Fish Audio cannot emit (anything outside 8, 16, 24, 32, 44.1 and 48 kHz) falls
+back to 16 kHz and is resampled locally.
+
+### 4. Configure a pipeline
+
+```yaml
+pipelines:
+  hybrid_fishaudio:
+    stt: local_stt
+    llm: openai_llm
+    tts: fishaudio_tts
+    options:
+      tts:
+        format:
+          encoding: mulaw
+          sample_rate: 8000
+```
+
+Every provider key can also be overridden per pipeline under `options.tts`, and
+per request at runtime (useful to switch voice mid-call).
+
+### 5. Test a call
+
+```bash
+agent check
+docker compose restart ai_engine
+```
+
+Place a call into the pipeline and watch the engine log:
+
+```
+Fish Audio TTS synthesis started   call_id=... model=s2.1-pro source_sample_rate=8000
+Fish Audio TTS synthesis completed call_id=... first_audio_ms=210 output_bytes=27040
+```
+
+`first_audio_ms` is the time from the request to the first audio chunk handed to
+the transport: that is the number to watch when tuning `latency` and
+`chunk_length`.
+
+## Testing without an account
+
+`scripts/fish_audio_mock.py` answers like the service does — Bearer auth, the
+`model` header, body and sample-rate validation, chunked audio — so the whole
+path can be exercised, including a real call:
+
+```bash
+python scripts/fish_audio_mock.py &
+
+# unit tests
+pytest tests/test_pipeline_fish_audio_adapters.py
+
+# same integration test, against the mock instead of the service
+FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_BASE_URL=http://127.0.0.1:8788/v1 \
+    pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+```
+
+To route an actual call through it, set `base_url: http://127.0.0.1:8788/v1` on
+the provider. The mock serves a generated tone by default; point
+`FISH_MOCK_LOCAL_WS=ws://127.0.0.1:8765` at a local AI server to hear speech
+instead. Three hooks in the request text exercise failure handling:
+`FISH_MOCK_401`, `FISH_MOCK_SLOW` and `FISH_MOCK_EMPTY`.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `Fish Audio TTS requires an API key` | `FISH_AUDIO_API_KEY` is unset, or the provider block has an empty `api_key`. |
+| Pipeline resolves to a placeholder adapter | Same cause, or `enabled: false`. The startup log says `Fish Audio TTS pipeline adapter not registered`. |
+| HTTP 401 in the engine log | Key rejected by the service; check it has TTS access and remaining credit. |
+| HTTP 402 / quota errors | Out of credit on the Fish Audio account. |
+| HTTP 422 `unsupported sample_rate` | Something forced a rate the service does not emit. Leave `sample_rate: null`. |
+| `Unsupported Fish Audio TTS output format` | `audio_format` must be `pcm` or `wav`; mp3 and opus are not used for calls. |
+| Audio plays but sounds thin or metallic | Check the transport encoding and rate in `options.tts.format`; on 8 kHz telephony the adapter should report `source_sample_rate=8000` (no resample). |
+| First audio is slow | Try `latency: low` and a smaller `chunk_length`; check network latency to the API, and confirm the greeting is not synthesised on the caller's first turn. |
+| No audio at all, no error | The service answered without audio (`output_bytes=0`); the call continues silently. Check the text sent and the account status. |
+
+## References
+
+- Fish Audio API reference: <https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech>
+- Provider keys and audio fields: [Configuration-Reference.md](Configuration-Reference.md)
+- Adapter: `src/pipelines/fish_audio.py`
+- Tests: `tests/test_pipeline_fish_audio_adapters.py`

--- a/docs/Provider-FishAudio-Setup.md
+++ b/docs/Provider-FishAudio-Setup.md
@@ -61,6 +61,7 @@ providers:
     top_p: 0.7
     speed: null            # prosody.speed override
     volume: null           # prosody.volume override
+    request_timeout_sec: 15 # whole-request budget, streamed body included
     output_resampler: inherit
 ```
 
@@ -140,6 +141,7 @@ instead. Three hooks in the request text exercise failure handling:
 | `Unsupported Fish Audio TTS output format` | `audio_format` must be `pcm` or `wav`; mp3 and opus are not used for calls. |
 | Audio plays but sounds thin or metallic | Check the transport encoding and rate in `options.tts.format`; on 8 kHz telephony the adapter should report `source_sample_rate=8000` (no resample). |
 | First audio is slow | Try `latency: low` and a smaller `chunk_length`; check network latency to the API, and confirm the greeting is not synthesised on the caller's first turn. |
+| Turn fails after ~15 s | The request budget (`request_timeout_sec`) elapsed; the provider never finished streaming. |
 | No audio at all, no error | The service answered without audio (`output_bytes=0`); the call continues silently. Check the text sent and the account status. |
 
 ## References

--- a/docs/Provider-FishAudio-Setup.md
+++ b/docs/Provider-FishAudio-Setup.md
@@ -54,6 +54,7 @@ providers:
     reference_id: null     # voice id from your Fish Audio library
     audio_format: pcm      # pcm (streamed) or wav (buffered)
     sample_rate: null      # null follows the call: 8 kHz telephony, 16 kHz wideband
+    transport: http        # http, or websocket for the realtime session
     latency: low           # low, normal, balanced
     chunk_length: 200      # 100-300, provider-side synthesis granularity
     normalize: true
@@ -129,9 +130,45 @@ the provider. The mock serves a generated tone by default; point
 instead. Three hooks in the request text exercise failure handling:
 `FISH_MOCK_401`, `FISH_MOCK_SLOW` and `FISH_MOCK_EMPTY`.
 
+## Realtime transport (websocket)
+
+Fish Audio also exposes a realtime endpoint, `wss://api.fish.audio/v1/tts/live`,
+which keeps one session open and accepts text as it is written. With
+`transport: websocket` the adapter opens that session for a whole turn and sends
+each fragment as the engine produces it, so the provider starts speaking while
+the model is still composing the rest — and the engine no longer waits for a
+fragment to be synthesised before consuming the next tokens.
+
+```yaml
+providers:
+  fishaudio_tts:
+    transport: websocket
+    # ws_base_url: wss://api.fish.audio/v1   # defaults to base_url with a ws scheme
+```
+
+Requirements and behaviour:
+
+- `msgpack` (already in `requirements.txt`) — the realtime protocol is
+  MessagePack. It is imported only when the websocket transport is used.
+- The engine feeds text progressively only for adapters that declare
+  `supports_text_stream`; with `transport: http` the same adapter keeps the
+  one-request-per-fragment path, so nothing else changes.
+- A superseded turn (barge-in, a newer transcript) cancels the session; the
+  provider sees the socket close, which is expected.
+- The session log lines are `Fish Audio realtime session opening` and
+  `... completed`, with `fragments`, `first_audio_ms` and `output_bytes`.
+
+Test it against the mock, which serves the realtime endpoint too:
+
+```bash
+python scripts/fish_audio_mock.py &     # HTTP on 8788, realtime on 8789
+FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_WS_BASE_URL=ws://127.0.0.1:8789/v1 \
+    pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+```
+
 ## Checking against the live service for free
 
-The `s2.1-pro-free` model answers without API credit, so the live endpoint can
+The `s2.1-pro-free` model answers without API credit, so both endpoints can
 be exercised at no cost:
 
 ```bash
@@ -142,7 +179,8 @@ FISH_AUDIO_API_KEY=... FISH_AUDIO_MODEL=s2.1-pro-free \
 
 Worth knowing before you top up: API credit is billed separately from the
 platform credit shown in the web app. An account with platform credits but no
-developer balance gets `402 Payment Required` from the paid models.
+developer balance gets `402 Payment Required` from the paid models, and the
+realtime endpoint refuses the websocket handshake with the same status.
 
 ## Troubleshooting
 
@@ -157,6 +195,7 @@ developer balance gets `402 Payment Required` from the paid models.
 | Audio plays but sounds thin or metallic | Check the transport encoding and rate in `options.tts.format`; on 8 kHz telephony the adapter should report `source_sample_rate=8000` (no resample). |
 | First audio is slow | Try `latency: low` and a smaller `chunk_length`; check network latency to the API, and confirm the greeting is not synthesised on the caller's first turn. |
 | Turn fails after ~15 s | The request budget (`request_timeout_sec`) elapsed; the provider never finished streaming. |
+| `realtime transport requires msgpack` | Install `msgpack` (it ships in `requirements.txt`) or switch back to `transport: http`. |
 | No audio at all, no error | The service answered without audio (`output_bytes=0`); the call continues silently. Check the text sent and the account status. |
 
 ## References

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 ari==0.1.3
 websockets==16.1.1
 aiohttp==3.14.3
+# MessagePack: Fish Audio realtime (websocket) transport only
+msgpack==1.1.0
 
 # Configuration and logging
 pydantic>=2.13.4

--- a/scripts/fish_audio_mock.py
+++ b/scripts/fish_audio_mock.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """Local mock of the Fish Audio TTS API, to exercise the provider without an account.
 
-It mirrors the documented surface of ``POST /v1/tts``: Bearer authentication, the
-``model`` header, the JSON body fields, format and sample-rate validation, and a
-chunked audio response. Audio is a short generated tone by default, so the mock
-is self-contained; point ``FISH_MOCK_LOCAL_WS`` at a local AI server websocket to
-hear real speech instead.
+It mirrors the documented surface of both transports:
+
+- ``POST /v1/tts`` — Bearer authentication, the ``model`` header, the JSON body
+  fields, format and sample-rate validation, and a chunked audio response.
+- ``wss://…/v1/tts/live`` — the realtime session: MessagePack messages, the
+  ``start`` / ``text`` / ``flush`` / ``stop`` client events, and ``audio`` /
+  ``finish`` server events.
+
+Audio is a short generated tone by default, so the mock is self-contained; point
+``FISH_MOCK_LOCAL_WS`` at a local AI server websocket to hear real speech.
 
 Usage:
     python scripts/fish_audio_mock.py &
@@ -14,30 +19,34 @@ Usage:
 
 Environment:
     FISH_MOCK_HOST            bind address (default 127.0.0.1)
-    FISH_MOCK_PORT            bind port (default 8788)
+    FISH_MOCK_PORT            HTTP bind port (default 8788)
+    FISH_MOCK_WS_PORT         websocket bind port (default 8789, 0 disables it)
     FISH_MOCK_FIRST_BYTE_SEC  delay before the first audio byte (default 0.12)
-    FISH_MOCK_CHUNK_MS        audio duration per HTTP chunk (default 40)
+    FISH_MOCK_CHUNK_MS        audio duration per chunk (default 40)
     FISH_MOCK_LOCAL_WS        optional local AI server websocket for real speech
 
 Hooks, triggered by the request text, to exercise failure handling:
-    FISH_MOCK_401     answer 401 Unauthorized
+    FISH_MOCK_401     answer 401 Unauthorized (HTTP) / refuse the session (websocket)
     FISH_MOCK_SLOW    wait 3 s before the first byte
-    FISH_MOCK_EMPTY   answer 200 with no audio
+    FISH_MOCK_EMPTY   answer without audio
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import math
 import os
 import struct
 import sys
+import threading
 import time
 import wave
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 HOST = os.getenv("FISH_MOCK_HOST", "127.0.0.1")
 PORT = int(os.getenv("FISH_MOCK_PORT", "8788"))
+WS_PORT = int(os.getenv("FISH_MOCK_WS_PORT", "8789"))
 FIRST_BYTE_DELAY_SEC = float(os.getenv("FISH_MOCK_FIRST_BYTE_SEC", "0.12"))
 CHUNK_MS = int(os.getenv("FISH_MOCK_CHUNK_MS", "40"))
 LOCAL_AI_WS = os.getenv("FISH_MOCK_LOCAL_WS", "")
@@ -56,7 +65,6 @@ def log(message: str) -> None:
 
 def _speech_from_local_ai(text: str, sample_rate: int) -> bytes:
     """Optional: fetch PCM16 speech from a local AI server websocket."""
-    import asyncio
     import base64
 
     import websockets
@@ -129,6 +137,22 @@ def wav_container(pcm: bytes, sample_rate: int) -> bytes:
     return buffer.getvalue()
 
 
+def validate_request(body: dict) -> tuple:
+    """Return (sample_rate, error) after the same checks the service documents."""
+    audio_format = str(body.get("format") or "mp3").lower()
+    if audio_format not in SUPPORTED_FORMATS:
+        return None, "unsupported format: %s" % audio_format
+    if audio_format not in SERVED_FORMATS:
+        return None, "this mock only serves pcm and wav"
+    sample_rate = int(body.get("sample_rate") or 44100)
+    if sample_rate not in SUPPORTED_RATES:
+        return None, "unsupported sample_rate: %s" % sample_rate
+    return sample_rate, None
+
+
+# ─── HTTP transport ──────────────────────────────────────────────────────
+
+
 class FishAudioMockHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     server_version = "FishAudioMock/1.0"
@@ -168,24 +192,15 @@ class FishAudioMockHandler(BaseHTTPRequestHandler):
             self._json(422, {"detail": "invalid JSON body"})
             return
 
-        model = self.headers.get("model", "(none)")
         text = str(body.get("text") or "")
         audio_format = str(body.get("format") or "mp3").lower()
-        sample_rate = body.get("sample_rate")
-
         log("POST /v1/tts model=%s format=%s sample_rate=%s latency=%s reference_id=%s text=%r"
-            % (model, audio_format, sample_rate, body.get("latency", "normal"),
-               body.get("reference_id"), text[:60]))
+            % (self.headers.get("model", "(none)"), audio_format, body.get("sample_rate"),
+               body.get("latency", "normal"), body.get("reference_id"), text[:60]))
 
-        if audio_format not in SUPPORTED_FORMATS:
-            self._json(422, {"detail": "unsupported format: %s" % audio_format})
-            return
-        if audio_format not in SERVED_FORMATS:
-            self._json(422, {"detail": "this mock only serves pcm and wav"})
-            return
-        sample_rate = int(sample_rate or 44100)
-        if sample_rate not in SUPPORTED_RATES:
-            self._json(422, {"detail": "unsupported sample_rate: %s" % sample_rate})
+        sample_rate, error = validate_request(body)
+        if error:
+            self._json(422, {"detail": error})
             return
         if not text:
             self._json(422, {"detail": "text is required"})
@@ -234,7 +249,123 @@ class FishAudioMockHandler(BaseHTTPRequestHandler):
         log("sent %d bytes (%.0f ms)" % (sent, (time.perf_counter() - started) * 1000))
 
 
+# ─── Realtime websocket transport ────────────────────────────────────────
+
+
+async def realtime_handler(connection) -> None:
+    pack, unpack = _msgpack_codec()
+    headers = getattr(getattr(connection, "request", None), "headers", None) or {}
+    authorization = headers.get("Authorization", "") if hasattr(headers, "get") else ""
+    if not str(authorization).startswith("Bearer "):
+        log("realtime: rejected, missing bearer token")
+        await connection.close(code=1008, reason="Unauthorized")
+        return
+
+    sample_rate = 44100
+    buffered = []
+    started = False
+    log("realtime: session opened (model=%s)" % (headers.get("model", "(none)") if hasattr(headers, "get") else "?"))
+    try:
+        async for message in connection:
+            if isinstance(message, str):
+                continue
+            event = unpack(message)
+            if not isinstance(event, dict):
+                continue
+            name = event.get("event")
+
+            if name == "start":
+                request = event.get("request") or {}
+                sample_rate, error = validate_request(request)
+                if error:
+                    log("realtime: %s" % error)
+                    await connection.send(pack({"event": "finish", "reason": "error"}))
+                    await connection.close(code=1008, reason=error)
+                    return
+                started = True
+                log("realtime: start format=%s sample_rate=%s latency=%s reference_id=%s"
+                    % (request.get("format"), sample_rate, request.get("latency"),
+                       request.get("reference_id")))
+                continue
+
+            if not started:
+                await connection.send(pack({"event": "finish", "reason": "error"}))
+                return
+
+            if name == "text":
+                fragment = str(event.get("text") or "")
+                if fragment:
+                    buffered.append(fragment)
+                continue
+
+            if name in ("flush", "stop"):
+                text = " ".join(buffered).strip()
+                buffered = []
+                if text:
+                    if "FISH_MOCK_401" in text:
+                        await connection.send(pack({"event": "finish", "reason": "error"}))
+                        await connection.close(code=1008, reason="Unauthorized (mock hook)")
+                        return
+                    if "FISH_MOCK_SLOW" in text:
+                        await asyncio.sleep(3.0)
+                    else:
+                        await asyncio.sleep(FIRST_BYTE_DELAY_SEC)
+                    audio = b"" if "FISH_MOCK_EMPTY" in text else synthesize(text, sample_rate)
+                    chunk_bytes = max(2, int(sample_rate * (CHUNK_MS / 1000.0)) * 2)
+                    for offset in range(0, len(audio), chunk_bytes):
+                        await connection.send(pack({
+                            "event": "audio",
+                            "audio": audio[offset:offset + chunk_bytes],
+                        }))
+                        await asyncio.sleep(CHUNK_MS / 4000.0)
+                    log("realtime: %s -> %d bytes for %r" % (name, len(audio), text[:50]))
+                if name == "stop":
+                    await connection.send(pack({"event": "finish", "reason": "stop"}))
+                    return
+                continue
+    except Exception as exc:  # noqa: BLE001 - the mock must stay up
+        log("realtime: session error (%s)" % type(exc).__name__)
+
+
+def _msgpack_codec():
+    try:
+        import ormsgpack
+
+        return ormsgpack.packb, ormsgpack.unpackb
+    except ImportError:
+        pass
+    import msgpack
+
+    return (
+        lambda obj: msgpack.packb(obj, use_bin_type=True),
+        lambda data: msgpack.unpackb(data, raw=False),
+    )
+
+
+def serve_realtime() -> None:
+    """Run the websocket transport in its own event loop."""
+    try:
+        _msgpack_codec()
+    except ImportError:
+        log("realtime transport disabled: install msgpack (or ormsgpack) to enable it")
+        return
+    try:
+        from websockets.asyncio.server import serve
+    except ImportError:
+        log("realtime transport disabled: the websockets package is required")
+        return
+
+    async def run() -> None:
+        async with serve(realtime_handler, HOST, WS_PORT, max_size=None):
+            log("Fish Audio mock realtime endpoint on ws://%s:%d/v1/tts/live" % (HOST, WS_PORT))
+            await asyncio.Future()
+
+    asyncio.run(run())
+
+
 def main() -> int:
+    if WS_PORT:
+        threading.Thread(target=serve_realtime, name="fish-mock-ws", daemon=True).start()
     server = ThreadingHTTPServer((HOST, PORT), FishAudioMockHandler)
     log("Fish Audio mock listening on http://%s:%d/v1%s"
         % (HOST, PORT, " (speech from %s)" % LOCAL_AI_WS if LOCAL_AI_WS else " (generated tone)"))

--- a/scripts/fish_audio_mock.py
+++ b/scripts/fish_audio_mock.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Local mock of the Fish Audio TTS API, to exercise the provider without an account.
+
+It mirrors the documented surface of ``POST /v1/tts``: Bearer authentication, the
+``model`` header, the JSON body fields, format and sample-rate validation, and a
+chunked audio response. Audio is a short generated tone by default, so the mock
+is self-contained; point ``FISH_MOCK_LOCAL_WS`` at a local AI server websocket to
+hear real speech instead.
+
+Usage:
+    python scripts/fish_audio_mock.py &
+    FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_BASE_URL=http://127.0.0.1:8788/v1 \
+        pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+
+Environment:
+    FISH_MOCK_HOST            bind address (default 127.0.0.1)
+    FISH_MOCK_PORT            bind port (default 8788)
+    FISH_MOCK_FIRST_BYTE_SEC  delay before the first audio byte (default 0.12)
+    FISH_MOCK_CHUNK_MS        audio duration per HTTP chunk (default 40)
+    FISH_MOCK_LOCAL_WS        optional local AI server websocket for real speech
+
+Hooks, triggered by the request text, to exercise failure handling:
+    FISH_MOCK_401     answer 401 Unauthorized
+    FISH_MOCK_SLOW    wait 3 s before the first byte
+    FISH_MOCK_EMPTY   answer 200 with no audio
+"""
+from __future__ import annotations
+
+import io
+import json
+import math
+import os
+import struct
+import sys
+import time
+import wave
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+HOST = os.getenv("FISH_MOCK_HOST", "127.0.0.1")
+PORT = int(os.getenv("FISH_MOCK_PORT", "8788"))
+FIRST_BYTE_DELAY_SEC = float(os.getenv("FISH_MOCK_FIRST_BYTE_SEC", "0.12"))
+CHUNK_MS = int(os.getenv("FISH_MOCK_CHUNK_MS", "40"))
+LOCAL_AI_WS = os.getenv("FISH_MOCK_LOCAL_WS", "")
+
+# Mirrors the documented Fish Audio contract.
+SUPPORTED_RATES = (8000, 16000, 24000, 32000, 44100, 48000)
+SUPPORTED_FORMATS = ("pcm", "wav", "mp3", "opus")
+SERVED_FORMATS = ("pcm", "wav")
+# Rates a local AI server typically offers, when one is configured.
+LOCAL_AI_RATES = (8000, 16000, 24000)
+
+
+def log(message: str) -> None:
+    print(time.strftime("%H:%M:%S"), message, flush=True)
+
+
+def _speech_from_local_ai(text: str, sample_rate: int) -> bytes:
+    """Optional: fetch PCM16 speech from a local AI server websocket."""
+    import asyncio
+    import base64
+
+    import websockets
+
+    async def fetch() -> bytes:
+        async with websockets.connect(LOCAL_AI_WS, ping_interval=None, max_size=None) as websocket:
+            await websocket.send(json.dumps(
+                {"type": "set_mode", "mode": "tts", "call_id": "fish-audio-mock"}))
+            while True:
+                message = json.loads(await asyncio.wait_for(websocket.recv(), 10))
+                if message.get("type") == "mode_ready":
+                    break
+            await websocket.send(json.dumps({
+                "type": "tts_request",
+                "mode": "tts",
+                "call_id": "fish-audio-mock",
+                "text": text,
+                "output_encoding": "linear16",
+                "output_sample_rate_hz": sample_rate,
+            }))
+            while True:
+                raw = await asyncio.wait_for(websocket.recv(), 30)
+                if isinstance(raw, bytes):
+                    continue
+                message = json.loads(raw)
+                if message.get("type") == "tts_response":
+                    return base64.b64decode(message.get("audio_data", ""))
+
+    return asyncio.run(fetch())
+
+
+def _generated_tone(text: str, sample_rate: int) -> bytes:
+    """Self-contained audio: one short warbling syllable per word."""
+    samples = []
+    syllable = int(sample_rate * 0.18)
+    gap = int(sample_rate * 0.05)
+    for index, word in enumerate(text.split() or ["mock"]):
+        frequency = 180 + (len(word) * 17) + (index % 3) * 40
+        for position in range(syllable):
+            envelope = math.sin(math.pi * position / syllable)
+            samples.append(int(9000 * envelope * math.sin(
+                2 * math.pi * frequency * position / sample_rate)))
+        samples.extend([0] * gap)
+    return struct.pack("<" + "h" * len(samples), *samples)
+
+
+def synthesize(text: str, sample_rate: int) -> bytes:
+    if LOCAL_AI_WS:
+        source_rate = sample_rate if sample_rate in LOCAL_AI_RATES else 16000
+        try:
+            pcm = _speech_from_local_ai(text, source_rate)
+            if pcm and source_rate == sample_rate:
+                return pcm
+            if pcm:
+                import audioop
+
+                return audioop.ratecv(pcm, 2, 1, source_rate, sample_rate, None)[0]
+        except Exception as exc:  # noqa: BLE001 - the mock must stay up
+            log("local AI server unavailable (%s); using a generated tone" % type(exc).__name__)
+    return _generated_tone(text, sample_rate)
+
+
+def wav_container(pcm: bytes, sample_rate: int) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm)
+    return buffer.getvalue()
+
+
+class FishAudioMockHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "FishAudioMock/1.0"
+
+    def log_message(self, fmt, *args):  # silence the default access log
+        pass
+
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 - http.server API
+        if self.path.startswith("/v1/wallet"):
+            self._json(200, {"credit": "42.0"})
+            return
+        self._json(404, {"detail": "Not Found"})
+
+    def do_POST(self):  # noqa: N802 - http.server API
+        if not self.path.startswith("/v1/tts"):
+            self._json(404, {"detail": "Not Found"})
+            return
+
+        authorization = self.headers.get("Authorization", "")
+        if not authorization.startswith("Bearer ") or len(authorization) <= len("Bearer "):
+            log("rejected: missing bearer token")
+            self._json(401, {"detail": "Unauthorized"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self._json(422, {"detail": "invalid JSON body"})
+            return
+
+        model = self.headers.get("model", "(none)")
+        text = str(body.get("text") or "")
+        audio_format = str(body.get("format") or "mp3").lower()
+        sample_rate = body.get("sample_rate")
+
+        log("POST /v1/tts model=%s format=%s sample_rate=%s latency=%s reference_id=%s text=%r"
+            % (model, audio_format, sample_rate, body.get("latency", "normal"),
+               body.get("reference_id"), text[:60]))
+
+        if audio_format not in SUPPORTED_FORMATS:
+            self._json(422, {"detail": "unsupported format: %s" % audio_format})
+            return
+        if audio_format not in SERVED_FORMATS:
+            self._json(422, {"detail": "this mock only serves pcm and wav"})
+            return
+        sample_rate = int(sample_rate or 44100)
+        if sample_rate not in SUPPORTED_RATES:
+            self._json(422, {"detail": "unsupported sample_rate: %s" % sample_rate})
+            return
+        if not text:
+            self._json(422, {"detail": "text is required"})
+            return
+        if "FISH_MOCK_401" in text:
+            log("hook: answering 401")
+            self._json(401, {"detail": "Unauthorized (mock hook)"})
+            return
+
+        audio = synthesize(text, sample_rate)
+        if audio_format == "wav":
+            audio = wav_container(audio, sample_rate)
+        if "FISH_MOCK_EMPTY" in text:
+            log("hook: answering without audio")
+            audio = b""
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        if "FISH_MOCK_SLOW" in text:
+            log("hook: waiting 3 s before the first byte")
+            time.sleep(3.0)
+        else:
+            time.sleep(FIRST_BYTE_DELAY_SEC)
+
+        chunk_bytes = max(2, int(sample_rate * (CHUNK_MS / 1000.0)) * 2)
+        sent = 0
+        started = time.perf_counter()
+        try:
+            for offset in range(0, len(audio), chunk_bytes):
+                chunk = audio[offset:offset + chunk_bytes]
+                self.wfile.write(b"%x\r\n" % len(chunk))
+                self.wfile.write(chunk)
+                self.wfile.write(b"\r\n")
+                self.wfile.flush()
+                sent += len(chunk)
+                # Stream faster than real time, like a remote provider would.
+                time.sleep(CHUNK_MS / 4000.0)
+            self.wfile.write(b"0\r\n\r\n")
+            self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            log("client closed the stream after %d bytes" % sent)
+            return
+        log("sent %d bytes (%.0f ms)" % (sent, (time.perf_counter() - started) * 1000))
+
+
+def main() -> int:
+    server = ThreadingHTTPServer((HOST, PORT), FishAudioMockHandler)
+    log("Fish Audio mock listening on http://%s:%d/v1%s"
+        % (HOST, PORT, " (speech from %s)" % LOCAL_AI_WS if LOCAL_AI_WS else " (generated tone)"))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fish_audio_mock.py
+++ b/scripts/fish_audio_mock.py
@@ -324,7 +324,12 @@ async def realtime_handler(connection) -> None:
                     return
                 continue
     except Exception as exc:  # noqa: BLE001 - the mock must stay up
-        log("realtime: session error (%s)" % type(exc).__name__)
+        # A caller that hangs up, or an engine that drops a superseded turn,
+        # closes the socket without a stop event: that is normal.
+        if type(exc).__name__ in ("ConnectionClosedOK", "ConnectionClosedError", "ConnectionClosed"):
+            log("realtime: client closed the session")
+        else:
+            log("realtime: session error (%s)" % type(exc).__name__)
 
 
 def _msgpack_codec():

--- a/src/config.py
+++ b/src/config.py
@@ -703,6 +703,8 @@ class FishAudioProviderConfig(BaseModel):
     speed: Optional[float] = None
     volume: Optional[float] = None
     output_resampler: Literal["inherit", "linear", "bandlimited"] = Field(default="inherit")
+    # Whole-request budget, including the streamed body.
+    request_timeout_sec: float = Field(default=15.0, gt=0)
     # Provider-specific farewell hangup delay (overrides global)
     farewell_hangup_delay_sec: Optional[float] = None
 

--- a/src/config.py
+++ b/src/config.py
@@ -675,6 +675,38 @@ class CambAiProviderConfig(BaseModel):
     farewell_hangup_delay_sec: Optional[float] = None
 
 
+class FishAudioProviderConfig(BaseModel):
+    """Fish Audio TTS provider configuration.
+
+    Fish Audio streams raw PCM at a requested sample rate, so a telephone call
+    can be served at 8 kHz without an intermediate resample.
+
+    API Reference: https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+    """
+    enabled: bool = Field(default=True)
+    api_key: Optional[str] = None
+    base_url: str = Field(default="https://api.fish.audio/v1")
+    # Speech model, sent as the `model` request header.
+    model: str = Field(default="s2.1-pro")  # s1, s2-pro, s2.1-pro, drama-3-preview
+    # Voice model id from the Fish Audio library; None uses the account default.
+    reference_id: Optional[str] = None
+    # Raw PCM streams chunk by chunk; wav is buffered and decoded.
+    audio_format: Literal["pcm", "wav"] = Field(default="pcm")
+    # None follows the call: 8 kHz on telephony, 16 kHz on wideband transports.
+    sample_rate: Optional[int] = None
+    latency: Literal["low", "normal", "balanced"] = Field(default="low")
+    chunk_length: int = Field(default=200, ge=100, le=300)
+    normalize: bool = Field(default=True)
+    temperature: float = Field(default=0.7, ge=0.0, le=1.0)
+    top_p: float = Field(default=0.7, ge=0.0, le=1.0)
+    # Prosody overrides; None leaves the model default.
+    speed: Optional[float] = None
+    volume: Optional[float] = None
+    output_resampler: Literal["inherit", "linear", "bandlimited"] = Field(default="inherit")
+    # Provider-specific farewell hangup delay (overrides global)
+    farewell_hangup_delay_sec: Optional[float] = None
+
+
 _AZURE_REGION_RE = re.compile(r"^[a-z][a-z0-9-]{0,48}[a-z0-9]$")
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -686,6 +686,11 @@ class FishAudioProviderConfig(BaseModel):
     enabled: bool = Field(default=True)
     api_key: Optional[str] = None
     base_url: str = Field(default="https://api.fish.audio/v1")
+    # http posts one request per fragment; websocket keeps one realtime session
+    # per turn and receives the text as the engine produces it.
+    transport: Literal["http", "websocket"] = Field(default="http")
+    # Defaults to base_url with a ws/wss scheme; override to reach a local mock.
+    ws_base_url: Optional[str] = None
     # Speech model, sent as the `model` request header.
     model: str = Field(default="s2.1-pro")  # s1, s2-pro, s2.1-pro, drama-3-preview
     # Voice model id from the Fish Audio library; None uses the account default.

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -45,6 +45,7 @@ GroqSTTProviderConfig = _parent_config.GroqSTTProviderConfig
 GroqTTSProviderConfig = _parent_config.GroqTTSProviderConfig
 ElevenLabsProviderConfig = _parent_config.ElevenLabsProviderConfig
 CambAiProviderConfig = _parent_config.CambAiProviderConfig
+FishAudioProviderConfig = _parent_config.FishAudioProviderConfig
 OpenAIRealtimeProviderConfig = _parent_config.OpenAIRealtimeProviderConfig
 GrokProviderConfig = _parent_config.GrokProviderConfig
 AzureSTTProviderConfig = _parent_config.AzureSTTProviderConfig
@@ -85,6 +86,7 @@ __all__ = [
     'GroqTTSProviderConfig',
     'ElevenLabsProviderConfig',
     'CambAiProviderConfig',
+    'FishAudioProviderConfig',
     'OpenAIRealtimeProviderConfig',
     'GrokProviderConfig',
     'AzureSTTProviderConfig',

--- a/src/config/audio_baselines.py
+++ b/src/config/audio_baselines.py
@@ -104,6 +104,13 @@ PROVIDER_AUDIO_BASELINES: Mapping[str, Mapping[str, Any]] = {
         "output_format": "ulaw_8000",
         "output_resampler": "inherit",
     },
+    "fishaudio_tts": {
+        "audio_format": "pcm",
+        "sample_rate": 8000,
+        "target_encoding": "mulaw",
+        "target_sample_rate_hz": 8000,
+        "output_resampler": "inherit",
+    },
     "openai_stt": {
         "input_encoding": "linear16",
         "input_sample_rate_hz": 16000,
@@ -123,6 +130,7 @@ PROVIDER_AUDIO_EXTRA_FIELDS: Mapping[str, frozenset[str]] = {
     "groq_tts": frozenset({"response_format", "output_format"}),
     "azure_tts": frozenset({"output_format", "response_format"}),
     "elevenlabs_tts": frozenset({"output_format", "response_format"}),
+    "fishaudio_tts": frozenset({"audio_format", "sample_rate"}),
     "openai_tts": frozenset({"response_format", "output_format"}),
 }
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -16439,6 +16439,9 @@ class Engine:
 
                         stream_q: asyncio.Queue = asyncio.Queue(maxsize=256)
                         old_provider_name = getattr(session, "provider_name", None)
+                        # Set when the TTS adapter consumes a text stream for the turn.
+                        tts_stream_task = None
+                        text_q = None
                         try:
                             self._assign_session_provider(session, "pipeline")
                             await self.session_store.upsert_call(session)
@@ -16467,6 +16470,62 @@ class Engine:
                             if not stream_id:
                                 raise RuntimeError("start_streaming_playback returned no stream_id")
 
+                            async def _deliver_tts_chunk(tts_chunk) -> None:
+                                """Hand one synthesized chunk to the playback stream."""
+                                nonlocal first_tts_ts
+                                if not tts_chunk:
+                                    return
+                                if first_tts_ts is None:
+                                    first_tts_ts = time.time()
+                                    turn_latency_ms = (first_tts_ts - turn_start_time) * 1000
+                                    session.turn_latencies_ms.append(turn_latency_ms)
+                                    try:
+                                        if t_start is not None:
+                                            _TURN_STT_TO_TTS.labels(pipeline_label, provider_label).observe(
+                                                max(0.0, first_tts_ts - t_start)
+                                            )
+                                    except Exception:
+                                        pass
+                                await self._put_pipeline_stream_chunk(
+                                    call_id, stream_id, stream_q, tts_chunk
+                                )
+
+                            # Adapters that hold a provider session open for the whole turn
+                            # take the text as it is produced, so token consumption never
+                            # waits on synthesis. Others keep the per-fragment request path.
+                            if bool(getattr(pipeline.tts_adapter, "supports_text_stream", False)):
+                                text_q = asyncio.Queue()
+
+                                async def _text_fragments():
+                                    while True:
+                                        fragment = await text_q.get()
+                                        if fragment is None:
+                                            return
+                                        yield fragment
+
+                                async def _drain_tts_stream():
+                                    async for tts_chunk in pipeline.tts_adapter.synthesize_stream(
+                                        call_id, _text_fragments(), pipeline.tts_options,
+                                    ):
+                                        await _deliver_tts_chunk(tts_chunk)
+
+                                tts_stream_task = asyncio.ensure_future(_drain_tts_stream())
+                                logger.info(
+                                    "Pipeline TTS text streaming active",
+                                    call_id=call_id,
+                                    pipeline=pipeline_label,
+                                )
+
+                            async def _speak(fragment: str) -> None:
+                                """Send one text fragment to the voice."""
+                                if text_q is not None:
+                                    await text_q.put(fragment)
+                                    return
+                                async for tts_chunk in pipeline.tts_adapter.synthesize(
+                                    call_id, fragment, pipeline.tts_options,
+                                ):
+                                    await _deliver_tts_chunk(tts_chunk)
+
                             async for token in pipeline.llm_adapter.generate_stream(
                                 call_id, transcript_text, context_for_llm, llm_options,
                             ):
@@ -16480,39 +16539,18 @@ class Engine:
                                     sentence_buffer = sentence_buffer[split_pos:]
 
                                     if to_speak:
-                                        async for tts_chunk in pipeline.tts_adapter.synthesize(
-                                            call_id, to_speak, pipeline.tts_options,
-                                        ):
-                                            if tts_chunk:
-                                                if first_tts_ts is None:
-                                                    first_tts_ts = time.time()
-                                                    turn_latency_ms = (first_tts_ts - turn_start_time) * 1000
-                                                    session.turn_latencies_ms.append(turn_latency_ms)
-                                                    try:
-                                                        if t_start is not None:
-                                                            _TURN_STT_TO_TTS.labels(pipeline_label, provider_label).observe(
-                                                                max(0.0, first_tts_ts - t_start)
-                                                            )
-                                                    except Exception:
-                                                        pass
-                                                await self._put_pipeline_stream_chunk(
-                                                    call_id, stream_id, stream_q, tts_chunk
-                                                )
+                                        await _speak(to_speak)
 
                             # Flush remaining sentence buffer
                             remainder = sentence_buffer.strip()
                             if remainder:
-                                async for tts_chunk in pipeline.tts_adapter.synthesize(
-                                    call_id, remainder, pipeline.tts_options,
-                                ):
-                                    if tts_chunk:
-                                        if first_tts_ts is None:
-                                            first_tts_ts = time.time()
-                                            turn_latency_ms = (first_tts_ts - turn_start_time) * 1000
-                                            session.turn_latencies_ms.append(turn_latency_ms)
-                                        await self._put_pipeline_stream_chunk(
-                                            call_id, stream_id, stream_q, tts_chunk
-                                        )
+                                await _speak(remainder)
+
+                            if tts_stream_task is not None:
+                                # Close the text stream and let the session drain.
+                                await text_q.put(None)
+                                await tts_stream_task
+                                tts_stream_task = None
 
                             # End-of-segment sentinel
                             await self._put_pipeline_stream_chunk(
@@ -16550,6 +16588,12 @@ class Engine:
                             # Don't return — fall through to serial path below
                             full_response_text = ""
                         finally:
+                            if tts_stream_task is not None and not tts_stream_task.done():
+                                tts_stream_task.cancel()
+                                try:
+                                    await tts_stream_task
+                                except BaseException:  # cleanup only
+                                    pass
                             try:
                                 self._assign_session_provider(session, old_provider_name)
                                 await self.session_store.upsert_call(session)

--- a/src/pipelines/base.py
+++ b/src/pipelines/base.py
@@ -358,3 +358,24 @@ class TTSComponent(Component):
         options: Dict[str, Any],
     ) -> AsyncIterator[bytes]:
         """Yield audio frames (μ-law or PCM) for the supplied text."""
+
+    # Adapters that hold one provider session open for a whole turn set this to
+    # True and implement ``synthesize_stream``. The engine then feeds them text
+    # as the LLM produces it, instead of waiting for each fragment to be
+    # synthesised before consuming the next tokens.
+    supports_text_stream: bool = False
+
+    async def synthesize_stream(
+        self,
+        call_id: str,
+        text_chunks: AsyncIterator[str],
+        options: Dict[str, Any],
+    ) -> AsyncIterator[bytes]:
+        """Yield audio frames for a stream of text fragments (one turn).
+
+        The default implementation synthesises each fragment in turn, so the
+        engine can use a single code path for every adapter.
+        """
+        async for text in text_chunks:
+            async for chunk in self.synthesize(call_id, text, options):
+                yield chunk

--- a/src/pipelines/fish_audio.py
+++ b/src/pipelines/fish_audio.py
@@ -1,0 +1,378 @@
+"""
+Fish Audio TTS Pipeline Adapter.
+
+Implements the TTSComponent interface for Fish Audio's speech models (S1, S2 and
+the drama preview). The provider streams raw PCM back over chunked HTTP and can
+emit it at the call's own sample rate, so a telephone call needs no intermediate
+resampling: audio is converted to the transport encoding chunk by chunk and
+reaches the caller while the sentence is still being synthesised.
+
+API Reference: https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+"""
+from __future__ import annotations
+
+import io
+import time
+import uuid
+import wave
+from typing import Any, AsyncIterator, Callable, Dict, Optional, Tuple
+
+import aiohttp
+
+from ..audio import (
+    convert_pcm16le_to_target_format,
+    resample_audio,
+    resolve_output_resampler_policy,
+)
+from ..config import AppConfig, FishAudioProviderConfig
+from ..logging_config import get_logger
+from .base import TTSComponent
+
+logger = get_logger(__name__)
+
+# Sample rates Fish Audio accepts for raw PCM and WAV output.
+FISH_AUDIO_SAMPLE_RATES = (8000, 16000, 24000, 32000, 44100, 48000)
+# Used when the negotiated transport rate is not one the provider can emit.
+FISH_AUDIO_FALLBACK_SAMPLE_RATE = 16000
+# Size of the HTTP reads while the response is still streaming.
+FISH_AUDIO_READ_BYTES = 4096
+
+
+class FishAudioTTSAdapter(TTSComponent):
+    """
+    Fish Audio TTS adapter for pipeline orchestrator.
+
+    Converts text to speech with Fish Audio and adapts its native PCM output to
+    the negotiated per-call transport.
+    """
+
+    wideband_output_format = {
+        "encoding": "linear16",
+        "sample_rate": 16000,
+        "options": {"audio_format": "pcm", "sample_rate": 16000},
+    }
+
+    def __init__(
+        self,
+        component_key: str,
+        app_config: AppConfig,
+        provider_config: FishAudioProviderConfig,
+        options: Optional[Dict[str, Any]] = None,
+        *,
+        session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
+    ):
+        self.component_key = component_key
+        self._app_config = app_config
+        self._provider_config = provider_config
+        self._pipeline_defaults = options or {}
+        self._session_factory = session_factory
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def start(self) -> None:
+        logger.debug(
+            "Fish Audio TTS adapter initialized",
+            component=self.component_key,
+            model=self._provider_config.model,
+            reference_id=self._provider_config.reference_id,
+            latency=self._provider_config.latency,
+        )
+
+    async def stop(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+        self._session = None
+
+    async def open_call(self, call_id: str, options: Dict[str, Any]) -> None:
+        await self._ensure_session()
+
+    async def close_call(self, call_id: str) -> None:
+        pass
+
+    async def validate_connectivity(self, options: Dict[str, Any]) -> Dict[str, Any]:
+        merged = self._compose_options(options or {})
+        return await super().validate_connectivity(merged)
+
+    async def synthesize(
+        self,
+        call_id: str,
+        text: str,
+        options: Dict[str, Any],
+    ) -> AsyncIterator[bytes]:
+        """
+        Synthesize text to speech using the Fish Audio TTS API.
+
+        Yields audio chunks in the negotiated per-call transport format, as soon
+        as the provider sends them.
+        """
+        if not text:
+            return
+            yield  # Makes this an async generator
+
+        await self._ensure_session()
+        merged = self._compose_options(options)
+
+        api_key = merged.get("api_key")
+        if not api_key:
+            raise RuntimeError("Fish Audio TTS requires an API key (FISH_AUDIO_API_KEY)")
+
+        target_encoding = merged["format"]["encoding"]
+        target_sample_rate = int(merged["format"]["sample_rate"])
+        audio_format = str(merged["audio_format"]).lower()
+        if audio_format not in {"pcm", "wav"}:
+            raise RuntimeError(
+                "Unsupported Fish Audio TTS output format: "
+                + audio_format
+                + " (use pcm or wav)"
+            )
+        source_sample_rate = self._resolve_source_sample_rate(
+            merged.get("sample_rate"), target_sample_rate
+        )
+
+        payload: Dict[str, Any] = {
+            "text": text,
+            "format": audio_format,
+            "sample_rate": source_sample_rate,
+            "latency": merged["latency"],
+            "chunk_length": int(merged["chunk_length"]),
+            "normalize": bool(merged["normalize"]),
+            "temperature": float(merged["temperature"]),
+            "top_p": float(merged["top_p"]),
+        }
+        reference_id = merged.get("reference_id")
+        if reference_id:
+            payload["reference_id"] = reference_id
+        prosody: Dict[str, Any] = {}
+        if merged.get("speed") is not None:
+            prosody["speed"] = float(merged["speed"])
+        if merged.get("volume") is not None:
+            prosody["volume"] = float(merged["volume"])
+        if prosody:
+            payload["prosody"] = prosody
+
+        headers = {
+            "Authorization": "Bearer " + str(api_key),
+            "Content-Type": "application/json",
+            # Fish Audio selects the speech model with a header, not a body field.
+            "model": str(merged["model"]),
+        }
+
+        base_url = str(merged["base_url"]).rstrip("/")
+        url = base_url + "/tts"
+        request_id = "fish-tts-" + uuid.uuid4().hex[:12]
+        chunk_ms = int(merged.get("chunk_size_ms", 20))
+        resampler_mode = merged["output_resampler"]
+
+        logger.info(
+            "Fish Audio TTS synthesis started",
+            call_id=call_id,
+            request_id=request_id,
+            text_preview=text[:64],
+            model=merged["model"],
+            reference_id=reference_id,
+            latency=merged["latency"],
+            source_sample_rate=source_sample_rate,
+            target_encoding=target_encoding,
+            target_sample_rate=target_sample_rate,
+        )
+
+        started_at = time.perf_counter()
+        first_audio_ms: Optional[float] = None
+        output_bytes = 0
+
+        try:
+            async with self._session.post(url, json=payload, headers=headers) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    logger.error(
+                        "Fish Audio TTS synthesis failed",
+                        call_id=call_id,
+                        request_id=request_id,
+                        status=response.status,
+                        body=body[:200],
+                    )
+                    response.raise_for_status()
+
+                if audio_format == "pcm" and source_sample_rate == target_sample_rate:
+                    # The provider rate already matches the call: convert and forward
+                    # each HTTP chunk instead of waiting for the whole sentence.
+                    emit_size = self._chunk_size_bytes(
+                        target_encoding, target_sample_rate, chunk_ms
+                    )
+                    carry = b""
+                    pending = bytearray()
+                    async for raw in response.content.iter_chunked(FISH_AUDIO_READ_BYTES):
+                        if not raw:
+                            continue
+                        data = carry + raw
+                        aligned = len(data) - (len(data) % 2)
+                        carry = data[aligned:]
+                        if not aligned:
+                            continue
+                        pending.extend(
+                            convert_pcm16le_to_target_format(
+                                data[:aligned], target_encoding
+                            )
+                        )
+                        if first_audio_ms is None and pending:
+                            first_audio_ms = (time.perf_counter() - started_at) * 1000.0
+                        while len(pending) >= emit_size:
+                            chunk = bytes(pending[:emit_size])
+                            del pending[:emit_size]
+                            output_bytes += len(chunk)
+                            yield chunk
+                    if pending:
+                        output_bytes += len(pending)
+                        yield bytes(pending)
+                else:
+                    raw_audio = await response.read()
+                    pcm_data, decoded_rate = self._decode_audio(
+                        raw_audio, audio_format, source_sample_rate
+                    )
+                    if decoded_rate != target_sample_rate:
+                        pcm_data, _ = resample_audio(
+                            pcm_data,
+                            decoded_rate,
+                            target_sample_rate,
+                            mode=resampler_mode,
+                        )
+                    converted = convert_pcm16le_to_target_format(
+                        pcm_data, target_encoding
+                    )
+                    first_audio_ms = (time.perf_counter() - started_at) * 1000.0
+                    for chunk in self._chunk_audio(
+                        converted, target_encoding, target_sample_rate, chunk_ms
+                    ):
+                        if chunk:
+                            output_bytes += len(chunk)
+                            yield chunk
+
+            logger.info(
+                "Fish Audio TTS synthesis completed",
+                call_id=call_id,
+                request_id=request_id,
+                first_audio_ms=round(first_audio_ms, 2) if first_audio_ms else None,
+                total_ms=round((time.perf_counter() - started_at) * 1000.0, 2),
+                output_bytes=output_bytes,
+                target_encoding=target_encoding,
+                target_sample_rate=target_sample_rate,
+            )
+
+        except aiohttp.ClientError as exc:
+            logger.error(
+                "Fish Audio TTS HTTP error",
+                call_id=call_id,
+                request_id=request_id,
+                error=str(exc),
+            )
+            raise
+
+    def _resolve_source_sample_rate(
+        self, configured: Optional[int], target_sample_rate: int
+    ) -> int:
+        """Pick the sample rate to request from Fish Audio.
+
+        Following the call's own rate keeps the telephone path resample-free. An
+        explicitly configured rate wins; a rate the provider cannot emit falls
+        back to 16 kHz and is resampled locally.
+        """
+        candidate = int(configured) if configured else int(target_sample_rate)
+        if candidate in FISH_AUDIO_SAMPLE_RATES:
+            return candidate
+        logger.debug(
+            "Fish Audio TTS sample rate unsupported by the provider; falling back",
+            component=self.component_key,
+            requested=candidate,
+            fallback=FISH_AUDIO_FALLBACK_SAMPLE_RATE,
+        )
+        return FISH_AUDIO_FALLBACK_SAMPLE_RATE
+
+    def _decode_audio(
+        self, raw_audio: bytes, audio_format: str, source_sample_rate: int
+    ) -> Tuple[bytes, int]:
+        """Return (PCM16 frames, sample rate) for a buffered response."""
+        if audio_format == "wav":
+            with wave.open(io.BytesIO(raw_audio), "rb") as wav_file:
+                return wav_file.readframes(wav_file.getnframes()), wav_file.getframerate()
+        return raw_audio, source_sample_rate
+
+    async def _ensure_session(self) -> None:
+        if self._session and not self._session.closed:
+            return
+        factory = self._session_factory or aiohttp.ClientSession
+        self._session = factory()
+
+    def _compose_options(self, runtime_options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Merge runtime options with pipeline and provider defaults."""
+        runtime_options = runtime_options or {}
+        runtime_format = (
+            runtime_options.get("format") or runtime_options.get("target_format") or {}
+        )
+        default_format = (
+            self._pipeline_defaults.get("format")
+            or self._pipeline_defaults.get("target_format")
+            or {}
+        )
+
+        def pick(key: str, provider_value: Any) -> Any:
+            return runtime_options.get(
+                key, self._pipeline_defaults.get(key, provider_value)
+            )
+
+        merged = {
+            "api_key": pick("api_key", self._provider_config.api_key),
+            "base_url": pick("base_url", self._provider_config.base_url),
+            "model": pick("model", self._provider_config.model),
+            "reference_id": pick("reference_id", self._provider_config.reference_id),
+            "audio_format": pick("audio_format", self._provider_config.audio_format),
+            "sample_rate": pick("sample_rate", self._provider_config.sample_rate),
+            "latency": pick("latency", self._provider_config.latency),
+            "chunk_length": pick("chunk_length", self._provider_config.chunk_length),
+            "normalize": pick("normalize", self._provider_config.normalize),
+            "temperature": pick("temperature", self._provider_config.temperature),
+            "top_p": pick("top_p", self._provider_config.top_p),
+            "speed": pick("speed", self._provider_config.speed),
+            "volume": pick("volume", self._provider_config.volume),
+            "format": {
+                "encoding": runtime_format.get(
+                    "encoding", default_format.get("encoding", "mulaw")
+                ),
+                "sample_rate": int(
+                    runtime_format.get(
+                        "sample_rate", default_format.get("sample_rate", 8000)
+                    )
+                ),
+            },
+            "chunk_size_ms": pick("chunk_size_ms", 20),
+            "output_resampler": pick(
+                "output_resampler", self._provider_config.output_resampler
+            ),
+        }
+
+        merged["output_resampler"] = resolve_output_resampler_policy(
+            provider_mode=merged.get("output_resampler")
+        )[0]
+        return merged
+
+    @staticmethod
+    def _chunk_size_bytes(encoding: str, sample_rate: int, chunk_ms: int) -> int:
+        bytes_per_sample = 1 if encoding.lower() in {"ulaw", "mulaw", "mu-law"} else 2
+        return max(
+            bytes_per_sample,
+            int(sample_rate * (chunk_ms / 1000.0) * bytes_per_sample),
+        )
+
+    def _chunk_audio(
+        self,
+        audio: bytes,
+        encoding: str,
+        sample_rate: int,
+        chunk_ms: int = 20,
+    ) -> list:
+        """Split encoded audio into transport-sized playback chunks."""
+        chunk_size = self._chunk_size_bytes(encoding, sample_rate, chunk_ms)
+        chunks = []
+        for index in range(0, len(audio), chunk_size):
+            chunk = audio[index:index + chunk_size]
+            if chunk:
+                chunks.append(chunk)
+        return chunks

--- a/src/pipelines/fish_audio.py
+++ b/src/pipelines/fish_audio.py
@@ -179,8 +179,12 @@ class FishAudioTTSAdapter(TTSComponent):
         first_audio_ms: Optional[float] = None
         output_bytes = 0
 
+        # Bound the whole exchange: a hung provider must not hold the turn open.
+        timeout = aiohttp.ClientTimeout(total=float(merged["request_timeout_sec"]))
         try:
-            async with self._session.post(url, json=payload, headers=headers) as response:
+            async with self._session.post(
+                url, json=payload, headers=headers, timeout=timeout
+            ) as response:
                 if response.status >= 400:
                     body = await response.text()
                     logger.error(
@@ -343,6 +347,9 @@ class FishAudioTTSAdapter(TTSComponent):
                 ),
             },
             "chunk_size_ms": pick("chunk_size_ms", 20),
+            "request_timeout_sec": pick(
+                "request_timeout_sec", self._provider_config.request_timeout_sec
+            ),
             "output_resampler": pick(
                 "output_resampler", self._provider_config.output_resampler
             ),

--- a/src/pipelines/fish_audio.py
+++ b/src/pipelines/fish_audio.py
@@ -2,15 +2,25 @@
 Fish Audio TTS Pipeline Adapter.
 
 Implements the TTSComponent interface for Fish Audio's speech models (S1, S2 and
-the drama preview). The provider streams raw PCM back over chunked HTTP and can
-emit it at the call's own sample rate, so a telephone call needs no intermediate
-resampling: audio is converted to the transport encoding chunk by chunk and
-reaches the caller while the sentence is still being synthesised.
+the drama preview), over either transport:
 
-API Reference: https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+- ``http`` (default): ``POST /v1/tts`` returns raw PCM over a chunked response.
+  One request per text fragment, converted and forwarded chunk by chunk.
+- ``websocket``: the realtime endpoint ``wss://api.fish.audio/v1/tts/live`` keeps
+  one session open for a whole turn. Text is sent as the LLM produces it and
+  audio comes back while the sentence is still being written, so the engine never
+  waits for a fragment to be synthesised before consuming the next tokens.
+
+Both transports ask the provider for the call's own sample rate, so a telephone
+call needs no intermediate resampling.
+
+API Reference:
+  https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech
+  https://docs.fish.audio/api-reference/endpoint/websocket/tts-live
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import time
 import uuid
@@ -36,6 +46,34 @@ FISH_AUDIO_SAMPLE_RATES = (8000, 16000, 24000, 32000, 44100, 48000)
 FISH_AUDIO_FALLBACK_SAMPLE_RATE = 16000
 # Size of the HTTP reads while the response is still streaming.
 FISH_AUDIO_READ_BYTES = 4096
+# Realtime path of the websocket endpoint, appended to the configured base URL.
+FISH_AUDIO_WS_PATH = "/tts/live"
+
+
+def _load_msgpack() -> Tuple[Callable[[Any], bytes], Callable[[bytes], Any]]:
+    """Return (pack, unpack) for the realtime transport.
+
+    The websocket endpoint speaks MessagePack. Import lazily so the HTTP
+    transport keeps working when the optional dependency is absent.
+    """
+    try:
+        import ormsgpack
+
+        return ormsgpack.packb, ormsgpack.unpackb
+    except ImportError:
+        pass
+    try:
+        import msgpack
+
+        return (
+            lambda obj: msgpack.packb(obj, use_bin_type=True),
+            lambda data: msgpack.unpackb(data, raw=False),
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "Fish Audio realtime transport requires msgpack (pip install msgpack) "
+            "or ormsgpack; use transport: http otherwise"
+        ) from exc
 
 
 class FishAudioTTSAdapter(TTSComponent):
@@ -67,6 +105,8 @@ class FishAudioTTSAdapter(TTSComponent):
         self._pipeline_defaults = options or {}
         self._session_factory = session_factory
         self._session: Optional[aiohttp.ClientSession] = None
+        # The engine feeds text progressively only when the realtime transport is on.
+        self.supports_text_stream = self._compose_options({})["transport"] == "websocket"
 
     async def start(self) -> None:
         logger.debug(
@@ -75,6 +115,7 @@ class FishAudioTTSAdapter(TTSComponent):
             model=self._provider_config.model,
             reference_id=self._provider_config.reference_id,
             latency=self._provider_config.latency,
+            transport=self._provider_config.transport,
         )
 
     async def stop(self) -> None:
@@ -99,7 +140,7 @@ class FishAudioTTSAdapter(TTSComponent):
         options: Dict[str, Any],
     ) -> AsyncIterator[bytes]:
         """
-        Synthesize text to speech using the Fish Audio TTS API.
+        Synthesize one text fragment over the HTTP endpoint.
 
         Yields audio chunks in the negotiated per-call transport format, as soon
         as the provider sends them.
@@ -110,10 +151,7 @@ class FishAudioTTSAdapter(TTSComponent):
 
         await self._ensure_session()
         merged = self._compose_options(options)
-
-        api_key = merged.get("api_key")
-        if not api_key:
-            raise RuntimeError("Fish Audio TTS requires an API key (FISH_AUDIO_API_KEY)")
+        api_key = self._require_api_key(merged)
 
         target_encoding = merged["format"]["encoding"]
         target_sample_rate = int(merged["format"]["sample_rate"])
@@ -128,39 +166,11 @@ class FishAudioTTSAdapter(TTSComponent):
             merged.get("sample_rate"), target_sample_rate
         )
 
-        payload: Dict[str, Any] = {
-            "text": text,
-            "format": audio_format,
-            "sample_rate": source_sample_rate,
-            "latency": merged["latency"],
-            "chunk_length": int(merged["chunk_length"]),
-            "normalize": bool(merged["normalize"]),
-            "temperature": float(merged["temperature"]),
-            "top_p": float(merged["top_p"]),
-        }
-        reference_id = merged.get("reference_id")
-        if reference_id:
-            payload["reference_id"] = reference_id
-        prosody: Dict[str, Any] = {}
-        if merged.get("speed") is not None:
-            prosody["speed"] = float(merged["speed"])
-        if merged.get("volume") is not None:
-            prosody["volume"] = float(merged["volume"])
-        if prosody:
-            payload["prosody"] = prosody
-
-        headers = {
-            "Authorization": "Bearer " + str(api_key),
-            "Content-Type": "application/json",
-            # Fish Audio selects the speech model with a header, not a body field.
-            "model": str(merged["model"]),
-        }
-
-        base_url = str(merged["base_url"]).rstrip("/")
-        url = base_url + "/tts"
+        payload = self._build_request(merged, source_sample_rate, audio_format, text=text)
+        headers = self._build_headers(api_key, merged)
+        url = str(merged["base_url"]).rstrip("/") + "/tts"
         request_id = "fish-tts-" + uuid.uuid4().hex[:12]
         chunk_ms = int(merged.get("chunk_size_ms", 20))
-        resampler_mode = merged["output_resampler"]
 
         logger.info(
             "Fish Audio TTS synthesis started",
@@ -168,7 +178,7 @@ class FishAudioTTSAdapter(TTSComponent):
             request_id=request_id,
             text_preview=text[:64],
             model=merged["model"],
-            reference_id=reference_id,
+            reference_id=merged.get("reference_id"),
             latency=merged["latency"],
             source_sample_rate=source_sample_rate,
             target_encoding=target_encoding,
@@ -237,7 +247,7 @@ class FishAudioTTSAdapter(TTSComponent):
                             pcm_data,
                             decoded_rate,
                             target_sample_rate,
-                            mode=resampler_mode,
+                            mode=merged["output_resampler"],
                         )
                     converted = convert_pcm16le_to_target_format(
                         pcm_data, target_encoding
@@ -269,6 +279,244 @@ class FishAudioTTSAdapter(TTSComponent):
                 error=str(exc),
             )
             raise
+
+    async def synthesize_stream(
+        self,
+        call_id: str,
+        text_chunks: AsyncIterator[str],
+        options: Dict[str, Any],
+    ) -> AsyncIterator[bytes]:
+        """
+        Synthesize a whole turn over the realtime websocket session.
+
+        Text fragments are sent as the engine produces them and audio is yielded
+        as the provider returns it. Falls back to one HTTP request per fragment
+        when the realtime transport is not selected.
+        """
+        merged = self._compose_options(options)
+        if str(merged["transport"]).lower() != "websocket":
+            async for text in text_chunks:
+                async for chunk in self.synthesize(call_id, text, options):
+                    yield chunk
+            return
+
+        api_key = self._require_api_key(merged)
+        pack, unpack = _load_msgpack()
+        await self._ensure_session()
+
+        target_encoding = merged["format"]["encoding"]
+        target_sample_rate = int(merged["format"]["sample_rate"])
+        source_sample_rate = self._resolve_source_sample_rate(
+            merged.get("sample_rate"), target_sample_rate
+        )
+        chunk_ms = int(merged.get("chunk_size_ms", 20))
+        emit_size = self._chunk_size_bytes(target_encoding, target_sample_rate, chunk_ms)
+        request_id = "fish-tts-" + uuid.uuid4().hex[:12]
+        url = self._websocket_url(merged)
+
+        logger.info(
+            "Fish Audio realtime session opening",
+            call_id=call_id,
+            request_id=request_id,
+            model=merged["model"],
+            reference_id=merged.get("reference_id"),
+            latency=merged["latency"],
+            source_sample_rate=source_sample_rate,
+            target_encoding=target_encoding,
+            target_sample_rate=target_sample_rate,
+        )
+
+        started_at = time.perf_counter()
+        first_audio_ms: Optional[float] = None
+        output_bytes = 0
+        fragments = 0
+        carry = b""
+        pending = bytearray()
+        resample_state = None
+        sender: Optional[asyncio.Task] = None
+
+        async def feed(websocket) -> None:
+            """Send each fragment as it is produced, then close the text stream."""
+            nonlocal fragments
+            try:
+                async for fragment in text_chunks:
+                    if not fragment:
+                        continue
+                    fragments += 1
+                    await websocket.send_bytes(pack({"event": "text", "text": fragment}))
+                    # Flush so the provider starts on this fragment instead of
+                    # waiting for its own buffer to fill.
+                    await websocket.send_bytes(pack({"event": "flush"}))
+            finally:
+                with_stop = {"event": "stop"}
+                try:
+                    await websocket.send_bytes(pack(with_stop))
+                except Exception:  # noqa: BLE001 - the socket may already be gone
+                    pass
+
+        timeout = aiohttp.ClientTimeout(total=float(merged["request_timeout_sec"]))
+        try:
+            async with self._session.ws_connect(
+                url,
+                headers=self._build_headers(api_key, merged),
+                timeout=timeout,
+                heartbeat=20,
+                max_msg_size=0,
+            ) as websocket:
+                await websocket.send_bytes(
+                    pack({
+                        "event": "start",
+                        "request": self._build_request(
+                            merged, source_sample_rate, "pcm", text=""
+                        ),
+                    })
+                )
+                sender = asyncio.ensure_future(feed(websocket))
+
+                async for message in websocket:
+                    if message.type is aiohttp.WSMsgType.BINARY:
+                        event = unpack(message.data)
+                    elif message.type is aiohttp.WSMsgType.TEXT:
+                        continue
+                    elif message.type in (
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.CLOSING,
+                        aiohttp.WSMsgType.CLOSE,
+                    ):
+                        break
+                    elif message.type is aiohttp.WSMsgType.ERROR:
+                        raise RuntimeError("Fish Audio realtime socket error")
+                    else:
+                        continue
+
+                    if not isinstance(event, dict):
+                        continue
+                    name = event.get("event")
+                    if name == "audio":
+                        data = carry + (event.get("audio") or b"")
+                        aligned = len(data) - (len(data) % 2)
+                        carry = data[aligned:]
+                        if not aligned:
+                            continue
+                        pcm = data[:aligned]
+                        if source_sample_rate != target_sample_rate:
+                            pcm, resample_state = resample_audio(
+                                pcm,
+                                source_sample_rate,
+                                target_sample_rate,
+                                mode=merged["output_resampler"],
+                                state=resample_state,
+                            )
+                        pending.extend(
+                            convert_pcm16le_to_target_format(pcm, target_encoding)
+                        )
+                        if first_audio_ms is None and pending:
+                            first_audio_ms = (time.perf_counter() - started_at) * 1000.0
+                        while len(pending) >= emit_size:
+                            chunk = bytes(pending[:emit_size])
+                            del pending[:emit_size]
+                            output_bytes += len(chunk)
+                            yield chunk
+                    elif name == "finish":
+                        reason = event.get("reason")
+                        if reason == "error":
+                            raise RuntimeError(
+                                "Fish Audio realtime session finished with an error"
+                            )
+                        break
+                    elif name == "log":
+                        logger.debug(
+                            "Fish Audio realtime log",
+                            call_id=call_id,
+                            request_id=request_id,
+                            message=str(event.get("message"))[:200],
+                        )
+
+                if pending:
+                    output_bytes += len(pending)
+                    yield bytes(pending)
+
+            logger.info(
+                "Fish Audio realtime session completed",
+                call_id=call_id,
+                request_id=request_id,
+                fragments=fragments,
+                first_audio_ms=round(first_audio_ms, 2) if first_audio_ms else None,
+                total_ms=round((time.perf_counter() - started_at) * 1000.0, 2),
+                output_bytes=output_bytes,
+            )
+
+        except aiohttp.ClientError as exc:
+            logger.error(
+                "Fish Audio realtime connection error",
+                call_id=call_id,
+                request_id=request_id,
+                error=str(exc),
+            )
+            raise
+        finally:
+            if sender is not None and not sender.done():
+                sender.cancel()
+                try:
+                    await sender
+                except (asyncio.CancelledError, Exception):  # noqa: B014 - cleanup only
+                    pass
+
+    def _require_api_key(self, merged: Dict[str, Any]) -> str:
+        api_key = merged.get("api_key")
+        if not api_key:
+            raise RuntimeError("Fish Audio TTS requires an API key (FISH_AUDIO_API_KEY)")
+        return str(api_key)
+
+    def _build_headers(self, api_key: str, merged: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            "Authorization": "Bearer " + api_key,
+            "Content-Type": "application/json",
+            # Fish Audio selects the speech model with a header, not a body field.
+            "model": str(merged["model"]),
+        }
+
+    def _build_request(
+        self,
+        merged: Dict[str, Any],
+        source_sample_rate: int,
+        audio_format: str,
+        *,
+        text: str,
+    ) -> Dict[str, Any]:
+        """Body shared by the HTTP request and the realtime start event."""
+        request: Dict[str, Any] = {
+            "text": text,
+            "format": audio_format,
+            "sample_rate": source_sample_rate,
+            "latency": merged["latency"],
+            "chunk_length": int(merged["chunk_length"]),
+            "normalize": bool(merged["normalize"]),
+            "temperature": float(merged["temperature"]),
+            "top_p": float(merged["top_p"]),
+        }
+        reference_id = merged.get("reference_id")
+        if reference_id:
+            request["reference_id"] = reference_id
+        prosody: Dict[str, Any] = {}
+        if merged.get("speed") is not None:
+            prosody["speed"] = float(merged["speed"])
+        if merged.get("volume") is not None:
+            prosody["volume"] = float(merged["volume"])
+        if prosody:
+            request["prosody"] = prosody
+        return request
+
+    def _websocket_url(self, merged: Dict[str, Any]) -> str:
+        configured = merged.get("ws_base_url")
+        base = str(configured or merged["base_url"]).rstrip("/")
+        if base.startswith("https://"):
+            base = "wss://" + base[len("https://"):]
+        elif base.startswith("http://"):
+            base = "ws://" + base[len("http://"):]
+        if base.endswith(FISH_AUDIO_WS_PATH):
+            return base
+        return base + FISH_AUDIO_WS_PATH
 
     def _resolve_source_sample_rate(
         self, configured: Optional[int], target_sample_rate: int
@@ -325,6 +573,8 @@ class FishAudioTTSAdapter(TTSComponent):
         merged = {
             "api_key": pick("api_key", self._provider_config.api_key),
             "base_url": pick("base_url", self._provider_config.base_url),
+            "ws_base_url": pick("ws_base_url", self._provider_config.ws_base_url),
+            "transport": pick("transport", self._provider_config.transport),
             "model": pick("model", self._provider_config.model),
             "reference_id": pick("reference_id", self._provider_config.reference_id),
             "audio_format": pick("audio_format", self._provider_config.audio_format),

--- a/src/pipelines/orchestrator.py
+++ b/src/pipelines/orchestrator.py
@@ -20,6 +20,7 @@ from ..config import (
     AzureSTTProviderConfig,
     AzureTTSProviderConfig,
     CambAiProviderConfig,
+    FishAudioProviderConfig,
     DeepgramProviderConfig,
     ElevenLabsProviderConfig,
     GoogleProviderConfig,
@@ -45,6 +46,7 @@ from .minimax import MiniMaxLLMAdapter
 from .telnyx import TelnyxLLMAdapter
 from .azure import AzureSTTFastAdapter, AzureSTTRealtimeAdapter, AzureTTSAdapter
 from .cambai import CambAiTTSAdapter
+from .fish_audio import FishAudioTTSAdapter
 
 logger = get_logger(__name__)
 
@@ -237,6 +239,7 @@ class PipelineOrchestrator:
         self._google_provider_config: Optional[GoogleProviderConfig] = self._hydrate_google_config()
         self._elevenlabs_provider_config: Optional[ElevenLabsProviderConfig] = self._hydrate_elevenlabs_config()
         self._cambai_provider_config: Optional[CambAiProviderConfig] = self._hydrate_cambai_config()
+        self._fishaudio_provider_config: Optional[FishAudioProviderConfig] = self._hydrate_fishaudio_config()
         self._groq_stt_provider_config: Optional[GroqSTTProviderConfig] = self._hydrate_groq_stt_config()
         self._groq_tts_provider_config: Optional[GroqTTSProviderConfig] = self._hydrate_groq_tts_config()
         self._azure_stt_provider_config: Optional[AzureSTTProviderConfig] = self._hydrate_azure_stt_config()
@@ -805,6 +808,19 @@ class PipelineOrchestrator:
         else:
             logger.debug("CAMB AI TTS pipeline adapter not registered - API key unavailable or config missing")
 
+        # Fish Audio TTS adapter
+        if self._fishaudio_provider_config:
+            tts_factory = self._make_fishaudio_tts_factory(self._fishaudio_provider_config)
+            self.register_factory("fishaudio_tts", tts_factory)
+            logger.info(
+                "Fish Audio TTS pipeline adapter registered",
+                tts_factory="fishaudio_tts",
+                model=self._fishaudio_provider_config.model,
+                reference_id=self._fishaudio_provider_config.reference_id,
+            )
+        else:
+            logger.debug("Fish Audio TTS pipeline adapter not registered - API key unavailable or config missing")
+
         # Ollama LLM adapter - for self-hosted local LLMs
         # Read config from providers.ollama_llm in YAML if available
         ollama_provider_config = {}
@@ -1242,6 +1258,23 @@ class PipelineOrchestrator:
 
         return factory
 
+    def _make_fishaudio_tts_factory(
+        self,
+        provider_config: FishAudioProviderConfig,
+    ) -> ComponentFactory:
+        """Create factory for Fish Audio TTS adapter."""
+        config_payload = provider_config.model_dump()
+
+        def factory(component_key: str, options: Dict[str, Any]) -> Component:
+            return FishAudioTTSAdapter(
+                component_key,
+                self.config,
+                FishAudioProviderConfig(**config_payload),
+                options,
+            )
+
+        return factory
+
     def _hydrate_google_config(self) -> Optional[GoogleProviderConfig]:
         providers = getattr(self.config, "providers", {}) or {}
         raw_config = providers.get("google")
@@ -1365,6 +1398,56 @@ class PipelineOrchestrator:
                 **{**config.model_dump(), "api_key": os.getenv("ELEVENLABS_API_KEY")}
             )
 
+        return config
+
+    def _hydrate_fishaudio_config(self) -> Optional[FishAudioProviderConfig]:
+        """Hydrate Fish Audio provider config from YAML or env."""
+        providers = getattr(self.config, "providers", {}) or {}
+        raw_config = providers.get("fishaudio") or providers.get("fishaudio_tts")
+        if not raw_config:
+            api_key = os.getenv("FISH_AUDIO_API_KEY")
+            if api_key:
+                return FishAudioProviderConfig(api_key=api_key)
+            return None
+        if isinstance(raw_config, FishAudioProviderConfig):
+            config = raw_config
+        elif isinstance(raw_config, dict):
+            if raw_config.get("enabled") is False:
+                logger.debug("Fish Audio TTS adapter disabled by provider configuration")
+                return None
+            try:
+                known_fields = set(FishAudioProviderConfig.model_fields.keys())
+                filtered = {}
+                for key, value in raw_config.items():
+                    if key not in known_fields:
+                        continue
+                    if isinstance(value, str) and value == "":
+                        continue
+                    filtered[key] = value
+                config = FishAudioProviderConfig(**filtered)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to hydrate Fish Audio provider config for pipelines",
+                    error=str(exc),
+                )
+                return None
+        else:
+            return None
+
+        if not config.enabled:
+            logger.debug("Fish Audio TTS adapter disabled by provider configuration")
+            return None
+
+        if not config.api_key and not os.getenv("FISH_AUDIO_API_KEY"):
+            logger.warning(
+                "Fish Audio TTS adapter requires FISH_AUDIO_API_KEY; falling back to placeholder adapter",
+            )
+            return None
+
+        if not config.api_key:
+            config = FishAudioProviderConfig(
+                **{**config.model_dump(), "api_key": os.getenv("FISH_AUDIO_API_KEY")}
+            )
         return config
 
     def _hydrate_cambai_config(self) -> Optional[CambAiProviderConfig]:

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -95,7 +95,9 @@ class _FakeSession:
         self.closed = False
 
     def post(self, url, json=None, params=None, headers=None, data=None, timeout=None):
-        self.requests.append({"url": url, "json": json, "headers": headers})
+        self.requests.append(
+            {"url": url, "json": json, "headers": headers, "timeout": timeout}
+        )
         response = _FakeResponse(self._chunks, status=self._status)
         self.responses.append(response)
         return response
@@ -249,6 +251,20 @@ async def test_fish_audio_runtime_options_override_defaults():
     assert payload["reference_id"] == "other-voice"
     assert payload["latency"] == "balanced"
     assert payload["prosody"] == {"speed": 1.1, "volume": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_request_is_bounded_by_a_timeout():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)
+
+    [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+    assert session.requests[0]["timeout"].total == 15.0
+
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)
+    [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {"request_timeout_sec": 4})]
+    assert session.requests[0]["timeout"].total == 4.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -350,6 +350,7 @@ async def test_fish_audio_live_api():
     app_config = _build_app_config(api_key=api_key)
     payload = dict(app_config.providers["fishaudio_tts"])
     payload["base_url"] = os.getenv("FISH_AUDIO_BASE_URL", payload["base_url"])
+    payload["model"] = os.getenv("FISH_AUDIO_MODEL", payload["model"])
     payload["reference_id"] = os.getenv("FISH_AUDIO_REFERENCE_ID") or None
     provider_config = FishAudioProviderConfig(**payload)
 

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -1,0 +1,349 @@
+import io
+import os
+import struct
+import wave
+
+import pytest
+
+from src.config import AppConfig, FishAudioProviderConfig
+from src.pipelines.fish_audio import FishAudioTTSAdapter
+from src.pipelines.orchestrator import PipelineOrchestrator, PipelineOrchestratorError
+
+
+def _build_app_config(api_key: str = "test-key") -> AppConfig:
+    providers = {
+        "fishaudio_tts": {
+            "api_key": api_key,
+            "model": "s2.1-pro",
+            "reference_id": "voice-model-id",
+            "audio_format": "pcm",
+            "latency": "low",
+            "base_url": "https://api.fish.audio/v1",
+        },
+        "local": {
+            "ws_url": "ws://127.0.0.1:8765",
+        },
+    }
+    pipelines = {
+        "fishaudio_pipeline": {
+            "stt": "local_stt",
+            "llm": "local_llm",
+            "tts": "fishaudio_tts",
+        }
+    }
+    return AppConfig(
+        default_provider="local",
+        providers=providers,
+        asterisk={"host": "127.0.0.1", "username": "ari", "password": "secret"},
+        llm={"initial_greeting": "hi", "prompt": "prompt", "model": "gpt-4o"},
+        audio_transport="audiosocket",
+        downstream_mode="stream",
+        pipelines=pipelines,
+        active_pipeline="fishaudio_pipeline",
+    )
+
+
+class _FakeContent:
+    """Mimics aiohttp's StreamReader for the chunks we care about."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.iterated = False
+
+    def iter_chunked(self, size):
+        self.iterated = True
+        chunks = self._chunks
+
+        async def iterator():
+            for chunk in chunks:
+                yield chunk
+
+        return iterator()
+
+
+class _FakeResponse:
+    def __init__(self, chunks, status: int = 200):
+        self._chunks = list(chunks)
+        self.status = status
+        self.content = _FakeContent(self._chunks)
+        self.read_called = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def read(self):
+        self.read_called = True
+        return b"".join(self._chunks)
+
+    async def text(self):
+        return b"".join(self._chunks).decode("utf-8", errors="ignore")
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise Exception("HTTP %d" % self.status)
+
+
+class _FakeSession:
+    def __init__(self, chunks, status: int = 200):
+        self._chunks = list(chunks)
+        self._status = status
+        self.requests = []
+        self.responses = []
+        self.closed = False
+
+    def post(self, url, json=None, params=None, headers=None, data=None, timeout=None):
+        self.requests.append({"url": url, "json": json, "headers": headers})
+        response = _FakeResponse(self._chunks, status=self._status)
+        self.responses.append(response)
+        return response
+
+    async def close(self):
+        self.closed = True
+
+
+def _pcm16_tone(num_samples: int, amplitude: int = 1000) -> bytes:
+    """Non-silent PCM16 so format conversion produces observable output."""
+    return struct.pack("<" + "h" * num_samples, *([amplitude, -amplitude] * (num_samples // 2)))
+
+
+def _wav_container(pcm: bytes, sample_rate: int) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm)
+    return buffer.getvalue()
+
+
+async def _adapter(session, options=None, api_key: str = "test-key"):
+    app_config = _build_app_config(api_key=api_key)
+    provider_config = FishAudioProviderConfig(**app_config.providers["fishaudio_tts"])
+    adapter = FishAudioTTSAdapter(
+        "fishaudio_tts",
+        app_config,
+        provider_config,
+        options or {},
+        session_factory=lambda: session,
+    )
+    await adapter.start()
+    await adapter.open_call("call-1", {})
+    return adapter
+
+
+# ─── Unit Tests (mocked HTTP) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_sends_expected_request():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)
+
+    [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    assert len(session.requests) == 1
+    request = session.requests[0]
+    assert request["url"] == "https://api.fish.audio/v1/tts"
+
+    payload = request["json"]
+    assert payload["text"] == "Bonjour"
+    assert payload["format"] == "pcm"
+    # Telephony call: ask the provider for 8 kHz so nothing is resampled.
+    assert payload["sample_rate"] == 8000
+    assert payload["latency"] == "low"
+    assert payload["reference_id"] == "voice-model-id"
+    assert payload["chunk_length"] == 200
+
+    headers = request["headers"]
+    assert headers["Authorization"] == "Bearer test-key"
+    # Fish Audio selects the speech model with a header.
+    assert headers["model"] == "s2.1-pro"
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_streams_chunks_as_they_arrive():
+    # Three HTTP chunks of 20 ms each at 8 kHz (160 samples, 320 bytes).
+    session = _FakeSession([_pcm16_tone(160), _pcm16_tone(160), _pcm16_tone(160)])
+    adapter = await _adapter(session)
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    # One 20 ms mu-law chunk (160 bytes) per 20 ms of PCM, streamed not buffered.
+    assert [len(chunk) for chunk in chunks] == [160, 160, 160]
+    assert session.responses[0].content.iterated is True
+    assert session.responses[0].read_called is False
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_realigns_samples_split_across_http_chunks():
+    tone = _pcm16_tone(160)
+    # Split in the middle of a 16-bit sample: the adapter must carry the odd byte.
+    session = _FakeSession([tone[:161], tone[161:]])
+    adapter = await _adapter(session)
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    assert b"".join(chunks) != b""
+    assert sum(len(chunk) for chunk in chunks) == 160
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_wideband_transport_requests_16k_pcm():
+    session = _FakeSession([_pcm16_tone(320)])
+    options = {"format": {"encoding": "linear16", "sample_rate": 16000}}
+    adapter = await _adapter(session, options)
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    assert session.requests[0]["json"]["sample_rate"] == 16000
+    # 20 ms of PCM16 at 16 kHz is 640 bytes.
+    assert [len(chunk) for chunk in chunks] == [640]
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_unsupported_rate_falls_back_and_resamples():
+    session = _FakeSession([_pcm16_tone(320)])
+    options = {"format": {"encoding": "linear16", "sample_rate": 22050}}
+    adapter = await _adapter(session, options)
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    # 22050 Hz is not a Fish Audio output rate: request 16 kHz and resample here.
+    assert session.requests[0]["json"]["sample_rate"] == 16000
+    assert session.responses[0].read_called is True
+    assert b"".join(chunks) != b""
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_decodes_wav_container():
+    pcm = _pcm16_tone(160)
+    session = _FakeSession([_wav_container(pcm, 8000)])
+    adapter = await _adapter(session, {"audio_format": "wav"})
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+    assert session.requests[0]["json"]["format"] == "wav"
+    assert sum(len(chunk) for chunk in chunks) == 160
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_runtime_options_override_defaults():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)
+
+    runtime = {
+        "model": "s1",
+        "reference_id": "other-voice",
+        "latency": "balanced",
+        "speed": 1.1,
+        "volume": 0.5,
+    }
+    [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", runtime)]
+
+    request = session.requests[0]
+    assert request["headers"]["model"] == "s1"
+    payload = request["json"]
+    assert payload["reference_id"] == "other-voice"
+    assert payload["latency"] == "balanced"
+    assert payload["prosody"] == {"speed": 1.1, "volume": 0.5}
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_empty_text_yields_nothing():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)
+
+    chunks = [chunk async for chunk in adapter.synthesize("call-1", "", {})]
+
+    assert chunks == []
+    assert session.requests == []
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_missing_api_key_raises():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session, api_key="unused")
+    adapter._provider_config = FishAudioProviderConfig(api_key=None)
+
+    with pytest.raises(RuntimeError, match="FISH_AUDIO_API_KEY"):
+        [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_unsupported_format_raises():
+    session = _FakeSession([b""])
+    adapter = await _adapter(session, {"audio_format": "mp3"})
+
+    with pytest.raises(RuntimeError, match="Unsupported Fish Audio TTS output format"):
+        [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_api_error_raises():
+    session = _FakeSession([b'{"detail": "unauthorized"}'], status=401)
+    adapter = await _adapter(session)
+
+    with pytest.raises(Exception):
+        [chunk async for chunk in adapter.synthesize("call-1", "Bonjour", {})]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_orchestrator_registers_fish_audio_tts():
+    app_config = _build_app_config()
+    orchestrator = PipelineOrchestrator(app_config)
+    await orchestrator.start()
+
+    resolution = orchestrator.get_pipeline("call-1")
+    assert isinstance(resolution.tts_adapter, FishAudioTTSAdapter)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_orchestrator_skips_disabled_provider():
+    # A disabled provider is not registered, so a pipeline that references it is
+    # reported as invalid rather than silently answering with a placeholder.
+    app_config = _build_app_config()
+    app_config.providers["fishaudio_tts"]["enabled"] = False
+    orchestrator = PipelineOrchestrator(app_config)
+
+    with pytest.raises(PipelineOrchestratorError, match="fishaudio_tts"):
+        await orchestrator.start()
+
+
+# ─── Integration Test (live API) ────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fish_audio_live_api():
+    """Integration test: call the real Fish Audio API and verify telephone audio."""
+    api_key = os.getenv("FISH_AUDIO_API_KEY")
+    if not api_key:
+        pytest.skip("FISH_AUDIO_API_KEY not set - skipping live API test")
+
+    app_config = _build_app_config(api_key=api_key)
+    payload = dict(app_config.providers["fishaudio_tts"])
+    reference_id = os.getenv("FISH_AUDIO_REFERENCE_ID")
+    payload["reference_id"] = reference_id or None
+    provider_config = FishAudioProviderConfig(**payload)
+
+    adapter = FishAudioTTSAdapter("fishaudio_tts", app_config, provider_config, {})
+    await adapter.start()
+    await adapter.open_call("call-live", {})
+
+    try:
+        chunks = [
+            chunk
+            async for chunk in adapter.synthesize(
+                "call-live", "Bonjour, ici le test Fish Audio.", {}
+            )
+        ]
+        synthesized = b"".join(chunks)
+        assert len(synthesized) > 100, "expected substantial audio, got %d bytes" % len(synthesized)
+        # mu-law 8 kHz in 20 ms chunks is 160 bytes per chunk.
+        for chunk in chunks:
+            assert len(chunk) <= 160
+    finally:
+        await adapter.stop()

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -555,6 +555,7 @@ async def test_fish_audio_live_realtime():
     payload["transport"] = "websocket"
     payload["ws_base_url"] = os.getenv("FISH_AUDIO_WS_BASE_URL") or None
     payload["base_url"] = os.getenv("FISH_AUDIO_BASE_URL", payload["base_url"])
+    payload["model"] = os.getenv("FISH_AUDIO_MODEL", payload["model"])
     payload["reference_id"] = os.getenv("FISH_AUDIO_REFERENCE_ID") or None
     provider_config = FishAudioProviderConfig(**payload)
 

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -318,15 +318,23 @@ async def test_pipeline_orchestrator_skips_disabled_provider():
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_fish_audio_live_api():
-    """Integration test: call the real Fish Audio API and verify telephone audio."""
+    """Integration test against a real endpoint.
+
+    Point it at the service with FISH_AUDIO_API_KEY (and optionally
+    FISH_AUDIO_REFERENCE_ID), or at the bundled mock with:
+
+        python scripts/fish_audio_mock.py &
+        FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_BASE_URL=http://127.0.0.1:8788/v1 \
+            pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+    """
     api_key = os.getenv("FISH_AUDIO_API_KEY")
     if not api_key:
         pytest.skip("FISH_AUDIO_API_KEY not set - skipping live API test")
 
     app_config = _build_app_config(api_key=api_key)
     payload = dict(app_config.providers["fishaudio_tts"])
-    reference_id = os.getenv("FISH_AUDIO_REFERENCE_ID")
-    payload["reference_id"] = reference_id or None
+    payload["base_url"] = os.getenv("FISH_AUDIO_BASE_URL", payload["base_url"])
+    payload["reference_id"] = os.getenv("FISH_AUDIO_REFERENCE_ID") or None
     provider_config = FishAudioProviderConfig(**payload)
 
     adapter = FishAudioTTSAdapter("fishaudio_tts", app_config, provider_config, {})
@@ -345,5 +353,7 @@ async def test_fish_audio_live_api():
         # mu-law 8 kHz in 20 ms chunks is 160 bytes per chunk.
         for chunk in chunks:
             assert len(chunk) <= 160
+        # Audio must arrive progressively, not as a single blob.
+        assert len(chunks) > 1
     finally:
         await adapter.stop()

--- a/tests/test_pipeline_fish_audio_adapters.py
+++ b/tests/test_pipeline_fish_audio_adapters.py
@@ -1,8 +1,10 @@
+import asyncio
 import io
 import os
 import struct
 import wave
 
+import aiohttp
 import pytest
 
 from src.config import AppConfig, FishAudioProviderConfig
@@ -328,6 +330,164 @@ async def test_pipeline_orchestrator_skips_disabled_provider():
         await orchestrator.start()
 
 
+
+# ─── Realtime transport (websocket) ─────────────────────────────────────
+
+
+class _FakeWebSocket:
+    """Minimal aiohttp-like websocket speaking the Fish Audio realtime protocol."""
+
+    def __init__(self, pack, audio_chunks, finish_reason="stop"):
+        self._pack = pack
+        self._audio_chunks = list(audio_chunks)
+        self._finish_reason = finish_reason
+        self.sent = []
+        self.closed = False
+        self._stopped = asyncio.Event()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.closed = True
+        return False
+
+    async def send_bytes(self, data):
+        self.sent.append(data)
+
+    def __aiter__(self):
+        return self._messages()
+
+    async def _messages(self):
+        # Let the sender task deliver "start" and the first fragments.
+        await asyncio.sleep(0)
+        for chunk in self._audio_chunks:
+            yield _FakeWSMessage(self._pack({"event": "audio", "audio": chunk}))
+            await asyncio.sleep(0)
+        # The provider only finishes once the client closed the text stream.
+        for _ in range(100):
+            if any(b"stop" in message for message in self.sent):
+                break
+            await asyncio.sleep(0.01)
+        yield _FakeWSMessage(self._pack({"event": "finish", "reason": self._finish_reason}))
+
+
+class _FakeWSMessage:
+    def __init__(self, data):
+        self.type = aiohttp.WSMsgType.BINARY
+        self.data = data
+
+
+class _WebSocketSession(_FakeSession):
+    """HTTP session whose ws_connect returns the fake websocket."""
+
+    def __init__(self, websocket):
+        super().__init__([b""])
+        self.websocket = websocket
+        self.ws_calls = []
+
+    def ws_connect(self, url, headers=None, timeout=None, heartbeat=None, max_msg_size=None):
+        self.ws_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        return self.websocket
+
+
+async def _fragments(*texts):
+    for text in texts:
+        yield text
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_transport_declares_text_streaming():
+    session = _FakeSession([b""])
+    http_adapter = await _adapter(session)
+    assert http_adapter.supports_text_stream is False
+
+    ws_adapter = await _adapter(session, {"transport": "websocket"})
+    assert ws_adapter.supports_text_stream is True
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_realtime_session_follows_the_protocol():
+    msgpack = pytest.importorskip("msgpack")
+
+    def pack(obj):
+        return msgpack.packb(obj, use_bin_type=True)
+
+    def unpack(data):
+        return msgpack.unpackb(data, raw=False)
+
+    websocket = _FakeWebSocket(pack, [_pcm16_tone(160), _pcm16_tone(160)])
+    session = _WebSocketSession(websocket)
+    adapter = await _adapter(session, {"transport": "websocket"})
+
+    chunks = []
+    async for chunk in adapter.synthesize_stream(
+        "call-1", _fragments("Bonjour,", " vous etes bien chez Rea PC."), {}
+    ):
+        chunks.append(chunk)
+
+    # The realtime endpoint is derived from the configured base URL.
+    assert session.ws_calls[0]["url"] == "wss://api.fish.audio/v1/tts/live"
+    assert session.ws_calls[0]["headers"]["model"] == "s2.1-pro"
+
+    events = [unpack(message) for message in websocket.sent]
+    assert [event["event"] for event in events] == [
+        "start", "text", "flush", "text", "flush", "stop",
+    ]
+    start_request = events[0]["request"]
+    assert start_request["format"] == "pcm"
+    assert start_request["sample_rate"] == 8000
+    assert start_request["latency"] == "low"
+    assert start_request["reference_id"] == "voice-model-id"
+    assert start_request["text"] == ""
+    assert [event["text"] for event in events if event["event"] == "text"] == [
+        "Bonjour,", " vous etes bien chez Rea PC.",
+    ]
+
+    # Audio comes back as 20 ms mu-law chunks, as on the HTTP path.
+    assert [len(chunk) for chunk in chunks] == [160, 160]
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_realtime_error_is_raised():
+    msgpack = pytest.importorskip("msgpack")
+    pack = lambda obj: msgpack.packb(obj, use_bin_type=True)  # noqa: E731
+
+    websocket = _FakeWebSocket(pack, [], finish_reason="error")
+    session = _WebSocketSession(websocket)
+    adapter = await _adapter(session, {"transport": "websocket"})
+
+    with pytest.raises(RuntimeError, match="realtime session finished with an error"):
+        async for _ in adapter.synthesize_stream("call-1", _fragments("Bonjour"), {}):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_stream_falls_back_to_http_requests():
+    session = _FakeSession([_pcm16_tone(160)])
+    adapter = await _adapter(session)  # transport http
+
+    chunks = []
+    async for chunk in adapter.synthesize_stream(
+        "call-1", _fragments("Bonjour,", " bienvenue."), {}
+    ):
+        chunks.append(chunk)
+
+    # One request per fragment, and audio for both.
+    assert len(session.requests) == 2
+    assert sum(len(chunk) for chunk in chunks) == 320
+
+
+@pytest.mark.asyncio
+async def test_fish_audio_realtime_url_can_be_overridden():
+    session = _FakeSession([b""])
+    adapter = await _adapter(
+        session, {"transport": "websocket", "ws_base_url": "http://127.0.0.1:8789/v1"}
+    )
+    assert adapter._websocket_url(adapter._compose_options({})) == (
+        "ws://127.0.0.1:8789/v1/tts/live"
+    )
+
 # ─── Integration Test (live API) ────────────────────────────────────────
 
 
@@ -371,6 +531,47 @@ async def test_fish_audio_live_api():
         for chunk in chunks:
             assert len(chunk) <= 160
         # Audio must arrive progressively, not as a single blob.
+        assert len(chunks) > 1
+    finally:
+        await adapter.stop()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fish_audio_live_realtime():
+    """Realtime integration test, against the service or the bundled mock.
+
+        python scripts/fish_audio_mock.py &
+        FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_WS_BASE_URL=ws://127.0.0.1:8789/v1 \
+            pytest -m integration tests/test_pipeline_fish_audio_adapters.py
+    """
+    api_key = os.getenv("FISH_AUDIO_API_KEY")
+    if not api_key:
+        pytest.skip("FISH_AUDIO_API_KEY not set - skipping live API test")
+    pytest.importorskip("msgpack")
+
+    app_config = _build_app_config(api_key=api_key)
+    payload = dict(app_config.providers["fishaudio_tts"])
+    payload["transport"] = "websocket"
+    payload["ws_base_url"] = os.getenv("FISH_AUDIO_WS_BASE_URL") or None
+    payload["base_url"] = os.getenv("FISH_AUDIO_BASE_URL", payload["base_url"])
+    payload["reference_id"] = os.getenv("FISH_AUDIO_REFERENCE_ID") or None
+    provider_config = FishAudioProviderConfig(**payload)
+
+    adapter = FishAudioTTSAdapter("fishaudio_tts", app_config, provider_config, {})
+    await adapter.start()
+    await adapter.open_call("call-live", {})
+
+    try:
+        chunks = []
+        async for chunk in adapter.synthesize_stream(
+            "call-live", _fragments("Bonjour,", " ici le test temps reel."), {}
+        ):
+            chunks.append(chunk)
+        synthesized = b"".join(chunks)
+        assert len(synthesized) > 100, "expected substantial audio, got %d bytes" % len(synthesized)
+        for chunk in chunks:
+            assert len(chunk) <= 160
         assert len(chunks) > 1
     finally:
         await adapter.stop()


### PR DESCRIPTION
## Summary

Adds the **Fish Audio realtime transport** (`wss://api.fish.audio/v1/tts/live`) and, to make it usable, a small addition to the pipeline TTS interface: an adapter can declare that it takes **a stream of text for a whole turn** instead of one finished fragment at a time.

Why it matters beyond this provider: in the streaming-overlap turn, `synthesize()` is awaited to completion for every sentence, so LLM token consumption stops while the sentence is being synthesised. Adapters that keep a provider session open (Fish Audio realtime, and the same shape exists at ElevenLabs, Cartesia, Azure) cannot express that today.

> **Builds on #653** (the Fish Audio provider itself). The first four commits here are that PR; review or merge it first — this one is the realtime follow-up.

## Related Issue(s)

- Follows #653.

## Implementation Notes

Key files touched:

- `src/pipelines/base.py` — `TTSComponent.supports_text_stream` and `synthesize_stream(call_id, text_chunks, options)`. The default implementation synthesises fragment by fragment, so **every existing adapter keeps working unchanged**.
- `src/engine.py` — when the adapter declares `supports_text_stream`, the turn feeds fragments into a queue consumed by `synthesize_stream` and forwards audio as it arrives; otherwise the per-fragment path is exactly as before. The per-chunk bookkeeping (first-audio latency, `_TURN_STT_TO_TTS`, playback push) moved into one helper shared by both paths, and a superseded turn cancels the streaming task in `finally`.
- `src/pipelines/fish_audio.py` — `transport: http` (default, unchanged) or `websocket`: open the session, send `start` with the same request body as the HTTP call, then `text` + `flush` per fragment, `stop` at the end of the turn, yielding converted audio as it arrives. `msgpack` is imported lazily, so the HTTP transport has no new requirement.
- `src/config.py` — `transport` and `ws_base_url` (defaults to `base_url` with a `ws`/`wss` scheme; also lets the mock be reached).
- `scripts/fish_audio_mock.py` — now serves the realtime endpoint as well (MessagePack, `start`/`text`/`flush`/`stop` → `audio`/`finish`), so the realtime path can be exercised without an account.
- `requirements.txt` — `msgpack==1.1.0`, needed only by the realtime transport.
- Docs: realtime section in the setup guide, `transport`/`ws_base_url` in the configuration reference.

Design notes:

- **Opt-in everywhere.** The interface addition is a default method plus a flag; the engine branches on the flag; the provider defaults to HTTP. No existing behaviour changes.
- **Session per turn, not per fragment.** A session per fragment would add a handshake where HTTP keep-alive already costs nothing; the win comes from sending text while the model writes it.
- **Cancellation.** A barge-in or a superseded transcript cancels the streaming task; the adapter cancels its sender and closes the socket, which the provider sees as a normal close.

## Testing

- [x] Unit tests

```bash
pytest tests/test_pipeline_fish_audio_adapters.py    # 19 passed, 2 skipped (integration)
pytest -q                                            # 2625 passed, 24 skipped
```

New tests cover the protocol sequence (`start`/`text`/`flush`/`stop`), the `start` request fields, audio chunking, a provider error surfacing, the fallback to HTTP requests when `transport: http`, the websocket URL derivation, and `supports_text_stream` per transport.

The 11 failures I see locally (`test_update_recover_script.py`, `test_admin_google_live_validation.py`, `test_check_no_committed_secrets.py`) reproduce identically on a pristine `main` checkout in the same container: they need `git`/`python3` binaries my test container lacks.

- [x] Integration / manual tests

```bash
python scripts/fish_audio_mock.py &   # HTTP on 8788, realtime on 8789
FISH_AUDIO_API_KEY=mock-key FISH_AUDIO_BASE_URL=http://127.0.0.1:8788/v1 \
    FISH_AUDIO_WS_BASE_URL=ws://127.0.0.1:8789/v1 \
    pytest -m integration tests/test_pipeline_fish_audio_adapters.py   # 2 passed
```

Then a real call through Asterisk with `transport: websocket`, in a lab running the full stack (local STT, remote LLM, µ-law 8 kHz over AudioSocket):

- Test call ID: `1789220767.197`
- Engine log: `Pipeline TTS text streaming active`, then `Fish Audio realtime session opening` / `... completed` per turn.
- Mock log: one session per turn, `start format=pcm sample_rate=8000 latency=low`, then one `flush` per fragment **as the model produced it** (`'Non,'`, then `"Supprimer l'icône de Chrome ne coupe pas votre con…"`, …), audio streamed back in 20 ms chunks and audible in the caller-side recording.
- A superseded turn closed the session cleanly (the mock logs the client close; no error surfaced to the call).

- [ ] `agent check` — not run: no Go toolchain in this environment.

**Live check against `wss://api.fish.audio/v1/tts/live`.** Verified against the real service, same `s2.1-pro-free` model (no API credit needed, so this is reproducible):

```bash
FISH_AUDIO_API_KEY=... FISH_AUDIO_MODEL=s2.1-pro-free \
    FISH_AUDIO_REFERENCE_ID=<a voice id from the library> \
    pytest -m integration tests/test_pipeline_fish_audio_adapters.py   # 2 passed
```

- The live session accepts `start` / `text` / `flush` / `stop` exactly as implemented and answers with `audio` events then `finish`: 19 295 bytes in 121 chunks for a two-fragment turn.
- A real call through Asterisk with `transport: websocket` against the live service: `fragments=5` and `fragments=6` on two turns, `first_audio_ms` 951 ms and 1027 ms (one handshake per turn plus network), audio clean on the caller side.
- An account without API credit is refused **at the websocket handshake** with `402` (aiohttp `WSServerHandshakeError`) rather than in a response body, where the HTTP endpoint answers `402` in the response. Worth knowing for operators, and now in the setup guide.

So the realtime protocol in this PR is the one the service actually speaks, not only the one the mock encodes.

## Review Checkpoints

- [x] Draft opened after a coherent vertical slice was ready to review
- [ ] Review fixes will be pushed as a cohesive batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

